### PR TITLE
[ci-cd] Setup GitHub actions to check, build, and deploy PR changes

### DIFF
--- a/.github/workflows/ci-workflows.yml
+++ b/.github/workflows/ci-workflows.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Purge Old Static Assets
         env:
           PR_BRANCH: ${{ github.head_ref }}
-        run: git rm -rf $PR_BRANCH
+        run: rm -rf $PR_BRANCH
       - name: Download Built Static Assets
         uses: actions/download-artifact@master
         with:

--- a/.github/workflows/ci-workflows.yml
+++ b/.github/workflows/ci-workflows.yml
@@ -29,7 +29,7 @@ jobs:
           path: frontend/build
   deploy:
     runs-on: ubuntu-latest
-    needs: [check, build]
+    needs: [build]
     steps:
       - name: Setup gh-pages Branch
         env:

--- a/.github/workflows/ci-workflows.yml
+++ b/.github/workflows/ci-workflows.yml
@@ -1,0 +1,55 @@
+name: CI
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Node
+        uses: actions/setup-node@v1
+      - name: Yarn Install
+        run: cd frontend && yarn install
+      - name: Run TypeScript Compiler
+        run: cd frontend && yarn tsc
+      - name: Run Linter
+        run: cd frontend && yarn lint
+      - name: Run Tests
+        run: cd frontend && yarn test
+      - name: Build main-site-frontend
+        env:
+          PR_BRANCH: ${{ github.head_ref }}
+        run: |
+          cd frontend
+          PUBLIC_URL=$PR_BRANCH yarn build:stage
+      - name: Upload Built Static Assets
+        uses: actions/upload-artifact@master
+          with:
+            name: built-frontend-assets
+            path: frontend/build
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [check, build]
+    steps:
+      - name: Setup gh-pages Branch
+        env:
+          ACCESS_TOKEN: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
+        run: |
+          git clone "https://${ACCESS_TOKEN}@github.com/cornell-dti/samwise.git"
+      - name: Purge Old Static Assets
+        env:
+          PR_BRANCH: ${{ github.head_ref }}
+        run: git rm -rf $PR_BRANCH
+      - name: Download Built Static Assets
+        uses: actions/download-artifact@master
+        with:
+          name: built-frontend-assets
+          path: ${{ github.head_ref }}
+      - name: Commit and Push New Static Assets
+        env:
+          PR_BRANCH: ${{ github.head_ref }}
+        run: |
+          git config --global user.name "deployment-bot"
+          git add .
+          git commit -m "Deploy for $PR_BRANCH"
+          git push

--- a/.github/workflows/ci-workflows.yml
+++ b/.github/workflows/ci-workflows.yml
@@ -52,8 +52,9 @@ jobs:
       - name: Commit and Push New Static Assets
         env:
           PR_BRANCH: ${{ github.head_ref }}
+          ACCESS_TOKEN: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
         run: |
           git config --global user.name "deployment-bot"
           git add .
           git commit -m "Deploy for $PR_BRANCH"
-          git push
+          git push "https://${ACCESS_TOKEN}@github.com/cornell-dti/samwise.git"

--- a/.github/workflows/ci-workflows.yml
+++ b/.github/workflows/ci-workflows.yml
@@ -24,9 +24,9 @@ jobs:
           PUBLIC_URL=$PR_BRANCH yarn build:stage
       - name: Upload Built Static Assets
         uses: actions/upload-artifact@master
-          with:
-            name: built-frontend-assets
-            path: frontend/build
+        with:
+          name: built-frontend-assets
+          path: frontend/build
   deploy:
     runs-on: ubuntu-latest
     needs: [check, build]

--- a/.github/workflows/ci-workflows.yml
+++ b/.github/workflows/ci-workflows.yml
@@ -37,7 +37,9 @@ jobs:
         run: |
           rm -rf *
           git clone "https://${ACCESS_TOKEN}@github.com/cornell-dti/samwise.git" .
-          git checkout -b gh-pages
+          git remote set-url origin https://github.com/cornell-dti/samwise.git
+          git fetch origin
+          git checkout -b gh-pages origin/gh-pages
       - name: Purge Old Static Assets
         env:
           PR_BRANCH: ${{ github.head_ref }}

--- a/.github/workflows/ci-workflows.yml
+++ b/.github/workflows/ci-workflows.yml
@@ -21,7 +21,7 @@ jobs:
           PR_BRANCH: ${{ github.head_ref }}
         run: |
           cd frontend
-          PUBLIC_URL=$PR_BRANCH yarn build:stage
+          PUBLIC_URL="/$PR_BRANCH" yarn build:stage
       - name: Upload Built Static Assets
         uses: actions/upload-artifact@master
         with:

--- a/.github/workflows/ci-workflows.yml
+++ b/.github/workflows/ci-workflows.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           rm -rf *
           git clone "https://${ACCESS_TOKEN}@github.com/cornell-dti/samwise.git" .
+          git checkout -b gh-pages
       - name: Purge Old Static Assets
         env:
           PR_BRANCH: ${{ github.head_ref }}

--- a/.github/workflows/ci-workflows.yml
+++ b/.github/workflows/ci-workflows.yml
@@ -35,7 +35,8 @@ jobs:
         env:
           ACCESS_TOKEN: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
         run: |
-          git clone "https://${ACCESS_TOKEN}@github.com/cornell-dti/samwise.git"
+          rm -rf *
+          git clone "https://${ACCESS_TOKEN}@github.com/cornell-dti/samwise.git" .
       - name: Purge Old Static Assets
         env:
           PR_BRANCH: ${{ github.head_ref }}


### PR DESCRIPTION
### Inside This PR

#### Summary

We want to see pr changes get deployed so that we can directly play with it without installing anything.
We want deployment to happen in isolation with other PR so that they don't interfere.

#### Strategy

1. Build the frontend assets with the branch name as the root path. In this way, we can deploy stuff to a subdirectory with all the URL still correctly resolved.
2. Do some git magic to put the built stuff into the corresponding `gh-pages` branch, commit, and push.
3. Now it will be automatically deployed by GitHub Pages. Profit!

#### Why Other Strategies Do Not Work

- Deploy to Firebase: Firebase does not allow us to programmatically create new sites within the same project.
- Deploy to Netlify/zuit: No good support for subdirectory only deploy. The problem is that we still want to keep other branches stuff around, so we must use git, and GitHub Pages can satisfy these two requirement at once!

#### Test Plan
See CI build

#### Future Work

Automatically purge deleted branches's file in `gh-pages` branch.

### Checklist:

- [x] My code follows the code style of this project.
- [x] I tested affected functionality.
- [x] I resolved any merge conflicts.
- [x] My PR is ready for review.
