### PR TITLE
Bring back the bear

### DIFF
--- a/frontend/src/components/TaskView/ProgressTracker/ProgressIndicator.module.scss
+++ b/frontend/src/components/TaskView/ProgressTracker/ProgressIndicator.module.scss
@@ -6,6 +6,7 @@
   align-items: center;
   justify-content: center;
   margin: 1em;
+  flex: auto;
 }
 
 .ProgressText {

--- a/frontend/src/components/TaskView/ProgressTracker/ProgressIndicator.tsx
+++ b/frontend/src/components/TaskView/ProgressTracker/ProgressIndicator.tsx
@@ -39,8 +39,8 @@ export default function ProgressIndicator(
   { completedTasksCount, allTasksCount, inMobileView }: Props,
 ): ReactElement {
   const containerStyle: CSSProperties = inMobileView
-    ? { flex: 'auto', height: '2em' }
-    : { flexDirection: 'column-reverse', margin: '0', width: '2em', height: '100%' };
+    ? { height: '2em' }
+    : { flexDirection: 'column-reverse', margin: '0', width: '2em' };
   const textStyle: CSSProperties = inMobileView ? {} : { width: '70px', marginBottom: '8px' };
   const fractionString = `${completedTasksCount}/${allTasksCount}`;
   return (


### PR DESCRIPTION
### Summary <!-- Required -->

`height: '100%'` uses up the space for bear. Use `flex: auto` to automatically reserve space for bear

- [x] The bear is back

### Test Plan <!-- Required -->

<img width="1772" alt="Screen Shot 2019-09-28 at 02 59 25" src="https://user-images.githubusercontent.com/4290500/65812921-0239c900-e19c-11e9-8c77-a0f7e4bb955a.png">
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ⬆️ 