### PR TITLE
Add script to add `type: 'ONE_TIME'` to all existing task

### DIFF
--- a/admin-scripts/add-type-one-time.py
+++ b/admin-scripts/add-type-one-time.py
@@ -1,0 +1,33 @@
+import firebase_admin
+from firebase_admin import credentials
+from firebase_admin import firestore
+
+cred = credentials.Certificate("firebaseadmin.json")
+firebase_admin.initialize_app(cred)
+
+db = firestore.client()
+
+
+def chunks(list, n):
+    chunk = []
+    for item in list:
+        if len(chunk) == n:
+            yield chunk
+            chunk = []
+        chunk.append(item)
+    if len(chunk) > 0:
+        yield chunk
+
+
+def main() -> None:
+    tasks = db.collection("samwise-tasks").stream()
+    # A batch can update at most 500 objects at a time.
+    for task_chunk in chunks(tasks, 500):
+        batch = db.batch()
+        for task in task_chunk:
+            task_ref = db.collection("samwise-tasks").document(task.id)
+            batch.update(task_ref, {"type": "ONE_TIME"})
+        batch.commit()
+
+
+main()


### PR DESCRIPTION
### Inside This PR
To deploy a new version to production, we first need to normalize the database to  use the latest schema with the additional type field. This script does the normalization.

### Test Plan
To ease your testing, changing 500 to 2 in the code.
1. Create 5-6 random tasks on the staging site.
2. In firebase console, remove the type field.
3. Download firebase admin sdk of the STAGING site and put it in admin-scripts/firebaseadmin.json
4. `python3 add-type-one-time.py`
5. Observe the firebase console. The field should be added back.

I have run this on my machine, but it's highly recommended that a code reviewer also run this to ensure we don't mess up the production db.

### Checklist:
- [x] My code follows the code style of this project.
- [x] I tested affected functionality.
- [x] I resolved any merge conflicts.
- [x] My PR is ready for review.