### PR TITLE
Fix overlapping ColorPicker with class name on mobile settings page

### DIFF
--- a/frontend/src/components/TitleBar/Tags/ColorEditor.module.css
+++ b/frontend/src/components/TitleBar/Tags/ColorEditor.module.css
@@ -23,6 +23,7 @@
   text-transform: capitalize;
 }
 
+
 .ColorDisplay {
   display: block;
   position: absolute;
@@ -42,6 +43,6 @@
 
 .ColorPicker {
   position: absolute !important;
-  right: 59px !important;
+  right: 59px;
   z-index: 3;
 }

--- a/frontend/src/components/TitleBar/Tags/ColorEditor.module.css
+++ b/frontend/src/components/TitleBar/Tags/ColorEditor.module.css
@@ -1,3 +1,22 @@
+@media (max-width: 500px) {
+  .ColorEdit {
+  
+    width: 54px !important;
+    font-size: 0px !important;
+    float: right;
+    position: absolute !important;
+    right: 70px !important;
+  }
+  
+  .ColorPicker {
+    position: absolute !important;
+    right: 79px !important;
+    top: 50px !important;
+    z-index: 3;
+
+  }
+}
+
 .ColorEdit {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/components/TitleBar/Tags/ColorEditor.module.css
+++ b/frontend/src/components/TitleBar/Tags/ColorEditor.module.css
@@ -2,18 +2,17 @@
   .ColorEdit {
   
     width: 54px !important;
-    font-size: 0px !important;
+    font-size: 0 !important;
     float: right;
-    position: absolute !important;
-    right: 70px !important;
+    position: absolute;
+    right: 70px;
   }
   
   .ColorPicker {
-    position: absolute !important;
+    position: absolute;
     right: 79px !important;
-    top: 50px !important;
+    top: 50px;
     z-index: 3;
-
   }
 }
 

--- a/frontend/src/components/TitleBar/Tags/TagItem.module.css
+++ b/frontend/src/components/TitleBar/Tags/TagItem.module.css
@@ -1,3 +1,10 @@
+@media (max-width: 500px) {
+  .DeleteTag {
+    position: absolute;
+    right: 5px;
+    float: right !important;
+  }
+}
 .ColorConfigItem {
   position: relative;
   width: 100%;
@@ -26,7 +33,7 @@
 
 .DeleteTag:hover,
 .DeleteTag:focus {
-  opacity: 0.85;
+  opacity: 0.50;
   stroke-width: 3px;
 }
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->
The code added in this PR changes the UI in screen widths below 500px, by removing the name of the color in order to condense the ColorPicker dropdown width. This fixes the overlapping text at small phone screen widths.

This pull request resolves issue #304.


### Test Plan <!-- Required -->

![az1QLhj](https://user-images.githubusercontent.com/7517829/66289471-cc3aca00-e8aa-11e9-983b-2df84afe20c0.png)


