### PR TITLE
Fix focus-to-future view ratio. (Fix #138)

### DIFF
--- a/frontend/src/components/TaskView/FutureView/index.tsx
+++ b/frontend/src/components/TaskView/FutureView/index.tsx
@@ -114,8 +114,9 @@ export default function FutureView(
 ): ReactElement {
   // the number of days in n-days mode.
   const nDays = useMappedWindowSize(({ width }) => {
-    if (width > 960) { return 5; }
-    if (width > 840) { return 4; }
+    if (width > 1280) { return 5; }
+    if (width > 960) { return 4; }
+    if (width > 840) { return 3; }
     return 1;
   });
   const controlOnChange = (change: Partial<FutureViewConfig>): void => {

--- a/frontend/src/components/TaskView/TaskView.css
+++ b/frontend/src/components/TaskView/TaskView.css
@@ -7,8 +7,8 @@
 
 @media only screen and (min-width: 840px) {
   .FocusPanel {
-    min-width: 250px;
-    max-width: 250px;
+    min-width: 350px;
+    max-width: 350px;
   }
 }
 


### PR DESCRIPTION
Adjusted width of the focus view to make it stick to the design.
Also changed the breakpoints of n-days view to make the cards not too narrow.