### PR TITLE
UI Fixes: Confetti and Onboarding

### DIFF
--- a/frontend/src/components/Popup/AllComplete/Celebrate.module.css
+++ b/frontend/src/components/Popup/AllComplete/Celebrate.module.css
@@ -26,6 +26,17 @@
   transform:translate(-50%, -50%)scale(0);*/
 }
 
+
+.ConfWrap{
+  position:fixed;
+  z-index:999;
+  top:30%;
+  /*left:50%;*/
+  left: 250px;
+  pointer-events:none;
+}
+
+
 /*.Main div{
   display:block;
   margin-left:20px;
@@ -80,14 +91,4 @@
 .Main button:active{
   background:white;
 }
-
-
 */
-.ConfWrap{
-  position:fixed;
-  z-index:999;
-  top:30%;
-  /*left:50%;*/
-  left: 250px;
-  pointer-events:none;
-}

--- a/frontend/src/components/Popup/AllComplete/index.tsx
+++ b/frontend/src/components/Popup/AllComplete/index.tsx
@@ -1,33 +1,36 @@
 import React, { ReactElement } from 'react';
 import { connect } from 'react-redux';
 import Confetti from 'react-dom-confetti';
+import { TasksProgressProps } from '../../../util/task-util';
 import styles from './Celebrate.module.css';
-import { State, Task } from '../../../store/store-types';
+import { getProgress } from '../../../store/selectors';
 // import Bear from '../../../assets/bear/happy-bear.png';
 
-type Props = { readonly focusTasks: Task[] };
+type Props = TasksProgressProps;
 
 /**
  * The all tasks complete page. Displays after a user completes all focused tasks.
  */
-function AllComplete({ focusTasks }: Props): ReactElement | null {
+function AllComplete({ completedTasksCount, allTasksCount }: Props): ReactElement | null {
   // Simple FSM. 0 = initial, 1 = saw unfinished tasks, 2 = finished all, 3 = hidden
   const [progress, setProgress] = React.useState<0 | 1 | 2 | 3>(0);
+
+  const percent = completedTasksCount / allTasksCount;
 
   switch (progress) {
     case 0:
     case 3:
-      if ((focusTasks.length > 0) && focusTasks.some(t => !t.complete)) {
+      if (allTasksCount > 0 && percent < 1) {
         setProgress(1);
       }
       return null;
     case 1:
-      if (focusTasks.length > 0 && focusTasks.every(t => t.complete)) {
+      if (allTasksCount > 0 && percent >= 1) {
         setProgress(2);
       }
       break;
     case 2:
-      if ((focusTasks.length > 0) && focusTasks.some(t => !t.complete)) {
+      if (allTasksCount > 0 && percent < 1) {
         setProgress(1);
       }
       break;
@@ -70,10 +73,5 @@ function AllComplete({ focusTasks }: Props): ReactElement | null {
   );
 }
 
-const Connected = connect(
-  ({ tasks }: State): Props => {
-    const focusTasks: Task[] = Array.from(tasks.values()).filter(t => t.inFocus);
-    return { focusTasks };
-  },
-)(AllComplete);
+const Connected = connect(getProgress)(AllComplete);
 export default Connected;

--- a/frontend/src/components/TitleBar/Onboarding/Onboard.module.css
+++ b/frontend/src/components/TitleBar/Onboarding/Onboard.module.css
@@ -148,3 +148,26 @@ p.SettingsSectionTitle {
   margin: 10px 10px 0 0;
   cursor: pointer;
 }
+
+
+
+
+.ImportExamContainer{
+  margin-top:30px;
+  font-size:16px;
+  line-height:20px;
+  cursor: pointer;
+}
+
+.ImportExamContainer input{
+  width:20px;
+  height:20px;
+  border-radius:3px;
+  vertical-align: middle;
+  margin-right:10px;
+  cursor:pointer;
+}
+
+.ImportExamContainer label{
+  cursor:pointer;
+}

--- a/frontend/src/components/TitleBar/Onboarding/Onboard.tsx
+++ b/frontend/src/components/TitleBar/Onboarding/Onboard.tsx
@@ -41,12 +41,22 @@ const taggedImages: TaggedImage[] = [
   },
 ];
 
-type AddClassProps = { readonly classTags: Tag[]; readonly showNext: () => void };
+type AddClassProps = {
+  readonly classTags: Tag[];
+  readonly showNext: (shouldImport: boolean) => void;
+};
 
 /**
  * Adding class as the first onboarding step.
  */
 function AddClassOnBoarding({ classTags, showNext }: AddClassProps): ReactElement {
+  const [addExam, setAddExam] = React.useState<boolean>(true);
+
+  const clickBox = (e: React.FormEvent<HTMLInputElement>): void => (
+    setAddExam((e.target as HTMLInputElement).checked)
+  );
+  const allDone = (): void => showNext(addExam);
+
   return (
     <div style={{ padding: '60px 40px' }}>
       {/* some random intro */}
@@ -62,22 +72,27 @@ function AddClassOnBoarding({ classTags, showNext }: AddClassProps): ReactElemen
         </div>
       </div>
       {/* display all class tags */}
-      <h2>Class Tags</h2>
+      <h2>My Classes</h2>
       <div className={styles.SettingsSection}>
-        <p className={styles.SettingsSectionTitle}>Class Tags</p>
         <div className={styles.SettingsSectionContent}>
           <ul className={styles.ColorConfigItemList}>
             {classTags.map(tag => <TagItem key={tag.id} tag={tag} />)}
           </ul>
         </div>
       </div>
+      <p className={styles.ImportExamContainer}>
+        <label htmlFor="onboardImportClass">
+          <input type="checkbox" id="onboardImportClass" checked={addExam} onChange={clickBox} />
+          Yes, please automatically import registrar-scheduled exams for my classes.
+        </label>
+      </p>
       {/* buttons */}
       <div className={styles.SignButtonContainer}>
-        <button type="button" onClick={importCourseExams} className={styles.SignButton}>
+        {/* <button type="button" onClick={importCourseExams} className={styles.SignButton}>
           Import Exams
-        </button>
+        </button> */}
         <span className={styles.Padding} />
-        <button type="button" className={styles.SignButton} onClick={showNext}>
+        <button type="button" className={styles.SignButton} onClick={allDone}>
           {classTags.length > 0 ? 'Done' : 'Skip Adding Classes'}
         </button>
       </div>
@@ -132,6 +147,12 @@ function Onboard({ classTags, completedOnboarding }: Props): ReactElement | null
   }
 
   const showNext = (): void => setProgress(prev => prev + 1);
+  const showNextImport = (shouldImport: boolean): void => {
+    if (shouldImport) {
+      importCourseExams();
+    }
+    showNext();
+  };
   const goBack = (): void => setProgress(prev => (prev > 1 ? prev - 1 : prev));
   const skipTutorial = (): void => setProgress(100);
 
@@ -140,7 +161,7 @@ function Onboard({ classTags, completedOnboarding }: Props): ReactElement | null
     : undefined;
   return (
     <div className={styles.Hero} style={onboardingContainerStyle}>
-      {progress === 0 && <AddClassOnBoarding classTags={classTags} showNext={showNext} />}
+      {progress === 0 && <AddClassOnBoarding classTags={classTags} showNext={showNextImport} />}
       {progress > 0 && (
         <SlidesOnBoarding
           progress={progress}

--- a/frontend/src/components/TitleBar/Onboarding/Onboard.tsx
+++ b/frontend/src/components/TitleBar/Onboarding/Onboard.tsx
@@ -138,8 +138,8 @@ function Onboard({ classTags, completedOnboarding }: Props): ReactElement | null
   const [progress, setProgress] = useState<number>(0);
 
   if (completedOnboarding || progress >= 7) {
-    if (progress >= 7) {
-      setProgress(0);
+    if (progress !== 1) {
+      setProgress(1);
     }
     completeOnboarding(true);
     // the conditions not to display the tutorial

--- a/frontend/src/components/TitleBar/Settings/SettingsPage.tsx
+++ b/frontend/src/components/TitleBar/Settings/SettingsPage.tsx
@@ -29,11 +29,11 @@ const ExamImporter = (): ReactElement => (
   <div className={styles.SettingsSection}>
     <p className={styles.SettingsSectionTitle}>Auto Import Exams</p>
     <div className={`${styles.SettingsButton} ${styles.SettingsSectionContent}`}>
-      Click the following button to automatically import the prelims and finals
-      from your added classes into your planner. We will only import those that
+      Click the following button to reimport the prelims and finals
+      from your classes into your planner. We will only import those that
       appears on Cornell prelim/final schedule webpage.
       <br />
-      <button type="button" onClick={importCourseExams}>Import</button>
+      <button type="button" onClick={importCourseExams}>Reimport Exams</button>
     </div>
   </div>
 );

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -296,6 +296,6 @@ export const importCourseExams = (): void => {
         batch.set(tasksCollection().doc(), transformedTask);
       });
       // eslint-disable-next-line no-alert
-      batch.commit().then(() => alert('Exams Added!'));
+      batch.commit().then(() => alert('Exams Added Successfully!'));
     });
 };


### PR DESCRIPTION
- Confetti now triggers correctly even with subtasks, resolving #212 
- Onboarding page now has a checkbox to import exams, not a button.
- Settings page import button has been relabeled as a reimport button
- Restarting the tutorial from Settings now only plays the tutorial, not the onboarding screen (which looked confusingly similar to the settings page the user just came from)