### PR TITLE
Fix the task filtering bug

### DIFF
--- a/frontend/src/util/task-util.test.ts
+++ b/frontend/src/util/task-util.test.ts
@@ -21,6 +21,10 @@ const exampleTasks: Task[] = [
   { ...testTaskCommon, inFocus: true, complete: false, children: Set.of('s1', 's2', 's3', 's4') },
   { ...testTaskCommon, inFocus: false, complete: true, children: Set.of('s1', 's2', 's3', 's4') },
   { ...testTaskCommon, inFocus: false, complete: false, children: Set.of('s1', 's2', 's3', 's4') },
+  { ...testTaskCommon, inFocus: true, complete: true, children: Set.of() },
+  { ...testTaskCommon, inFocus: true, complete: false, children: Set.of() },
+  { ...testTaskCommon, inFocus: false, complete: true, children: Set.of() },
+  { ...testTaskCommon, inFocus: false, complete: false, children: Set.of() },
 ];
 const exampleSubTasks: SubTask[] = [
   { id: 's1', order, name, complete: true, inFocus: true },
@@ -40,6 +44,10 @@ it('getFilteredCompletedInFocusTask works', () => {
     { ...testTaskCommon, inFocus: true, complete: false, subTasks: [s1, s2] },
     { ...testTaskCommon, inFocus: false, complete: true, subTasks: [s1, s3] },
     { ...testTaskCommon, inFocus: false, complete: false, subTasks: [s1] },
+    { ...testTaskCommon, inFocus: true, complete: true, subTasks: [] },
+    null,
+    null,
+    null,
   ];
   exampleTasks.forEach((t, i) => {
     expect(getFilteredCompletedInFocusTask(t, commonSubTaskMap)).toEqual(expectedResults[i]);
@@ -52,9 +60,40 @@ it('getFilteredNotCompletedInFocusTask works', () => {
     { ...testTaskCommon, inFocus: true, complete: false, subTasks: [s3, s4] },
     null,
     { ...testTaskCommon, inFocus: false, complete: false, subTasks: [s3] },
+    null,
+    { ...testTaskCommon, inFocus: true, complete: false, subTasks: [] },
+    null,
+    null,
   ];
   exampleTasks.forEach((t, i) => {
     expect(getFilteredNotCompletedInFocusTask(t, commonSubTaskMap)).toEqual(expectedResults[i]);
+  });
+});
+
+it('getFiltered(Completed|NotCompleted)InFocusTask are complementary', () => {
+  exampleTasks.forEach((task) => {
+    const completedResult = getFilteredCompletedInFocusTask(task, commonSubTaskMap);
+    const uncompletedResult = getFilteredNotCompletedInFocusTask(task, commonSubTaskMap);
+    const allSubTasks: SubTask[] = [];
+    if (completedResult) {
+      allSubTasks.push(...completedResult.subTasks);
+    }
+    if (uncompletedResult) {
+      allSubTasks.push(...uncompletedResult.subTasks);
+    }
+    // ensure disjoint union property
+    const subTaskIdSet = allSubTasks
+      .reduce((acc: Set<string>, s: SubTask) => acc.add(s.id), Set.of());
+    if (subTaskIdSet.size !== allSubTasks.length) {
+      const { complete, inFocus, children } = task;
+      let errorMessage = 'The subtasks in completed and uncompleted are not disjoint union.';
+      errorMessage += ` Task: { complete: ${complete}, inFocus: ${inFocus}, chilren: ${children} }.`;
+      errorMessage += ` Id Set: ${subTaskIdSet.toJS()}.`;
+      errorMessage += ` SubTasks: ${allSubTasks.map(s => s.id)}`;
+      throw new Error(errorMessage);
+    }
+    // ensure allSubTasks are all in focus.
+    allSubTasks.forEach(subTask => expect(task.inFocus || subTask.inFocus).toBe(true));
   });
 });
 
@@ -64,6 +103,10 @@ it('computeTaskProgress works', () => {
     { completedTasksCount: 2, allTasksCount: 5 },
     { completedTasksCount: 2, allTasksCount: 2 },
     { completedTasksCount: 1, allTasksCount: 2 },
+    { completedTasksCount: 1, allTasksCount: 1 },
+    { completedTasksCount: 0, allTasksCount: 1 },
+    { completedTasksCount: 0, allTasksCount: 0 },
+    { completedTasksCount: 0, allTasksCount: 0 },
   ];
   const expectedTotal = expectedResults.reduce((acc, curr) => ({
     completedTasksCount: acc.completedTasksCount + curr.completedTasksCount,

--- a/frontend/src/util/task-util.ts
+++ b/frontend/src/util/task-util.ts
@@ -48,6 +48,9 @@ export const getFilteredCompletedInFocusTask = (
       childrenArray.forEach((s) => {
         if (s != null && s.complete) { newSubTasks.push(s); }
       });
+      if (newSubTasks.length === 0) {
+        return null;
+      }
     }
   } else {
     childrenArray.forEach((s) => {


### PR DESCRIPTION
Now an uncompleted focus task with no subtask will not show up in completed section.
Additional blackbox tests have been added in `src/util/tasks-util.test.ts` to ensure there will be no regression.