### PR TITLE
Setup system for banner message and added first apology banner

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -4,15 +4,19 @@ service cloud.firestore {
     	return request.resource.data.owner == request.auth.token.email;
     }
     function canReadWriteDelete() {
-    	return request.auth.token.email == resource.data.owner
+    	return request.auth.token.email == resource.data.owner;
+    }
+    function canOperateOnEmailIdDocs(userEmail) {
+    	return request.auth.token.email == userEmail;
     }
     match /samwise-order-manager/{userEmail} {
-    	allow create: if request.auth.token.email == userEmail
-        allow read, write, delete: if request.auth.token.email == userEmail
+    	allow create, read, write, delete: if canOperateOnEmailIdDocs(userEmail)
     }
     match /samwise-settings/{userEmail} {
-    	allow create: if request.auth.token.email == userEmail
-        allow read, write, delete: if request.auth.token.email == userEmail
+    	allow create, read, write, delete: if canOperateOnEmailIdDocs(userEmail)
+    }
+    match /samwise-banner-message/{userEmail} {
+    	allow create, read, write, delete: if canOperateOnEmailIdDocs(userEmail)
     }
   	match /samwise-tags/{tag} {
     	allow create: if canCreate()

--- a/frontend/src/components/TitleBar/Banner/index.css
+++ b/frontend/src/components/TitleBar/Banner/index.css
@@ -1,0 +1,26 @@
+.Banner {
+  position: absolute;
+  align-items: center;
+  align-content: center;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: auto;
+  display: flex;
+  color: white;
+  padding: 1em;
+  background-color: #7fbdff;
+}
+
+.Text {
+  flex: auto;
+}
+
+.DismissButton {
+  color: white;
+  background: none;
+  padding: 8px;
+  border: 1px solid white;
+  border-radius: 5px;
+  cursor: pointer;
+}

--- a/frontend/src/components/TitleBar/Banner/index.tsx
+++ b/frontend/src/components/TitleBar/Banner/index.tsx
@@ -1,0 +1,31 @@
+import React, { ReactElement } from 'react';
+import { connect } from 'react-redux';
+import { getBannerMessage } from '../../../store/selectors';
+import { State } from '../../../store/store-types';
+import styles from './index.css';
+import { readBannerMessage } from '../../../firebase/actions';
+import { MessageWithId } from './messages';
+
+type Props = {
+  readonly message: MessageWithId | null;
+};
+
+const Banner = ({ message }: Props): ReactElement | null => {
+  if (message === null) {
+    return null;
+  }
+  const dismissHandler = (): void => {
+    readBannerMessage(message.id, true);
+  };
+  return (
+    <div className={styles.Banner}>
+      <span className={styles.Text}>{message.message}</span>
+      <button type="button" className={styles.DismissButton} onClick={dismissHandler}>
+        Dismiss
+      </button>
+    </div>
+  );
+};
+
+const Connected = connect((state: State) => getBannerMessage(state))(Banner);
+export default Connected;

--- a/frontend/src/components/TitleBar/Banner/messages.ts
+++ b/frontend/src/components/TitleBar/Banner/messages.ts
@@ -1,0 +1,37 @@
+import { BannerMessageIds, BannerMessageStatus } from '../../../store/store-types';
+
+/**
+ * This file contains a list of all banner messages we may send.
+ * It is a centralized place to compute what exact message we need to display.
+ */
+
+type MessagesType = { readonly [I in BannerMessageIds]: string };
+
+const messages: MessagesType = {
+  '2019-03-10-quota-exceeded-incident': 'We reached unexpected high traffic on the night of March 9, which resulted in the site being down for a upgrade. Sorry for any inconvenience this has caused you.',
+};
+
+// sorted in decreasing order of date
+const messageIdCollection: BannerMessageIds[] = [
+  // comment out the messages that no longer need to be displayed.
+  '2019-03-10-quota-exceeded-incident',
+];
+
+export type MessageWithId = { readonly id: BannerMessageIds; readonly message: string };
+
+/**
+ * @param status the current banner message status.
+ * @returns [message id, the message to display], or null if we don't need to display any of them.
+ */
+export default function findMessageToDisplay(status: BannerMessageStatus): MessageWithId | null {
+  // current stategy: only display the latest one
+  for (let i = 0; i < messageIdCollection.length; i += 1) {
+    const messageId = messageIdCollection[i];
+    const messageStatus = status[messageId];
+    const shouldBeDisplayed = messageStatus !== true;
+    if (shouldBeDisplayed) {
+      return { id: messageId, message: messages[messageId] };
+    }
+  }
+  return null;
+}

--- a/frontend/src/components/TitleBar/TitleBar.css
+++ b/frontend/src/components/TitleBar/TitleBar.css
@@ -1,4 +1,5 @@
 .Main {
+  position: relative;
   margin: 0;
   padding: 32px 32px 16px 32px;
 }

--- a/frontend/src/components/TitleBar/TitleBar.tsx
+++ b/frontend/src/components/TitleBar/TitleBar.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 // @ts-ignore this module does not have a ts definition file.
 import Clock from 'react-live-clock';
+import Banner from './Banner';
 import { date2FullDateString } from '../../util/datetime-util';
 import styles from './TitleBar.css';
 import SettingsButton from './Settings/SettingsButton';
@@ -12,6 +13,7 @@ import SettingsButton from './Settings/SettingsButton';
  */
 export default (): ReactElement => (
   <header className={styles.Main}>
+    <Banner />
     <span className={styles.Time}><Clock format="h:mm A" ticking /></span>
     <span className={styles.Date}>{date2FullDateString(new Date())}</span>
     <span className={styles.Links}><SettingsButton /></span>

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -1,7 +1,7 @@
 import { firestore } from 'firebase/app';
 import { Map, Set } from 'immutable';
 import {
-  Course, PartialMainTask, PartialSubTask, SubTask, Tag, Task,
+  Course, PartialMainTask, PartialSubTask, SubTask, Tag, Task, BannerMessageIds,
 } from '../store/store-types';
 import { FirestoreCommon, FirestoreTag, FirestoreTask, FirestoreSubTask } from './firestore-types';
 import { getAppUser } from './auth';
@@ -11,6 +11,7 @@ import {
   subTasksCollection,
   tagsCollection,
   tasksCollection,
+  bannerMessageStatusCollection,
 } from './db';
 import { error, ignore } from '../util/general-util';
 import { TaskDiff } from '../util/task-util';
@@ -283,6 +284,18 @@ export const completeOnboarding = (completedOnboarding: boolean): void => {
   settingsCollection().doc(getAppUser().email)
     .update({ completedOnboarding })
     .then(ignore);
+};
+
+export const readBannerMessage = (bannerMessageId: BannerMessageIds, isRead: boolean): void => {
+  const docRef = bannerMessageStatusCollection().doc(getAppUser().email);
+  db().runTransaction(async (transaction) => {
+    const doc = await transaction.get(docRef);
+    if (doc.exists) {
+      transaction.update(docRef, { [bannerMessageId]: isRead });
+    } else {
+      transaction.set(docRef, { [bannerMessageId]: isRead });
+    }
+  });
 };
 
 export const importCourseExams = (): void => {

--- a/frontend/src/firebase/db.ts
+++ b/frontend/src/firebase/db.ts
@@ -13,6 +13,7 @@ export const db = (): firebase.firestore.Firestore => firebase.firestore();
 const collections = {
   ORDER_MANAGER: 'samwise-order-manager',
   USER_SETTINGS: 'samwise-settings',
+  BANNER_MESSAGE: 'samwise-banner-message',
   TAGS: 'samwise-tags',
   TASKS: 'samwise-tasks',
   SUBTASKS: 'samwise-subtasks',
@@ -22,6 +23,9 @@ type Collection = firebase.firestore.CollectionReference;
 
 export const orderManagerCollection = (): Collection => db().collection(collections.ORDER_MANAGER);
 export const settingsCollection = (): Collection => db().collection(collections.USER_SETTINGS);
+export const bannerMessageStatusCollection = (): Collection => db().collection(
+  collections.BANNER_MESSAGE,
+);
 export const tagsCollection = (): Collection => db().collection(collections.TAGS);
 export const tasksCollection = (): Collection => db().collection(collections.TASKS);
 export const subTasksCollection = (): Collection => db().collection(collections.SUBTASKS);

--- a/frontend/src/store/action-types.ts
+++ b/frontend/src/store/action-types.ts
@@ -1,5 +1,6 @@
 import { Map } from 'immutable';
-import { Course, Settings, SubTask, Tag, Task } from './store-types';
+import { Course, Settings, SubTask, Tag, Task, BannerMessageStatus } from './store-types';
+import { type } from 'os';
 
 export type PatchTags = {
   readonly type: 'PATCH_TAGS';
@@ -27,6 +28,11 @@ export type PatchSettings = {
   readonly settings: Settings;
 };
 
+export type PatchBannerMessageStatus = {
+  readonly type: 'PATCH_BANNER_MESSAGES';
+  readonly change: BannerMessageStatus;
+};
+
 export type PatchCourses = {
   readonly type: 'PATCH_COURSES';
   readonly courses: Map<string, Course[]>;
@@ -37,4 +43,5 @@ export type Action =
   | PatchTasks
   | PatchSubTasks
   | PatchSettings
+  | PatchBannerMessageStatus
   | PatchCourses;

--- a/frontend/src/store/actions.ts
+++ b/frontend/src/store/actions.ts
@@ -5,8 +5,9 @@ import {
   PatchTags,
   PatchTasks,
   PatchSettings,
+  PatchBannerMessageStatus,
 } from './action-types';
-import { Course, Tag, Task, SubTask, Settings } from './store-types';
+import { Course, Tag, Task, SubTask, Settings, BannerMessageStatus } from './store-types';
 
 export const patchTags = (created: Tag[], edited: Tag[], deleted: string[]): PatchTags => ({
   type: 'PATCH_TAGS', created, edited, deleted,
@@ -24,6 +25,12 @@ export const patchSubTasks = (
 
 export const patchSettings = (settings: Settings): PatchSettings => ({
   type: 'PATCH_SETTINGS', settings,
+});
+
+export const patchBannerMessageStatus = (
+  change: BannerMessageStatus,
+): PatchBannerMessageStatus => ({
+  type: 'PATCH_BANNER_MESSAGES', change,
 });
 
 export const patchCourses = (courses: Map<string, Course[]>): PatchCourses => ({

--- a/frontend/src/store/reducers.ts
+++ b/frontend/src/store/reducers.ts
@@ -6,6 +6,7 @@ import {
   PatchTasks,
   PatchSubTasks,
   PatchSettings,
+  PatchBannerMessageStatus,
 } from './action-types';
 import { State } from './store-types';
 import { NONE_TAG_ID, NONE_TAG } from '../util/tag-util';
@@ -23,6 +24,7 @@ const initialState: State = {
   subTasks: Map(),
   taskChildrenMap: Map(),
   settings: { completedOnboarding: true, theme: 'light' },
+  bannerMessageStatus: {},
   courses: Map(),
 };
 
@@ -92,6 +94,10 @@ function patchSettings(state: State, { settings }: PatchSettings): State {
   return { ...state, settings };
 }
 
+function patchBannerMessageStatus(state: State, { change }: PatchBannerMessageStatus): State {
+  return { ...state, bannerMessageStatus: { ...state.bannerMessageStatus, ...change } };
+}
+
 function patchCourses(state: State, { courses }: PatchCourses): State {
   return { ...state, courses };
 }
@@ -106,6 +112,8 @@ export default function rootReducer(state: State = initialState, action: Action)
       return patchSubTasks(state, action);
     case 'PATCH_SETTINGS':
       return patchSettings(state, action);
+    case 'PATCH_BANNER_MESSAGES':
+      return patchBannerMessageStatus(state, action);
     case 'PATCH_COURSES':
       return patchCourses(state, action);
     default:

--- a/frontend/src/store/selectors.ts
+++ b/frontend/src/store/selectors.ts
@@ -1,8 +1,9 @@
 import { createSelector, createSelectorCreator, defaultMemoize } from 'reselect';
 import { Map, Set } from 'immutable';
-import { State, SubTask, Tag, Task } from './store-types';
+import { State, SubTask, Tag, Task, BannerMessageStatus } from './store-types';
 import { computeTaskProgress, TasksProgressProps } from '../util/task-util';
 import { NONE_TAG } from '../util/tag-util';
+import findMessageToDisplay, { MessageWithId } from '../components/TitleBar/Banner/messages';
 
 /*
  * --------------------------------------------------------------------------------
@@ -28,6 +29,9 @@ const getTags = ({ tags }: State): Map<string, Tag> => tags;
 const getTasks = ({ tasks }: State): Map<string, Task> => tasks;
 const getDateTaskMap = ({ dateTaskMap }: State): Map<string, Set<string>> => dateTaskMap;
 const getSubTasks = ({ subTasks }: State): Map<string, SubTask> => subTasks;
+const getBannerMessageStatus = (
+  { bannerMessageStatus }: State,
+): BannerMessageStatus => bannerMessageStatus;
 
 const getTasksId = ({ tasks }: State): Set<string> => Set(tasks.keys());
 
@@ -92,4 +96,9 @@ export const createGetIdOrderListByDate = (
 
 export const getProgress: SelectorOf<TasksProgressProps> = createSelector(
   [getTasksInFocus, getSubTasks], computeTaskProgress,
+);
+
+type BannerProps = { readonly message: MessageWithId | null };
+export const getBannerMessage: SelectorOf<BannerProps> = createSelector(
+  getBannerMessageStatus, status => ({ message: findMessageToDisplay(status) }),
 );

--- a/frontend/src/store/store-types.ts
+++ b/frontend/src/store/store-types.ts
@@ -50,6 +50,13 @@ export type Settings = {
   readonly theme: 'light' | 'dark';
 };
 
+export type BannerMessageIds =
+  | '2019-03-10-quota-exceeded-incident';
+
+export type BannerMessageStatus = {
+  readonly [I in BannerMessageIds]?: boolean;
+};
+
 /**
  * The type of a course info entry.
  */
@@ -71,5 +78,6 @@ export type State = {
   readonly subTasks: Map<string, SubTask>;
   readonly taskChildrenMap: Map<string, Set<string>>;
   readonly settings: Settings;
+  readonly bannerMessageStatus: BannerMessageStatus;
   readonly courses: Map<string, Course[]>;
 };


### PR DESCRIPTION
I added another collection in firestore called `samwise-banner-message`. Each document in the collection has this format: `{ [messageId]: true | false | undefined }`, whether `true` means that the user dismissed the message and `false | undefined` means that the user has not dismissed it.

The frontend has a set of potential messages to display. Currently, it will display the latest message that is not dismissed, but it can be easily changed in the future.

This pull request also adds our first banner message to apologize for the outage last night.