### PR TITLE
Mobile improvements

### DIFF
--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -1,6 +1,6 @@
 .TaskView {
   flex: 1 1 auto;
-  overflow: scroll;
+  overflow: hidden;
 }
 
 .Toast div {

--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -1,3 +1,8 @@
+.TaskView {
+  flex: 1 1 auto;
+  overflow: scroll;
+}
+
 .Toast div {
   min-height: unset !important;
   background: #676767;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,14 +13,14 @@ import { ModalsContainer } from './components/Util/Modals';
  */
 export default function App(): ReactElement {
   return (
-    <div>
+    <>
       <Onboard />
       <ToastContainer className={styles.Toast} />
       <ModalsContainer />
       <TitleBar />
       <TaskCreator />
-      <TaskView />
+      <TaskView className={styles.TaskView} />
       <AllComplete />
-    </div>
+    </>
   );
 }

--- a/frontend/src/components/TaskView/FutureView/FutureViewControl.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewControl.tsx
@@ -72,8 +72,8 @@ function getBiWeeklyViewHeaderTitle(biweeklyOffset: number): string {
   s.setDate(s.getDate() + biweeklyOffset * 14 - s.getDay()); // minus day offset
   const e = new Date(s);
   e.setDate(e.getDate() + 13);
-  const startString = `${s.getMonth() + 1}/${s.getDate()}/${s.getFullYear()}`;
-  const endString = `${e.getMonth() + 1}/${e.getDate()}/${e.getFullYear()}`;
+  const startString = `${s.getMonth() + 1}/${s.getDate()}/${s.getFullYear() % 100}`;
+  const endString = `${e.getMonth() + 1}/${e.getDate()}/${e.getFullYear() % 100}`;
   return `${startString} - ${endString}`;
 }
 

--- a/frontend/src/components/TaskView/FutureView/FutureViewControl.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewControl.tsx
@@ -85,8 +85,9 @@ function NavControl(props: NavControlProps): ReactElement {
   const prevHandler = changeOffset(-1);
   const nextHandler = changeOffset(+1);
   if (containerType === 'N_DAYS') {
-    const prevStyle = { left: -35 };
-    const nextStyle = { right: -35 };
+    const offset = isSmallScreen ? -10 : -35;
+    const prevStyle = { left: offset };
+    const nextStyle = { right: offset };
     return (
       <>
         {futureViewOffset >= 0 && (

--- a/frontend/src/components/TaskView/ProgressTracker/Bear.module.css
+++ b/frontend/src/components/TaskView/ProgressTracker/Bear.module.css
@@ -1,6 +1,6 @@
 .Bear {
-  width: 50px;
-  height: 50px;
-  background-size: 50px auto;
+  width: 48px;
+  height: 48px;
+  background-size: 48px auto;
   margin-left: 1em;
 }

--- a/frontend/src/components/TaskView/ProgressTracker/ProgressIndicator.module.scss
+++ b/frontend/src/components/TaskView/ProgressTracker/ProgressIndicator.module.scss
@@ -5,7 +5,7 @@
   align-content: center;
   align-items: center;
   justify-content: center;
-  margin: 1em;
+  margin: 8px;
   flex: auto;
 }
 
@@ -34,7 +34,7 @@
   bottom: 0;
   left: 0;
   border-radius: 1em;
-  background-color: #7ED321;
+  background-color: #7ed321;
 
   transition: all 0.7s ease-in-out;
 }

--- a/frontend/src/components/TaskView/ProgressTracker/ProgressIndicator.tsx
+++ b/frontend/src/components/TaskView/ProgressTracker/ProgressIndicator.tsx
@@ -39,8 +39,8 @@ export default function ProgressIndicator(
   { completedTasksCount, allTasksCount, inMobileView }: Props,
 ): ReactElement {
   const containerStyle: CSSProperties = inMobileView
-    ? { height: '2em' }
-    : { flexDirection: 'column-reverse', margin: '0', width: '2em' };
+    ? { height: '32px' }
+    : { flexDirection: 'column-reverse', margin: '0', width: '32px' };
   const textStyle: CSSProperties = inMobileView ? {} : { width: '70px', marginBottom: '8px' };
   const fractionString = `${completedTasksCount}/${allTasksCount}`;
   return (

--- a/frontend/src/components/TaskView/ProgressTracker/index.module.css
+++ b/frontend/src/components/TaskView/ProgressTracker/index.module.css
@@ -10,14 +10,10 @@
 .MobileView {
   flex-direction: row;
   margin-top: 16px;
-  transform:translateY(-50px);
 }
 
 .DesktopView {
-  margin-right: 16px;
-  margin-top: 68px;
-  margin-bottom: -82px;
   width: 70px;
+  margin-right: 1em;
   flex-direction: column-reverse;
-  transform:translate(-10px, -35px);
 }

--- a/frontend/src/components/TaskView/index.module.css
+++ b/frontend/src/components/TaskView/index.module.css
@@ -1,6 +1,5 @@
 .TaskView {
-  height: calc(100vh - 152px);
-  padding: 16px 32px;
+  padding: 0 32px;
   display: flex;
   flex-direction: row;
 }

--- a/frontend/src/components/TaskView/index.tsx
+++ b/frontend/src/components/TaskView/index.tsx
@@ -10,7 +10,11 @@ import SamwiseIcon from '../UI/SamwiseIcon';
 
 const FocusPanel = (): ReactElement => <div className={styles.FocusPanel}><FocusView /></div>;
 
-export default function TaskView(): ReactElement {
+const classNames = (...names: readonly string[]): string => names.join(' ');
+
+type Props = { readonly className: string };
+
+export default function TaskView({ className }: Props): ReactElement {
   const [doesShowFocusViewInWideScreen, setDoesShowFocusViewInWideScreen] = useState(true);
   const [doesShowFutureViewInSmallScreen, setDoesShowFutureViewInSmallScreen] = useState(false);
   const [config, setConfig] = useState<FutureViewConfig>(futureViewConfigProvider.initialValue);
@@ -22,7 +26,7 @@ export default function TaskView(): ReactElement {
   const FuturePanel = ({ children }: { readonly children?: ReactNode }): ReactElement => {
     const onChange = (c: FutureViewConfig): void => { setConfig(c); };
     return (
-      <div className={styles.FuturePanel}>
+      <div className={classNames(className, styles.FuturePanel)}>
         <div className={styles.FuturePanelContainer}>
           {children}
           <FutureView config={config} onConfigChange={onChange} />
@@ -38,7 +42,7 @@ export default function TaskView(): ReactElement {
   if (screenIsSmall) {
     const taskView = doesShowFutureViewInSmallScreen
       ? (
-        <div className={styles.TaskView}>
+        <div className={classNames(className, styles.TaskView)}>
           <FuturePanel />
           <SamwiseIcon
             iconName="pin-dark-filled"
@@ -47,7 +51,7 @@ export default function TaskView(): ReactElement {
           />
         </div>
       ) : (
-        <div className={styles.TaskView}>
+        <div className={classNames(className, styles.TaskView)}>
           <FocusPanel />
           <SamwiseIcon
             iconName="calendar-dark"
@@ -89,7 +93,7 @@ export default function TaskView(): ReactElement {
 
   return (
     <>
-      <div className={styles.TaskView}>
+      <div className={classNames(className, styles.TaskView)}>
         <ProgressTracker inMobileView={false} />
         {showFocusView && <FocusPanel />}
         {showFocusView && <div style={{ width: '2em' }} />}

--- a/frontend/src/components/TitleBar/Settings/SettingsButton.module.css
+++ b/frontend/src/components/TitleBar/Settings/SettingsButton.module.css
@@ -1,7 +1,7 @@
 .CloseButton {
   position: absolute;
-  top: 40px;
-  right: 40px;
+  top: 32px;
+  right: 32px;
   color: white;
   font-size: 30px;
 }
@@ -40,7 +40,7 @@
 }
 
 .ContentWrap {
-  padding: 60px 50px;
+  padding: 32px;
 }
 
 .SettingsButton:hover path {

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -33,6 +33,13 @@ body {
   }
 }
 
+#root {
+  display: flex;
+  flex-direction: column;
+  width: 100vw;
+  height: 100vh;
+}
+
 /*******************************
              Reset
 *******************************/

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -22,6 +22,15 @@ body {
   font-size: 14px;
   line-height: 1.4285em;
   overflow: hidden;
+  touch-action: manipulation;
+}
+
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  select,
+  textarea,
+  input {
+    font-size: 12px;
+  }
 }
 
 /*******************************

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -34,10 +34,14 @@ body {
 }
 
 #root {
+  position: fixed;
   display: flex;
   flex-direction: column;
-  width: 100vw;
-  height: 100vh;
+  overflow: hidden;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
 }
 
 /*******************************


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is the first step towards making mobile experience suck less.

- [x] Disable mobile click on input box auto-zoom behavior
- [x] Reduce settings page margin so that mobile view won't be to squeezed.
- [x] Use CSS Flexbox instead of magical margin and transform values to make the layout less likely to break in the future.
- [x] Fix bottom bear not shown bug in mobile safari. See the commit message for the hack.
- [x] Show 2 digit year in 2W nav so that it can be properly displayed on mobile

### Test Plan <!-- Required -->

- iPhone screenshot showing focusing in InputBox is no longer zoomed (although the UX is still terrible)
- The bear is finally back on iOS:
- Better 2W nav

<div>
<img src="https://user-images.githubusercontent.com/4290500/66244690-ae693b80-e6d7-11e9-957c-8289627fbbd6.PNG" width="200px" />
<img src="https://user-images.githubusercontent.com/4290500/66246623-5afcea80-e6e3-11e9-8f6d-44518d4f6783.PNG" width="200px" />
<img src="https://user-images.githubusercontent.com/4290500/66246738-846a4600-e6e4-11e9-8c7c-24162815ede1.PNG" width="200px" />
</div>

### Notes

![stupid-css](https://user-images.githubusercontent.com/4290500/66246744-98ae4300-e6e4-11e9-8f58-0cfb1ef3aea8.gif)