### PR TITLE
Store `RepeatMetaData` into `date` field for task

### DIFF
--- a/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
@@ -71,7 +71,9 @@ function FutureViewTask(
     }
   };
 
-  const replaceDateForFork = getDateWithDateString(original.date, containerDate);
+  const replaceDateForFork = getDateWithDateString(
+    original.type === 'ONE_TIME' ? original.date : null, containerDate,
+  );
   const replaceDateForForkOpt = original.type === 'ONE_TIME' ? null : replaceDateForFork;
   const TaskCheckBox = (): ReactElement => {
     const { id, complete } = original;

--- a/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
@@ -97,7 +97,8 @@ function FloatingTaskEditor(
   const { id: _, type, subTasks, ...mainTask } = task;
   const actions = {
     removeTask: (): void => removeTaskWithPotentialPrompt(
-      initialTask, getDateWithDateString(mainTask.date, taskAppearedDate),
+      initialTask,
+      getDateWithDateString(mainTask.date instanceof Date ? mainTask.date : null, taskAppearedDate),
     ),
     onSave: closePopup,
   };

--- a/frontend/src/components/Util/TaskEditors/InlineTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/InlineTaskEditor.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement, useState } from 'react';
 import { removeTaskWithPotentialPrompt } from 'util/task-util';
-import { getDateWithDateString } from 'util/datetime-util';
 import { Task } from '../../../store/store-types';
 import TaskEditor from './TaskEditor';
 import { CalendarPosition, TaskWithSubTasks } from './editors-types';
@@ -21,14 +20,12 @@ export default function InlineTaskEditor(
   const [disabled, setDisabled] = useState(true);
   const { id } = original;
   const { id: _, type, subTasks, ...mainTask } = filtered;
-  const taskAppearedDate = mainTask.date.toDateString(); // TODO: fix this hack
+  const taskAppearedDate = mainTask.date instanceof Date ? mainTask.date.toDateString() : null;
   // To un-mount the editor when finished editing.
   const onFocus = (): void => setDisabled(false);
   const onBlur = (): void => setDisabled(true);
   const actions = {
-    removeTask: () => removeTaskWithPotentialPrompt(
-      original, getDateWithDateString(mainTask.date, taskAppearedDate),
-    ),
+    removeTask: () => removeTaskWithPotentialPrompt(original, null),
     onSave: onBlur,
   };
   return (

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/EditorHeader.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/EditorHeader.tsx
@@ -2,13 +2,13 @@ import React, { ReactElement } from 'react';
 import Calendar from 'react-calendar';
 import styles from './index.module.css';
 import TagListPicker from '../../TagListPicker/TagListPicker';
-import { Tag } from '../../../../store/store-types';
+import { Tag, RepeatMetaData } from '../../../../store/store-types';
 import { CalendarPosition } from '../editors-types';
 import SamwiseIcon from '../../../UI/SamwiseIcon';
 
 type TagAndDate = {
   readonly tag: string;
-  readonly date: Date;
+  readonly date: Date | RepeatMetaData;
 };
 
 type Props = TagAndDate & {
@@ -63,8 +63,10 @@ export default function EditorHeader(
       <TagListPicker onTagChange={editTaskTag} />
     </div>
   );
-  const dateDisplay = (<span>{`${date.getMonth() + 1}/${date.getDate()}`}</span>);
-  const dateEditor = doesShowDateEditor && (
+  const dateDisplay = date instanceof Date
+    ? <span>{`${date.getMonth() + 1}/${date.getDate()}`}</span>
+    : <span>Repeated</span>;
+  const dateEditor = doesShowDateEditor && date instanceof Date && (
     <Calendar
       value={date}
       className={

--- a/frontend/src/components/Util/TaskEditors/editors-types.ts
+++ b/frontend/src/components/Util/TaskEditors/editors-types.ts
@@ -4,19 +4,22 @@
  * - 'right': to the right the element.
  * - null: defaults to 'center'.
  */
-import { SubTask } from '../../../store/store-types';
+import { SubTask, RepeatMetaData } from '../../../store/store-types';
 
 export type FloatingPosition = 'left' | 'right';
 export type CalendarPosition = 'top' | 'bottom';
 
-export type TaskWithSubTasks = {
+type CommonTaskWithSubTasks<D> = {
   readonly id: string;
-  readonly type: 'MASTER_TEMPLATE' | 'ONE_TIME';
   readonly order: number;
   readonly name: string;
   readonly tag: string;
-  readonly date: Date;
+  readonly date: D;
   readonly complete: boolean;
   readonly inFocus: boolean;
   readonly subTasks: SubTask[];
 };
+
+export type TaskWithSubTasks =
+  | (CommonTaskWithSubTasks<Date> & { readonly type: 'ONE_TIME' })
+  | (CommonTaskWithSubTasks<RepeatMetaData> & { readonly type: 'MASTER_TEMPLATE' });

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -219,10 +219,10 @@ export const forkTaskWithDiff = (
   const { tasks, subTasks } = store.getState();
   const repeatingTaskMaster = tasks.get(taskId) as RepeatingTask;
   const {
-    id, order, type, children, repeats, forks, ...originalTaskWithoutId
+    id, order, type, children, date, forks, ...originalTaskWithoutId
   } = repeatingTaskMaster;
   const newMainTask: TaskWithoutIdOrderChildren = {
-    ...originalTaskWithoutId, ...mainTaskEdits, type: 'ONE_TIME',
+    ...originalTaskWithoutId, ...mainTaskEdits, date: replaceDate, type: 'ONE_TIME',
   };
   const newSubTasks: WithoutId<SubTask>[] = [];
   subTaskCreations.forEach((s) => newSubTasks.push(s));
@@ -473,6 +473,9 @@ export const importCourseExams = (): void => {
         const examName = `${course.subject} ${course.courseNumber} ${courseType}`;
         const t = new Date(time);
         const filter = (task: Task): boolean => {
+          if (task.type === 'MASTER_TEMPLATE') {
+            return false;
+          }
           const { name, date } = task;
           return task.tag === tag.id && name === examName
             && date.getFullYear() === t.getFullYear()

--- a/frontend/src/firebase/firestore-types.ts
+++ b/frontend/src/firebase/firestore-types.ts
@@ -15,7 +15,6 @@ export type FirestoreTag = FirestoreCommon & {
 export type FirestoreCommonTask = FirestoreCommon & {
   readonly name: string;
   readonly tag: string;
-  readonly date: Date | firestore.Timestamp;
   readonly complete: boolean;
   readonly inFocus: boolean;
   readonly children: readonly string[];
@@ -35,7 +34,7 @@ export type ForkedTaskMetaData = {
 export type FirestoreMasterTask = FirestoreCommonTask & {
   readonly type: 'MASTER_TEMPLATE';
   // in master task, we only use the time component of the date
-  readonly repeats: {
+  readonly date: {
     readonly startDate: Date | firestore.Timestamp;
     readonly endDate: number | Date | firestore.Timestamp;
     readonly pattern: RepeatingPattern;
@@ -44,7 +43,10 @@ export type FirestoreMasterTask = FirestoreCommonTask & {
   readonly forks: readonly ForkedTaskMetaData[];
 };
 
-export type FirestoreOneTimeTask = FirestoreCommonTask & { readonly type: 'ONE_TIME' }
+export type FirestoreOneTimeTask = FirestoreCommonTask & {
+  readonly type: 'ONE_TIME';
+  readonly date: Date | firestore.Timestamp;
+};
 
 // all these tasks stay in 'samwise-tasks'
 // FirestoreLegacyTask should eventually be converted to FirestoreOneTimeTask.

--- a/frontend/src/store/reducers.ts
+++ b/frontend/src/store/reducers.ts
@@ -58,11 +58,13 @@ function patchTasks(state: State, { created, edited, deleted }: PatchTasks): Sta
       }
       const key = t.date.toDateString();
       const oldTask = state.tasks.get(t.id) || error();
-      const oldKey = oldTask.date.toDateString();
-      if (oldKey !== key) {
-        // remove first
-        const oldBucket = m.get(oldKey) || error('impossible!');
-        m.set(oldKey, oldBucket.remove(t.id));
+      if (oldTask.type === 'ONE_TIME') {
+        const oldKey = oldTask.date.toDateString();
+        if (oldKey !== key) {
+          // remove first
+          const oldBucket = m.get(oldKey) || error('impossible!');
+          m.set(oldKey, oldBucket.remove(t.id));
+        }
       }
       const set = m.get(key);
       if (set == null) {
@@ -76,10 +78,12 @@ function patchTasks(state: State, { created, edited, deleted }: PatchTasks): Sta
       if (oldTask == null) {
         return;
       }
-      const key = oldTask.date.toDateString();
-      const set = m.get(key);
-      if (set != null) {
-        m.set(key, set.remove(id));
+      if (oldTask.type === 'ONE_TIME') {
+        const key = oldTask.date.toDateString();
+        const set = m.get(key);
+        if (set != null) {
+          m.set(key, set.remove(id));
+        }
       }
     });
   });

--- a/frontend/src/store/selectors.ts
+++ b/frontend/src/store/selectors.ts
@@ -106,7 +106,7 @@ export const createGetIdOrderListByDate = (
           return;
         }
         const repeatedTask = task as RepeatingTask;
-        if (dateMatchRepeats(dateObj, repeatedTask.repeats, repeatedTask.forks)) {
+        if (dateMatchRepeats(dateObj, repeatedTask.date, repeatedTask.forks)) {
           const { order } = repeatedTask;
           list.push({ id, order });
         }

--- a/frontend/src/store/store-types.ts
+++ b/frontend/src/store/store-types.ts
@@ -23,18 +23,20 @@ export type SubTaskWithoutIdOrder = Pick<SubTask, 'name' | 'complete' | 'inFocus
  */
 export type PartialSubTask = Partial<SubTaskWithoutIdOrder>;
 
-export type CommonTask = {
+export type CommonTask<D> = {
   readonly id: string;
   readonly order: number;
   readonly name: string; // Example: "Task 1 name"
   readonly tag: string; // ID of the tag
-  readonly date: Date; // Example: new Date()
+  readonly date: D;
   readonly complete: boolean;
   readonly inFocus: boolean; // Whether the task is in focus
   readonly children: Set<string>;
 };
 
-export type OneTimeTask = CommonTask & {
+type FlexibleCommonTask = CommonTask<Date | RepeatMetaData>;
+
+export type OneTimeTask = CommonTask<Date> & {
   readonly type: 'ONE_TIME';
 };
 
@@ -43,7 +45,7 @@ export type OneTimeTask = CommonTask & {
  * Fields that are filled represent differences from master template
  */
 
-export type PartialTask = Partial<Pick<CommonTask, MainTaskProperties | 'children' >>;
+export type PartialTask = Partial<Pick<FlexibleCommonTask, MainTaskProperties | 'children' >>;
 
 export type RepeatingPattern =
   | { readonly type: 'WEEKLY'; readonly bitSet: number /* 7-bit */ }
@@ -61,9 +63,8 @@ export type ForkedTaskMetaData = {
   readonly replaceDate: Date;
 };
 
-export type RepeatingTask = CommonTask & {
+export type RepeatingTask = CommonTask<RepeatMetaData> & {
   readonly type: 'MASTER_TEMPLATE';
-  readonly repeats: RepeatMetaData;
   readonly forks: readonly ForkedTaskMetaData[];
 };
 
@@ -73,7 +74,7 @@ type MainTaskProperties = 'name' | 'tag' | 'date' | 'complete' | 'inFocus';
 /**
  * The task type without id and subtask.
  */
-export type MainTask = Readonly<Pick<CommonTask, MainTaskProperties>>;
+export type MainTask = Readonly<Pick<FlexibleCommonTask, MainTaskProperties>>;
 /**
  * The task type without id and subtask, and with all properties as optional.
  */

--- a/frontend/src/util/datetime-util.ts
+++ b/frontend/src/util/datetime-util.ts
@@ -73,15 +73,19 @@ export function isToday(date: Date): boolean {
 }
 
 /**
- * @param date the date object to mutate.
+ * @param date the date object to provide time information.
  * @param dateString the date string to apply.
  * @returns a new date object with the date info in the date string applied.
  */
-export function getDateWithDateString(date: Date, dateString: string): Date {
-  const newDate = new Date(date);
+export function getDateWithDateString(date: Date | null, dateString: string): Date {
+  const newDate = date === null ? new Date() : new Date(date);
   const dateInfo = new Date(dateString);
   newDate.setFullYear(dateInfo.getFullYear());
   newDate.setMonth(dateInfo.getMonth());
   newDate.setDate(dateInfo.getDate());
+  if (date === null) {
+    // Default to last second of the day.
+    newDate.setHours(23, 59, 59);
+  }
   return newDate;
 }

--- a/frontend/src/util/undo-util.ts
+++ b/frontend/src/util/undo-util.ts
@@ -40,7 +40,9 @@ export function clearLastRemovedTask(performUndo: boolean): void {
  */
 export function emitUndoAddTaskToast(task: TaskWithFullChildren): void {
   lastAddedTask = task;
-  const message = `Added Task "${task.name}" on ${date2String(task.date)}.`;
+  const message = task.type === 'ONE_TIME'
+    ? `Added Task "${task.name}" on ${date2String(task.date)}.`
+    : `Added Repeating Task ${task.name}`;
   emitToast({
     toastId: 'task-management',
     message,
@@ -54,7 +56,9 @@ export function emitUndoAddTaskToast(task: TaskWithFullChildren): void {
  */
 export function emitUndoRemoveTaskToast(task: TaskWithFullChildren): void {
   lastRemovedTask = task;
-  const message = `Removed Task "${task.name}" on ${date2String(task.date)}.`;
+  const message = task.type === 'ONE_TIME'
+    ? `Removed Task "${task.name}" on ${date2String(task.date)}.`
+    : `Removed Repeating Task ${task.name}`;
   emitToast({
     toastId: 'task-management',
     message,


### PR DESCRIPTION
### Inside This PR
It is a design mistake to use a separate field to store repeat metadata.

Reasons:
- It doesn't make a lot of sense to also keep `date` field for RepeatingTask. Before this change, we only use that to store time info, which is hard to statically ensure that we correctly populate it.
- It gives us a false sense of security that we have correctly dealt with the complexity of repeating task. Since we kept `date` field, TypeScript won't complain in a lot of places where we forget to consider that `date` in RepeatingTask has special meanings.

Therefore, I decide to make `date` to have different types for OneTimeTask and RepeatingTask, so we can use TypeScript to tell us where we did it wrong.
The majority of this commit is simply changing `repeatingPattern` to `date`, but I do discover a bug where the current behavior is wrong. In the focus view, we still always use the `date` field to decide the date when the task is due, which doesn't make sense for repeating task. I decide to ban forking or deleting ONE INSTANCE OF repeating task in focus view because it's not clear to the user what's the actual due date of a task in the focus view. We should probably add the ability back in the future and default to the earliest due date for repeating task in focus view, but it should be the concern of another pull request.

### Breaking Changes
- Temporarily removed the ability to fork or delete one instance of repeating task in focus view.

### Checklist:
- [x] My code follows the code style of this project.
- [x] I tested affected functionality.
- [x] I resolved any merge conflicts.
- [x] My PR is ready for review.
