### PR TITLE
Improve pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,25 @@
-<!-- Provide a general summary of your changes in the Title above -->
+### Summary <!-- Required -->
 
-### Inside This PR
+<!-- Provide a general summary of your changes in the Title above -->
 <!-- Itemize bug fixes, new features, and other changes -->
-<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->
+<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
 <!-- Some examples are shown below. -->
 
-- [ ] implemented X
+This pull request is the first step towards implementing feature Foo
+
+- [x] implemented X
 - [ ] fixed Y
 
+### Test Plan <!-- Required -->
+
+<!-- Provide screenshots or point out the additional unit tests -->
+
 ### Notes <!-- Optional -->
+
 <!--- List any important or subtle points, future considerations, or other items of note. -->
 
-### Breaking Changes
+### Breaking Changes  <!-- Optional -->
+
 <!-- Keep items that apply: -->
 - Database schema change (anything that changes Firestore collection structure)
 - Other change that could cause problems (Detailed in notes)
-
-### Checklist:
-<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
-<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-- [ ] My code follows the code style of this project.
-- [ ] I tested affected functionality.
-- [ ] I resolved any merge conflicts.
-- [ ] My PR is ready for review.


### PR DESCRIPTION
### Summary

The old template has some items that are rarely used and are almost always deleted by the author of the pull request. This commit tries to clean it up so that it's more useful and can be respected more.

- Add required summary and test plan
- Remove checklist (it is already enforced by earlier sections or by CI)

### Test Plan

eyes