### PR TITLE
Add cleanup workflow to remove staging resources after closing PR

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -49,3 +49,15 @@ jobs:
           git add .
           git commit -m "Deploy for ${{ github.event.number }}"
           git push "https://${ACCESS_TOKEN}@github.com/cornell-dti/samwise.git"
+      - name: Comment on Pull Request
+        uses: actions/github-script@0.2.0
+        with:
+          github-token: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
+          script: |
+            octokit.pulls.createReview({
+              owner: 'cornell-dti',
+              repo: 'samwise',
+              pull_number: ${{ github.event.number }},
+              event: 'COMMENT',
+              body: 'Deployed to https://staging-pr.samwise.today/${{ github.event.number }}'
+            });

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -16,7 +16,7 @@ jobs:
         run: cd frontend && yarn lint
       - name: Run Tests
         run: cd frontend && yarn test
-      - name: Build main-site-frontend
+      - name: Build frontend
         run: |
           cd frontend
           PUBLIC_URL="/${{ github.event.number }}" yarn build:stage

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -32,10 +32,9 @@ jobs:
       - name: Checkout gh-pages Branch
         uses: actions/checkout@master
         with:
-          token: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
           ref: gh-pages
       - name: Purge Old Static Assets
-        run: rm -rf ${{ github.event.number }}
+        run: git rm -rf ${{ github.event.number }} || echo "Nothing to remove"
       - name: Download Built Static Assets
         uses: actions/download-artifact@master
         with:
@@ -45,10 +44,11 @@ jobs:
         env:
           ACCESS_TOKEN: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
         run: |
-          git config --global user.name "deployment-bot"
+          git config user.name "deployment-bot"
+          git config user.email "hello@cornelldti.org"
           git add .
           git commit -m "Deploy for ${{ github.event.number }}"
-          git push "https://${ACCESS_TOKEN}@github.com/cornell-dti/samwise.git"
+          git push "https://${ACCESS_TOKEN}@github.com/cornell-dti/samwise.git" || echo "No Update"
       - name: Comment on Pull Request
         uses: actions/github-script@0.2.0
         with:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           github-token: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
           script: |
-            octokit.pulls.createReview({
+            github.pulls.createReview({
               owner: 'cornell-dti',
               repo: 'samwise',
               pull_number: ${{ github.event.number }},

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -47,7 +47,7 @@ jobs:
           git config user.name "deployment-bot"
           git config user.email "hello@cornelldti.org"
           git add .
-          git commit -m "Deploy for ${{ github.event.number }}"
+          git commit -m "Deploy for ${{ github.event.number }}" || echo "No Update"
           git push "https://${ACCESS_TOKEN}@github.com/cornell-dti/samwise.git" || echo "No Update"
       - name: Comment on Pull Request
         uses: actions/github-script@0.2.0

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -17,11 +17,9 @@ jobs:
       - name: Run Tests
         run: cd frontend && yarn test
       - name: Build main-site-frontend
-        env:
-          PR_BRANCH: ${{ github.head_ref }}
         run: |
           cd frontend
-          PUBLIC_URL="/$PR_BRANCH" yarn build:stage
+          PUBLIC_URL="/${{ github.event.number }}" yarn build:stage
       - name: Upload Built Static Assets
         uses: actions/upload-artifact@master
         with:
@@ -31,30 +29,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - name: Setup gh-pages Branch
-        env:
-          ACCESS_TOKEN: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
-        run: |
-          rm -rf *
-          git clone "https://${ACCESS_TOKEN}@github.com/cornell-dti/samwise.git" .
-          git remote set-url origin https://github.com/cornell-dti/samwise.git
-          git fetch origin
-          git checkout -b gh-pages origin/gh-pages
+      - name: Checkout gh-pages Branch
+        uses: actions/checkout@master
+        with:
+          token: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
+          ref: gh-pages
       - name: Purge Old Static Assets
-        env:
-          PR_BRANCH: ${{ github.head_ref }}
-        run: rm -rf $PR_BRANCH
+        run: rm -rf ${{ github.event.number }}
       - name: Download Built Static Assets
         uses: actions/download-artifact@master
         with:
           name: built-frontend-assets
-          path: ${{ github.head_ref }}
+          path: ${{ github.event.number }}
       - name: Commit and Push New Static Assets
         env:
-          PR_BRANCH: ${{ github.head_ref }}
           ACCESS_TOKEN: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
         run: |
           git config --global user.name "deployment-bot"
           git add .
-          git commit -m "Deploy for $PR_BRANCH"
+          git commit -m "Deploy for ${{ github.event.number }}"
           git push "https://${ACCESS_TOKEN}@github.com/cornell-dti/samwise.git"

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -47,8 +47,8 @@ jobs:
           git config user.name "deployment-bot"
           git config user.email "hello@cornelldti.org"
           git add .
-          git commit -m "Deploy for ${{ github.event.number }}" || echo "No Update"
-          git push "https://${ACCESS_TOKEN}@github.com/cornell-dti/samwise.git" || echo "No Update"
+          git commit -m "Deploy for ${{ github.event.number }}" || echo "Nothing to commit."
+          git push "https://${ACCESS_TOKEN}@github.com/cornell-dti/samwise.git" || echo "Nothing to push."
       - name: Comment on Pull Request
         uses: actions/github-script@0.2.0
         with:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -52,12 +52,11 @@ jobs:
       - name: Comment on Pull Request
         uses: actions/github-script@0.2.0
         with:
-          github-token: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
-            github.pulls.createReview({
+            github.issues.createComment({
               owner: 'cornell-dti',
               repo: 'samwise',
-              pull_number: ${{ github.event.number }},
-              event: 'COMMENT',
+              issue_number: ${{ github.event.number }},
               body: 'Deployed to https://staging-pr.samwise.today/${{ github.event.number }}'
             });

--- a/.github/workflows/cleanup-workflow.yml
+++ b/.github/workflows/cleanup-workflow.yml
@@ -1,0 +1,23 @@
+name: Cleanup
+on:
+  pull_request:
+    type: [closed]
+
+jobs:
+  clean-up:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages Branch
+        uses: actions/checkout@master
+        with:
+          token: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
+          ref: gh-pages
+      - name: Purge Static Assets
+        env:
+          ACCESS_TOKEN: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
+        run: |
+          rm -rf ${{ github.event.number }}
+          git config --global user.name "deployment-bot"
+          git add .
+          git commit -m "Deploy for ${{ github.event.number }}"
+          git push "https://${ACCESS_TOKEN}@github.com/cornell-dti/samwise.git"

--- a/.github/workflows/cleanup-workflow.yml
+++ b/.github/workflows/cleanup-workflow.yml
@@ -6,13 +6,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages Branch
-        if: github.event.state === 'closed'
+        if: github.event.state == 'closed'
         uses: actions/checkout@master
         with:
           token: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
           ref: gh-pages
       - name: Purge Static Assets
-        if: github.event.state === 'closed'
+        if: github.event.state == 'closed'
         env:
           ACCESS_TOKEN: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
         run: |

--- a/.github/workflows/cleanup-workflow.yml
+++ b/.github/workflows/cleanup-workflow.yml
@@ -9,15 +9,15 @@ jobs:
         if: github.event.state == 'closed'
         uses: actions/checkout@master
         with:
-          token: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
           ref: gh-pages
       - name: Purge Static Assets
         if: github.event.state == 'closed'
         env:
           ACCESS_TOKEN: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
         run: |
-          rm -rf ${{ github.event.number }}
-          git config --global user.name "deployment-bot"
+          git rm -rf ${{ github.event.number }} || echo "Nothing to remove"
+          git config user.name "deployment-bot"
+          git config user.email "hello@cornelldti.org"
           git add .
           git commit -m "Deploy for ${{ github.event.number }}"
           git push "https://${ACCESS_TOKEN}@github.com/cornell-dti/samwise.git"

--- a/.github/workflows/cleanup-workflow.yml
+++ b/.github/workflows/cleanup-workflow.yml
@@ -19,5 +19,5 @@ jobs:
           git config user.name "deployment-bot"
           git config user.email "hello@cornelldti.org"
           git add .
-          git commit -m "Deploy for ${{ github.event.number }}"
-          git push "https://${ACCESS_TOKEN}@github.com/cornell-dti/samwise.git"
+          git commit -m "Remove assets in ${{ github.event.number }}" || echo "Nothing to commit."
+          git push "https://${ACCESS_TOKEN}@github.com/cornell-dti/samwise.git" || echo "Nothing to push."

--- a/.github/workflows/cleanup-workflow.yml
+++ b/.github/workflows/cleanup-workflow.yml
@@ -1,18 +1,18 @@
 name: Cleanup
-on:
-  pull_request:
-    type: [closed]
+on: pull_request
 
 jobs:
   clean-up:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages Branch
+        if: github.event.state === 'closed'
         uses: actions/checkout@master
         with:
           token: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
           ref: gh-pages
       - name: Purge Static Assets
+        if: github.event.state === 'closed'
         env:
           ACCESS_TOKEN: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
         run: |


### PR DESCRIPTION
### Inside This PR

- [x] Use PR number instead of branch name for deployment bash path
- [x] Simplify staging PR deployment workflow by using official GitHub checkout action.
- [x] Add workflow to automatically cleanup staging resources after pull request is 

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I tested affected functionality.
- [x] I resolved any merge conflicts.
- [x] My PR is ready for review.
