### PR TITLE
Restore undo task remove for non-forked one time task

### DIFF
--- a/frontend/src/util/undo-util.ts
+++ b/frontend/src/util/undo-util.ts
@@ -29,6 +29,11 @@ export function clearLastRemovedTask(performUndo: boolean): void {
   if (lastRemovedTask !== null) {
     if (performUndo) {
       const { id, order, children, ...rest } = lastRemovedTask;
+      /*
+       * TODO:
+       * Also handle the case where the task is a forked one-time task and we need to add the
+       * metadata back to the master template.
+       */
       addTask(rest, children.map(({ id: _, ...s }) => s), 'no-undo');
     }
     lastRemovedTask = null;


### PR DESCRIPTION
Background:
Hopefully we can deploy a new version with the new exam and date information soon. However, without this commit, if we disable the currently unstable repeating task feature, our current product will be worse than the deployed one since we lose the undo remove task feature and need to prompt the user to delete the task.

My temporary solution and deployment plan:
Restore undo feature for non-forked one-time tasks. After this commit lands, create another commit that only enables repeating task creation UI with a flag. Since we don't support switching between one-time tasks and repeating tasks yet, it will effectively disable repeating task feature, which can unblock our deployment.

Why is non-forked one-time task special?
It's the simplest kind of task we know how to deal with since last winter. Dealing with repeating task and forked task is much more involved since we also need to do some manipulation with forked task metadata, which I don't think we should do it right now without a careful review.

### Inside This PR

- [x] Added check for whether a task is forked.
- [x] Do not require prompt for non-forked one time task removal
- [x] Restore undo task for non-forked one time task

### Checklist:
- [x] My code follows the code style of this project.
- [x] I tested affected functionality.
- [x] I resolved any merge conflicts.
- [x] My PR is ready for review.
