### PR TITLE
Fix the bug where we lose edit status on mouseleave

### DIFF
--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -98,11 +98,11 @@ function TaskEditor(
     if (onBlur) {
       onBlur();
     }
-    onSave();
   };
   const onSaveClicked = (): void => {
     if (type === 'ONE_TIME') {
       editTaskWithDiff(id, 'EDITING_ONE_TIME_TASK', diff);
+      onSave();
       return;
     }
     if (taskAppearedDate === null) {


### PR DESCRIPTION
#273 adds the missing line to the wrong place. After this fix, we will no longer close FloatingEditor after mouse moves out of the editor.

### Inside This PR
- [x] No longer call `onSave()` unconditionally on mouse leave for TaskEditor.
- [x] Ensure we always call `onSave()` when we are clicking the save button in TaskEditor.

### Checklist:
- [x] My code follows the code style of this project.
- [x] I tested affected functionality.
- [x] I resolved any merge conflicts.
- [x] My PR is ready for review.
