### PR TITLE
[ci] Ensure consistency of node version in two CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
   deploy-frontend:
     description: Deploy frontend to firebase hosting
     docker:
-      - image: circleci/node:jessie-browsers
+      - image: circleci/node:lts-jessie-browsers
     working_directory: ~/repo
     steps:
       - checkout


### PR DESCRIPTION
### Inside This PR
We should always use LTS so that we don't run into problems in this [failed job](https://circleci.com/gh/cornell-dti/samwise/403) later. This pull request unbreaks master deploy.

### Notes
Proof that this docker container exists: https://circleci.com/docs/2.0/docker-image-tags.json
Search for `lts-jessie-browsers`. Other than that, test in prod.

### Checklist:

- [x] My code follows the code style of this project.
- [x] I tested affected functionality.
- [x] I resolved any merge conflicts.
- [x] My PR is ready for review.
