### PR TITLE
No save focus and check

### DIFF
--- a/frontend/src/components/Util/TaskEditors/TaskEditor/MainTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/MainTaskEditor.tsx
@@ -29,7 +29,9 @@ function MainTaskEditor(
   const editName = (event: SyntheticEvent<HTMLInputElement>): void => onChange({
     name: event.currentTarget.value,
   });
-  const replaceDateForFork = getDateWithDateString(taskDate, dateAppeared);
+  const replaceDateForFork = taskDate == null
+    ? getDateWithDateString(taskDate, dateAppeared)
+    : null;
   const editComplete = (): void => editMainTask(id, replaceDateForFork, { complete: !complete });
   const editInFocus = (): void => editMainTask(id, replaceDateForFork, { inFocus: !inFocus });
 

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/MainTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/MainTaskEditor.tsx
@@ -2,6 +2,8 @@ import React, { KeyboardEvent, ReactElement, SyntheticEvent } from 'react';
 import styles from './index.module.css';
 import CheckBox from '../../../UI/CheckBox';
 import SamwiseIcon from '../../../UI/SamwiseIcon';
+import { editMainTask } from '../../../../firebase/actions';
+import { getDateWithDateString } from '../../../../util/datetime-util';
 
 type NameCompleteInFocus = {
   readonly name: string;
@@ -9,6 +11,9 @@ type NameCompleteInFocus = {
   readonly inFocus: boolean;
 };
 type Props = NameCompleteInFocus & {
+  readonly id: string;
+  readonly taskDate: Date | null;
+  readonly dateAppeared: string;
   readonly onChange: (change: Partial<NameCompleteInFocus>) => void;
   readonly onRemove: () => void;
   readonly onPressEnter: (id: 'main-task' | number) => void;
@@ -18,14 +23,15 @@ const deleteIconClass = [styles.TaskEditorIcon, styles.TaskEditorIconLeftPad].jo
 
 function MainTaskEditor(
   {
-    name, complete, inFocus, onChange, onRemove, onPressEnter,
+    id, taskDate, dateAppeared, name, complete, inFocus, onChange, onRemove, onPressEnter,
   }: Props,
 ): ReactElement {
   const editName = (event: SyntheticEvent<HTMLInputElement>): void => onChange({
     name: event.currentTarget.value,
   });
-  const editComplete = (): void => onChange({ complete: !complete });
-  const editInFocus = (): void => onChange({ inFocus: !inFocus });
+  const replaceDateForFork = getDateWithDateString(taskDate, dateAppeared);
+  const editComplete = (): void => editMainTask(id, replaceDateForFork, { complete: !complete });
+  const editInFocus = (): void => editMainTask(id, replaceDateForFork, { inFocus: !inFocus });
 
   const onKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
     if (event.key !== 'Enter') {

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/OneSubTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/OneSubTaskEditor.tsx
@@ -9,13 +9,18 @@ import styles from './index.module.css';
 import CheckBox from '../../../UI/CheckBox';
 import { PartialSubTask, SubTask } from '../../../../store/store-types';
 import SamwiseIcon from '../../../UI/SamwiseIcon';
+import { getDateWithDateString } from '../../../../util/datetime-util';
+import { editSubTask } from '../../../../firebase/actions';
 
 type Props = {
   readonly subTask: SubTask; // the subtask to edit
   readonly mainTaskComplete: boolean; // whether the main task is completed
+  readonly mainTaskId: string;
+  readonly taskDate: Date | null;
+  readonly dateAppeared: string;
   readonly needToBeFocused: boolean; // whether it needs to be focused.
   readonly afterFocusedCallback: () => void; // need to be called once we focused the subtask
-  readonly editSubTask: (subtaskId: string, partialSubTask: PartialSubTask) => void;
+  readonly editThisSubTask: (subtaskId: string, partialSubTask: PartialSubTask) => void;
   readonly removeSubTask: (subtaskId: string) => void;
   readonly onPressEnter: (id: 'main-task' | number) => void;
 };
@@ -27,18 +32,28 @@ function OneSubTaskEditor(
   {
     subTask,
     mainTaskComplete,
+    mainTaskId,
+    taskDate,
+    dateAppeared,
     needToBeFocused,
     afterFocusedCallback,
-    editSubTask,
+    editThisSubTask,
     removeSubTask,
     onPressEnter,
   }: Props,
 ): ReactElement {
   const onNameChange = (event: SyntheticEvent<HTMLInputElement>): void => {
-    editSubTask(subTask.id, { name: event.currentTarget.value });
+    editThisSubTask(subTask.id, { name: event.currentTarget.value });
   };
-  const onCompleteChange = (): void => editSubTask(subTask.id, { complete: !subTask.complete });
-  const onInFocusChange = (): void => editSubTask(subTask.id, { inFocus: !subTask.inFocus });
+  const replaceDateForFork = taskDate == null
+    ? getDateWithDateString(taskDate, dateAppeared)
+    : null;
+  const onCompleteChange = (): void => editSubTask(
+    mainTaskId, subTask.id, replaceDateForFork, { complete: !subTask.complete },
+  );
+  const onInFocusChange = (): void => editSubTask(
+    mainTaskId, subTask.id, replaceDateForFork, { inFocus: !subTask.inFocus },
+  );
   const onRemove = (): void => removeSubTask(subTask.id);
 
   const onKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -225,10 +225,13 @@ function TaskEditor(
           <OneSubTaskEditor
             key={subTask.id}
             subTask={subTask}
+            mainTaskId={id}
+            taskDate={date instanceof Date ? date : null}
+            dateAppeared={taskAppearedDate}
             mainTaskComplete={complete}
             needToBeFocused={subTaskToFocus === subTask.order}
             afterFocusedCallback={clearNeedToFocus}
-            editSubTask={dispatchEditSubTask}
+            editThisSubTask={dispatchEditSubTask}
             removeSubTask={dispatchDeleteSubTask}
             onPressEnter={pressEnterHandler}
           />

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -178,7 +178,9 @@ function TaskEditor(
     }
   };
   const clearNeedToFocus = (): void => setSubTaskToFocus(null);
-
+  if (taskAppearedDate === null) {
+    throw new Error('Impossible');
+  }
   const isOverdue = date < getTodayAtZeroAM() && !complete;
   const backgroundColor = getTag(tag).color;
   const formStyle = isOverdue
@@ -207,6 +209,9 @@ function TaskEditor(
           displayGrabber={displayGrabber == null ? false : displayGrabber}
         />
         <MainTaskEditor
+          id={id}
+          taskDate={date instanceof Date ? date : null}
+          dateAppeared={taskAppearedDate}
           name={name}
           complete={complete}
           inFocus={inFocus}


### PR DESCRIPTION
### Summary <!-- Required -->
Got rid of save prompt for checking and focusing a task in focus view. 
Also added this functionality for subtasks in focus view.

This pull request is the first step towards launching repeating task

- [x] implemented Make complete and focus in TaskEditor not go through save
- [ ] fixed Y

### Test Plan <!-- Required -->

Create a repeating task with subtasks. Make it focused. From focus view, mark the task as complete. Ensure that this task is also marked as completed in future view and that you are not prompted to save for this change. Do the same for marking subtasks of this repeated task as complete. Repeat with focusing/pinning this task from focus view.

