### PR TITLE
Reduce the default limit to reduce unexpected usage

### DIFF
--- a/admin/frontend/src/ControlPanel/index.tsx
+++ b/admin/frontend/src/ControlPanel/index.tsx
@@ -4,7 +4,7 @@ import { OneStat } from './stat-types';
 import StatDisplay from './StatDisplay';
 
 export default (): ReactElement => {
-  const [limit, setLimit] = useState(7);
+  const [limit, setLimit] = useState(1);
   const [stat, setStat] = useState<OneStat[] | null>(null);
 
   useEffect(() => {


### PR DESCRIPTION
This pull request simply changed default limit from 7 to 1 so that less data are fetched by default. It can help reduce the db usage when we are reading analytics data.