### PR TITLE
Put repeating task behind a flag

### DIFF
--- a/frontend/src/components/TaskCreator/DatePicker.tsx
+++ b/frontend/src/components/TaskCreator/DatePicker.tsx
@@ -18,6 +18,8 @@ type Props = {
   readonly onClearPicker: () => void;
 };
 
+const REPEATING_TASK_ENABLED: boolean = localStorage.getItem('REPEATING_TASK_ENABLED') != null;
+
 export default function DatePicker(props: Props): ReactElement {
   const {
     date, opened, datePicked, onDateChange, onPickerOpened, onClearPicker,
@@ -354,16 +356,18 @@ export default function DatePicker(props: Props): ReactElement {
       {displayedNode(!datePicked)}
       {opened && (
         <div className={styles.NewTaskDatePick}>
-          <p className={dateStyles.SelectTypeWrap}>
-            <select
-              className={dateStyles.SelectType}
-              value={isRepeat.toString()}
-              onChange={changeRepeat}
-            >
-              <option value="false">One-Time</option>
-              <option value="true">Repeating</option>
-            </select>
-          </p>
+          {REPEATING_TASK_ENABLED && (
+            <p className={dateStyles.SelectTypeWrap}>
+              <select
+                className={dateStyles.SelectType}
+                value={isRepeat.toString()}
+                onChange={changeRepeat}
+              >
+                <option value="false">One-Time</option>
+                <option value="true">Repeating</option>
+              </select>
+            </p>
+          )}
           {!isRepeat && <Calendar onChange={onChange} value={currDate} minDate={new Date()} calendarType="US" />}
           {isRepeat && openedRepeat}
           <p className={styles.NewTaskDateSave}>


### PR DESCRIPTION
### Inside This PR

This commit continues the deployment preparation starting from #277
By default, it will not be enabled and won't be accidently enabled because you have to set local storage in console manually.
To check I don't remove the feature completely, run `localStorage.set('REPEATING_TASK_ENABLED', 'true')` and refresh, the feature will reappear. Unset it, it will disappear. It's expected that this flag will be removed once we deployed a stable version to production.

### Checklist:

- [x] My code follows the code style of this project.
- [x] I tested affected functionality.
- [x] I resolved any merge conflicts.
- [x] My PR is ready for review.
