### PR TITLE
[cd] Create release workflow

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -7,8 +7,8 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Fail if base-ref is not master
-        if: github.base_ref != 'master'
+        if: github.ref != 'ref/head/master'
         run: |
           echo "Base ref must be master. Everything should go through staging first!"
-          echo "Your base ref is ${{github.base_ref}}."
+          echo "Your base ref is ${{ github.ref }}."
           exit 1

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -10,4 +10,5 @@ jobs:
         if: github.base_ref != 'master'
         run: |
           echo "Base ref must be master. Everything should go through staging first!"
+          echo "Your base ref is ${{github.base_ref}}."
           exit 1

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,5 +1,8 @@
 name: Release
-on: push
+on:
+  push:
+    branches:
+      - release
 
 jobs:
   check-base-ref:
@@ -12,3 +15,21 @@ jobs:
           echo "Base ref must be master. Everything should go through staging first!"
           echo "Your base ref is ${{ github.ref }}."
           exit 1
+  deploy:
+    runs-on: ubuntu-latest
+    needs: check-base-ref
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Node
+        uses: actions/setup-node@v1
+      - name: Yarn Install
+        run: cd frontend && yarn install
+      - name: Build frontend
+        run: cd frontend && yarn build
+      - name: Deploy to Production
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: |
+          cd frontend
+          ./node_modules/.bin/firebase use production
+          ./node_modules/.bin/firebase deploy --token=$FIREBASE_TOKEN --non-interactive --only hosting

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,0 +1,13 @@
+name: Release
+on: push
+
+jobs:
+  check-base-ref:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Fail if base-ref is not master
+        if: github.base_ref != 'master'
+        run: |
+          echo "Base ref must be master. Everything should go through staging first!"
+          exit 1


### PR DESCRIPTION
### Summary

Setup a release workflow. The config is mostly copied from cd workflow, but tweaked a little bit to use the production config: (`yarn build` instead of `yarn buiild:stage`, `use production` instead of `use default`).
I added another check `check-base-ref` in the workflow. It enforces that the base_ref is master, so we know everything goes through staging first.

To prevent abuse of release branch, an extremely strict branch protection rule has been setup. Merging to release requires three approvals, pushing after approval invalidates it, all status checks must pass, and branch must be up-to-date, etc. When all the conditions passed, only repo admins can push to release.

### Test Plan

See the dummy first few commits to see whether we get the `check-base-ref` job right.

### Notes

It should be merged by `squash and merge` to avoid adding the first junk commit into master.