### PR TITLE
Avoid firebase crashing when date is undefined

### DIFF
--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -337,7 +337,7 @@ export const editSubTask = (
   taskId: string, subtaskId: string, replaceDate: Date | null, partialSubTask: PartialSubTask,
 ): void => {
   const diff: Diff = {
-    mainTaskEdits: { date: replaceDate == null ? undefined : replaceDate },
+    mainTaskEdits: replaceDate == null ? {} : { date: replaceDate },
     subTaskCreations: Map(),
     subTaskEdits: Map<string, PartialSubTask>().set(subtaskId, partialSubTask),
     subTaskDeletions: Set(),


### PR DESCRIPTION
Firebase does not like undefined values in update object. As a result, it will crash with the old code. This bug appears when you are checking a subtask in `FutureView`.

Test Plan:
See hot-fix deployed to samwise.today.

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I tested affected functionality.
- [x] I resolved any merge conflicts.
- [x] My PR is ready for review.
