### PR TITLE
Unbreak master deploy by adding missing `cd frontend`

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -19,5 +19,6 @@ jobs:
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         run: |
+          cd frontend
           ./node_modules/.bin/firebase use default
           ./node_modules/.bin/firebase deploy --token=$FIREBASE_TOKEN --non-interactive --only hosting


### PR DESCRIPTION
### Summary <!-- Required -->

Add the missing `cd frontend` since everything is installed in `frontend` folder.

### Test Plan <!-- Required -->

Test in `master`.