### PR TITLE
Fix overdue alert position in future view

### DIFF
--- a/frontend/src/components/TaskView/FutureView/FutureViewDay.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewDay.tsx
@@ -2,11 +2,7 @@ import React, { ReactElement } from 'react';
 import { SimpleDate } from './future-view-types';
 import { FloatingPosition } from '../../Util/TaskEditors/editors-types';
 import styles from './FutureViewDay.css';
-import {
-  floatingViewWidth,
-  nDaysViewHeaderHeight,
-  otherViewsHeightHeader,
-} from './future-view-css-props';
+import { floatingViewWidth, headerHeight } from './future-view-css-props';
 import { getTodayAtZeroAM } from '../../../util/datetime-util';
 import { error } from '../../../util/general-util';
 import { useWindowSize, WindowSize } from '../../../hooks/window-size-hook';
@@ -44,7 +40,6 @@ const computeFloatingViewStyle = (props: PropsForPositionComputation): PositionS
     },
   } = props;
   // Compute the height of inner content
-  const headerHeight = inNDaysView ? nDaysViewHeaderHeight : nDaysViewHeaderHeight;
   const totalHeight = headerHeight + tasksHeight;
   // Decide the maximum allowed height and the actual height
   const maxAllowedHeight = inNDaysView ? 400 : 300;

--- a/frontend/src/components/TaskView/FutureView/FutureViewTask.css
+++ b/frontend/src/components/TaskView/FutureView/FutureViewTask.css
@@ -1,4 +1,5 @@
 .Task {
+  position: relative;
   color: white;
   cursor: pointer;
   margin: 0;

--- a/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
@@ -43,7 +43,6 @@ function FutureViewTask(
     compoundTask, inNDaysView, taskEditorPosition, isInMainList,
   }: Props,
 ): ReactElement | null {
-  const [overdueAlertPosition, setOverdueAlertPosition] = React.useState<AlertPos | null>(null);
   const isSmallScreen = useMappedWindowSize(({ width }) => width <= 768);
 
   if (compoundTask === null) {

--- a/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
@@ -11,8 +11,6 @@ import CheckBox from '../../UI/CheckBox';
 import { FloatingPosition } from '../../Util/TaskEditors/editors-types';
 import { getTodayAtZeroAM } from '../../../util/datetime-util';
 import OverdueAlert from '../../UI/OverdueAlert';
-import { headerHeight } from './future-view-css-props';
-import { error } from '../../../util/general-util';
 import { editMainTask, removeTask } from '../../../firebase/actions';
 import { useMappedWindowSize } from '../../../hooks/window-size-hook';
 import { NONE_TAG } from '../../../util/tag-util';
@@ -57,8 +55,8 @@ function FutureViewTask(
    * Get an onClickHandler when the element is clicked.
    * This methods ensure that only clicking on task text counts.
    *
-   * @param {function(): void} opener the opener passed by the floating task editor.
-   * @return {function} the onClick handler.
+   * @param opener the opener passed by the floating task editor.
+   * @return the onClick handler.
    */
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   const getOnClickHandler = (opener: () => void) => (event: SyntheticEvent<HTMLElement>): void => {
@@ -119,23 +117,9 @@ function FutureViewTask(
   ));
 
   const { date, complete } = original;
-  const overdueComponentOpt = overdueAlertPosition && (
-    <OverdueAlert absolutePosition={overdueAlertPosition} />
+  const overdueComponentOpt = (date < getTodayAtZeroAM() && !complete) && (
+    <OverdueAlert target="future-view-task" />
   );
-  const refHandler = (divElement: HTMLDivElement | null): void => {
-    if (divElement != null) {
-      const isOverdue = date < getTodayAtZeroAM() && !complete;
-      if (isOverdue && overdueAlertPosition == null) {
-        const { top } = divElement.getBoundingClientRect();
-        const parent = divElement.parentElement || error('Corrupted DOM!');
-        const parentRect = parent.getBoundingClientRect();
-        setOverdueAlertPosition({
-          top: top - parentRect.top + headerHeight,
-          right: 0,
-        });
-      }
-    }
-  };
   // Construct the trigger for the floating task editor.
   const trigger = (opened: boolean, opener: () => void): ReactElement => {
     const onClickHandler = getOnClickHandler(opener);
@@ -145,13 +129,7 @@ function FutureViewTask(
       : renderMainTaskInfo(isSmallScreen);
     const subtasks = inNDaysView ? renderSubTasks() : null;
     return (
-      <div
-        role="presentation"
-        className={styles.Task}
-        style={style}
-        onClick={onClickHandler}
-        ref={refHandler}
-      >
+      <div role="presentation" className={styles.Task} style={style} onClick={onClickHandler}>
         {overdueComponentOpt}
         {mainTasks}
         {subtasks}

--- a/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
@@ -11,7 +11,7 @@ import CheckBox from '../../UI/CheckBox';
 import { FloatingPosition } from '../../Util/TaskEditors/editors-types';
 import { getTodayAtZeroAM } from '../../../util/datetime-util';
 import OverdueAlert from '../../UI/OverdueAlert';
-import { nDaysViewHeaderHeight, otherViewsHeightHeader } from './future-view-css-props';
+import { headerHeight } from './future-view-css-props';
 import { error } from '../../../util/general-util';
 import { editMainTask, removeTask } from '../../../firebase/actions';
 import { useMappedWindowSize } from '../../../hooks/window-size-hook';
@@ -129,10 +129,9 @@ function FutureViewTask(
         const { top } = divElement.getBoundingClientRect();
         const parent = divElement.parentElement || error('Corrupted DOM!');
         const parentRect = parent.getBoundingClientRect();
-        const headerHeight = inNDaysView ? nDaysViewHeaderHeight : otherViewsHeightHeader;
         setOverdueAlertPosition({
-          top: top - parentRect.top + headerHeight - 3,
-          right: -5,
+          top: top - parentRect.top + headerHeight,
+          right: 0,
         });
       }
     }

--- a/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
@@ -33,8 +33,6 @@ type Props = OwnProps & {
   readonly compoundTask: CompoundTask | null;
 };
 
-type AlertPos = { readonly top: number; readonly right: number };
-
 /**
  * The component used to render one task in backlog day.
  */

--- a/frontend/src/components/TaskView/FutureView/future-view-css-props.ts
+++ b/frontend/src/components/TaskView/FutureView/future-view-css-props.ts
@@ -1,11 +1,7 @@
 /**
- * Header height in n-days view.
+ * Header height.
  */
-export const nDaysViewHeaderHeight = 66;
-/**
- * Header height in other views.
- */
-export const otherViewsHeightHeader = 47;
+export const headerHeight = 66;
 
 /**
  * Height of each task line in display.

--- a/frontend/src/components/UI/OverdueAlert.css
+++ b/frontend/src/components/UI/OverdueAlert.css
@@ -1,5 +1,7 @@
-.OverdueAlertRelative {
+.OverdueAlertInTaskCard {
   position: absolute;
+  top: -5px;
+  right: -5px;
   width: 2em;
   height: 2em;
   background-color: #D0021B;
@@ -7,15 +9,12 @@
   text-align: center;
   font-weight: bold;
   font-size: 1em;
-
-  /* Proposed Experimental Change */
-  top: -0.3em;
-  right: -0.3em;
-  /*border-bottom-left-radius: 1em;*/
 }
 
-.OverdueAlertAbsolute {
+.OverdueAlertInFutureView {
   position: absolute;
+  top: 0;
+  right: 0;
   z-index: 1;
   width: 1em;
   height: 1em;

--- a/frontend/src/components/UI/OverdueAlert.css
+++ b/frontend/src/components/UI/OverdueAlert.css
@@ -1,10 +1,7 @@
 .OverdueAlertRelative {
   position: absolute;
-  /*top: -1em;
-  right: -1em;*/
   width: 2em;
   height: 2em;
-  /*border-radius: 1em;*/
   background-color: #D0021B;
   line-height: 2em;
   text-align: center;
@@ -12,7 +9,8 @@
   font-size: 1em;
 
   /* Proposed Experimental Change */
-  top:-0.3em; right:-0.3em;
+  top: -0.3em;
+  right: -0.3em;
   /*border-bottom-left-radius: 1em;*/
 }
 
@@ -21,11 +19,9 @@
   z-index: 1;
   width: 1em;
   height: 1em;
-  border-radius: 0.5em;
   background-color: #D0021B;
   line-height: 1em;
   text-align: center;
   font-weight: bold;
   font-size: 0.5em;
-  box-shadow: 1px 1px 2px 0 rgba(0, 0, 0, 0.5);
 }

--- a/frontend/src/components/UI/OverdueAlert.tsx
+++ b/frontend/src/components/UI/OverdueAlert.tsx
@@ -1,18 +1,16 @@
 import React, { ReactElement } from 'react';
 import styles from './OverdueAlert.css';
 
-type Props = { readonly absolutePosition: { readonly top: number; readonly right: number } | null };
+type Props = { readonly target: 'task-card' | 'future-view-task' };
 
 /**
  * The overdue alert that will be displayed on the top-right corner of a div.
  */
-export default function OverdueAlert({ absolutePosition }: Props): ReactElement {
-  if (absolutePosition == null) {
-    return <div className={styles.OverdueAlertRelative}>!</div>;
-  }
-  const { top, right } = absolutePosition;
-  const style = { top: `${top}px`, right: `${right}px` };
-  return <div className={styles.OverdueAlertAbsolute} style={style}>!</div>;
+export default function OverdueAlert({ target }: Props): ReactElement {
+  const className = target === 'task-card'
+    ? styles.OverdueAlertInTaskCard
+    : styles.OverdueAlertInFutureView;
+  return <div className={className}>!</div>;
 }
 
 OverdueAlert.defaultProps = { absolutePosition: null };

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -140,7 +140,7 @@ function TaskEditor(
       onBlur={ignore}
       ref={editorRef}
     >
-      {isOverdue && <OverdueAlert />}
+      {isOverdue && <OverdueAlert target="task-card" />}
       <div>
         <EditorHeader tag={tag} date={date} onChange={editMainTask} getTag={getTag} />
         <MainTaskEditor


### PR DESCRIPTION
Before:
<img width="131" alt="Screen Shot 2019-03-14 at 12 09 26 PM" src="https://user-images.githubusercontent.com/4290500/54372611-082de980-4652-11e9-8938-40791eb6270b.png">

After:
<img width="140" alt="Screen Shot 2019-03-14 at 12 08 16 PM" src="https://user-images.githubusercontent.com/4290500/54372565-f0566580-4651-11e9-9271-cdbc86f752de.png">

Note: The deformed checkbox problem is not related to this one. It should be fixed independently in #175.