### PR TITLE
Remove Focus Scrollbar

### DIFF
--- a/frontend/src/components/TaskView/FocusView/index.module.css
+++ b/frontend/src/components/TaskView/FocusView/index.module.css
@@ -6,7 +6,7 @@
   display: flex;
   flex-direction: column;
   height: calc(100% - 54px);
-  overflow-y: scroll;
+  overflow-y: auto;
   overflow-x: hidden;
 }
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

Removed the ugly scrollbar in the focus view.

- [x] Made the overflow auto, not scroll, to hide the scrollbar when unneeded

### Test Plan <!-- Required -->

Scrollbar is gone when unneeded: 

![image](https://user-images.githubusercontent.com/6147405/66275662-e21f9f00-e858-11e9-8bd4-ccb23fd4fccd.png)

But comes back when it is:

![image](https://user-images.githubusercontent.com/6147405/66275665-e6e45300-e858-11e9-8785-9e4552d24a70.png)

Also tested on mobile preview via dev console; looks fine.