### PR TITLE
Fix misleading/default tooltip values

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.14.3",
     "firebase-tools": "^7.4.0",
+    "jest": "^24.9.0",
     "node-sass": "^4.12.0",
     "react-scripts": "^3.1.2",
     "svgo": "^1.3.0",

--- a/frontend/src/components/TitleBar/Settings/SettingsButton.tsx
+++ b/frontend/src/components/TitleBar/Settings/SettingsButton.tsx
@@ -17,7 +17,7 @@ export default function SettingsButton(): ReactElement {
       {showSettings && (
         <div className={styles.SettingsModal}>
           <button className={styles.CloseButton} type="submit" title="Close Settings" onClick={closeModal} tabIndex={-1}>
-            <SamwiseIcon iconName="x-light-settings"/>
+            <SamwiseIcon iconName="x-light-settings" />
           </button>
           <section className={styles.ContentWrap}>
             <h2>Settings</h2>

--- a/frontend/src/components/TitleBar/Settings/SettingsButton.tsx
+++ b/frontend/src/components/TitleBar/Settings/SettingsButton.tsx
@@ -17,7 +17,7 @@ export default function SettingsButton(): ReactElement {
       {showSettings && (
         <div className={styles.SettingsModal}>
           <button className={styles.CloseButton} type="submit" title="Close Settings" onClick={closeModal} tabIndex={-1}>
-            <SamwiseIcon iconName="x-light" />
+            <SamwiseIcon iconName="x-light-settings"/>
           </button>
           <section className={styles.ContentWrap}>
             <h2>Settings</h2>

--- a/frontend/src/components/TitleBar/Settings/__snapshots__/SettingsButton.test.tsx.snap
+++ b/frontend/src/components/TitleBar/Settings/__snapshots__/SettingsButton.test.tsx.snap
@@ -21,14 +21,14 @@ exports[`SettingsButton matches snapshot. 1`] = `
       title="Settings Button"
     >
       <span
-        title="settings"
+        title="Settings"
       >
         <svg
-          alt="settings"
+          alt="Settings"
           height="1em"
           onKeyUp={[Function]}
           tabIndex={0}
-          title="settings"
+          title="Settings"
           width="1em"
         >
           settings.svg

--- a/frontend/src/components/TitleBar/Settings/__snapshots__/SettingsPage.test.tsx.snap
+++ b/frontend/src/components/TitleBar/Settings/__snapshots__/SettingsPage.test.tsx.snap
@@ -146,15 +146,15 @@ exports[`SettingsPage matches snapshot. 1`] = `
               }
             />
             <span
-              title="dropdown"
+              title="More"
             >
               <svg
-                alt="dropdown"
+                alt="More"
                 className="Arrow"
                 height="1em"
                 onKeyUp={[Function]}
                 tabIndex={0}
-                title="dropdown"
+                title="More"
                 width="1em"
               >
                 v.svg
@@ -168,14 +168,14 @@ exports[`SettingsPage matches snapshot. 1`] = `
             type="button"
           >
             <span
-              title="delete"
+              title="Delete"
             >
               <svg
-                alt="delete"
+                alt="Delete"
                 height="1em"
                 onKeyUp={[Function]}
                 tabIndex={0}
-                title="delete"
+                title="Delete"
                 width="1em"
               >
                 XLight.svg
@@ -256,15 +256,15 @@ exports[`SettingsPage matches snapshot. 1`] = `
               }
             />
             <span
-              title="dropdown"
+              title="More"
             >
               <svg
-                alt="dropdown"
+                alt="More"
                 className="Arrow"
                 height="1em"
                 onKeyUp={[Function]}
                 tabIndex={0}
-                title="dropdown"
+                title="More"
                 width="1em"
               >
                 v.svg
@@ -278,14 +278,14 @@ exports[`SettingsPage matches snapshot. 1`] = `
             type="button"
           >
             <span
-              title="delete"
+              title="Delete"
             >
               <svg
-                alt="delete"
+                alt="Delete"
                 height="1em"
                 onKeyUp={[Function]}
                 tabIndex={0}
-                title="delete"
+                title="Delete"
                 width="1em"
               >
                 XLight.svg
@@ -320,15 +320,15 @@ exports[`SettingsPage matches snapshot. 1`] = `
               }
             />
             <span
-              title="dropdown"
+              title="More"
             >
               <svg
-                alt="dropdown"
+                alt="More"
                 className="Arrow"
                 height="1em"
                 onKeyUp={[Function]}
                 tabIndex={0}
-                title="dropdown"
+                title="More"
                 width="1em"
               >
                 v.svg

--- a/frontend/src/components/TitleBar/Tags/__snapshots__/ColorEditor.test.tsx.snap
+++ b/frontend/src/components/TitleBar/Tags/__snapshots__/ColorEditor.test.tsx.snap
@@ -16,15 +16,15 @@ exports[`ColorEditor matches snapshot. 1`] = `
     }
   />
   <span
-    title="dropdown"
+    title="More"
   >
     <svg
-      alt="dropdown"
+      alt="More"
       className="Arrow"
       height="1em"
       onKeyUp={[Function]}
       tabIndex={0}
-      title="dropdown"
+      title="More"
       width="1em"
     >
       v.svg

--- a/frontend/src/components/TitleBar/Tags/__snapshots__/OtherTagAdder.test.tsx.snap
+++ b/frontend/src/components/TitleBar/Tags/__snapshots__/OtherTagAdder.test.tsx.snap
@@ -28,15 +28,15 @@ exports[`OtherTagAdder matches snapshot. 1`] = `
       }
     />
     <span
-      title="dropdown"
+      title="More"
     >
       <svg
-        alt="dropdown"
+        alt="More"
         className="Arrow"
         height="1em"
         onKeyUp={[Function]}
         tabIndex={0}
-        title="dropdown"
+        title="More"
         width="1em"
       >
         v.svg

--- a/frontend/src/components/TitleBar/Tags/__snapshots__/TagItem.test.tsx.snap
+++ b/frontend/src/components/TitleBar/Tags/__snapshots__/TagItem.test.tsx.snap
@@ -38,15 +38,15 @@ exports[`TagItem with class matches snapshot. 1`] = `
       }
     />
     <span
-      title="dropdown"
+      title="More"
     >
       <svg
-        alt="dropdown"
+        alt="More"
         className="Arrow"
         height="1em"
         onKeyUp={[Function]}
         tabIndex={0}
-        title="dropdown"
+        title="More"
         width="1em"
       >
         v.svg
@@ -60,14 +60,14 @@ exports[`TagItem with class matches snapshot. 1`] = `
     type="button"
   >
     <span
-      title="delete"
+      title="Delete"
     >
       <svg
-        alt="delete"
+        alt="Delete"
         height="1em"
         onKeyUp={[Function]}
         tabIndex={0}
-        title="delete"
+        title="Delete"
         width="1em"
       >
         XLight.svg
@@ -111,15 +111,15 @@ exports[`TagItem without class matches snapshot. 1`] = `
       }
     />
     <span
-      title="dropdown"
+      title="More"
     >
       <svg
-        alt="dropdown"
+        alt="More"
         className="Arrow"
         height="1em"
         onKeyUp={[Function]}
         tabIndex={0}
-        title="dropdown"
+        title="More"
         width="1em"
       >
         v.svg
@@ -133,14 +133,14 @@ exports[`TagItem without class matches snapshot. 1`] = `
     type="button"
   >
     <span
-      title="delete"
+      title="Delete"
     >
       <svg
-        alt="delete"
+        alt="Delete"
         height="1em"
         onKeyUp={[Function]}
         tabIndex={0}
-        title="delete"
+        title="Delete"
         width="1em"
       >
         XLight.svg

--- a/frontend/src/components/UI/SamwiseIcon.tsx
+++ b/frontend/src/components/UI/SamwiseIcon.tsx
@@ -46,19 +46,19 @@ const SamwiseIcon = ({ iconName, title, ...otherProps }: Props): ReactElement =>
       break;
     case 'calendar-dark':
       SvgComponent = CalendarDark;
-      altText = 'calendar';
+      altText = 'Due date';
       break;
     case 'calendar-light':
       SvgComponent = CalendarLight;
-      altText = 'calendar';
+      altText = 'Due date';
       break;
     case 'checked-dark':
       SvgComponent = CheckedDark;
-      altText = 'checked';
+      altText = 'Checked';
       break;
     case 'checked-light':
       SvgComponent = CheckedLight;
-      altText = 'checked';
+      altText = 'Checked';
       break;
     case 'clock':
       SvgComponent = Clock;
@@ -66,39 +66,39 @@ const SamwiseIcon = ({ iconName, title, ...otherProps }: Props): ReactElement =>
       break;
     case 'grabber':
       SvgComponent = Grabber;
-      altText = 'grabber';
+      altText = 'Reorder';
       break;
     case 'hide':
       SvgComponent = Hide;
-      altText = 'hide';
+      altText = 'Hide';
       break;
     case 'pin-dark-filled':
       SvgComponent = PinDarkFilled;
-      altText = 'pin-filled';
+      altText = 'Unpin from Focus';
       break;
     case 'pin-dark-outline':
       SvgComponent = PinDarkOutline;
-      altText = 'pin-outline';
+      altText = 'Pin to Focus';
       break;
     case 'pin-light-filled':
       SvgComponent = PinLightFilled;
-      altText = 'pin-filled';
+      altText = 'Unpin from Focus';
       break;
     case 'pin-light-outline':
       SvgComponent = PinLightOutline;
-      altText = 'pin-outline';
+      altText = 'Pin to Focus';
       break;
     case 'settings':
       SvgComponent = Settings;
-      altText = 'settings';
+      altText = 'Settings';
       break;
     case 'show':
       SvgComponent = Show;
-      altText = 'hide';
+      altText = 'Show';
       break;
     case 'tag':
       SvgComponent = Tag;
-      altText = 'tag';
+      altText = 'Tag';
       break;
     case 'unchecked':
       SvgComponent = Unchecked;
@@ -106,15 +106,19 @@ const SamwiseIcon = ({ iconName, title, ...otherProps }: Props): ReactElement =>
       break;
     case 'dropdown':
       SvgComponent = DropDown;
-      altText = 'dropdown';
+      altText = 'More';
       break;
     case 'x-dark':
       SvgComponent = XDark;
-      altText = 'delete';
+      altText = 'Delete';
       break;
     case 'x-light':
       SvgComponent = XLight;
-      altText = 'delete';
+      altText = 'Delete';
+      break;
+    case 'x-light-settings':
+      SvgComponent = XLight;
+      altText = 'Close Settings';
       break;
     default:
       throw new Error(`Unrecognized icon name: ${iconName}`);

--- a/frontend/src/components/UI/SquareIconToggle.tsx
+++ b/frontend/src/components/UI/SquareIconToggle.tsx
@@ -24,7 +24,7 @@ export default function SquareIconToggle({ active, iconNames, onToggle }: Props)
     ? `${styles.SquareButton} ${styles.SquareButtonIconButton}`
     : `${styles.SquareButton} ${styles.SquareButtonIconButton} ${styles.active}`;
   return (
-    <button className={className} title="eye" type="button" onClick={onToggle}>
+    <button className={className} title="Hide/unhide completed tasks" type="button" onClick={onToggle}>
       <Icon
         className={styles.SquareButtonText}
         icon={active ? activeIconName : inactiveIconName}

--- a/frontend/src/components/UI/__snapshots__/SamwiseIcon.test.tsx.snap
+++ b/frontend/src/components/UI/__snapshots__/SamwiseIcon.test.tsx.snap
@@ -19,14 +19,14 @@ exports[`SamwiseIcon matches snapshot. 1`] = `
 
 exports[`SamwiseIcon matches snapshot. 2`] = `
 <span
-  title="calendar"
+  title="Due date"
 >
   <svg
-    alt="calendar"
+    alt="Due date"
     height="1em"
     onKeyUp={[Function]}
     tabIndex={0}
-    title="calendar"
+    title="Due date"
     width="1em"
   >
     calendar-dark.svg
@@ -36,14 +36,14 @@ exports[`SamwiseIcon matches snapshot. 2`] = `
 
 exports[`SamwiseIcon matches snapshot. 3`] = `
 <span
-  title="calendar"
+  title="Due date"
 >
   <svg
-    alt="calendar"
+    alt="Due date"
     height="1em"
     onKeyUp={[Function]}
     tabIndex={0}
-    title="calendar"
+    title="Due date"
     width="1em"
   >
     calendar-light.svg
@@ -53,14 +53,14 @@ exports[`SamwiseIcon matches snapshot. 3`] = `
 
 exports[`SamwiseIcon matches snapshot. 4`] = `
 <span
-  title="checked"
+  title="Checked"
 >
   <svg
-    alt="checked"
+    alt="Checked"
     height="1em"
     onKeyUp={[Function]}
     tabIndex={0}
-    title="checked"
+    title="Checked"
     width="1em"
   >
     checked-dark.svg
@@ -70,14 +70,14 @@ exports[`SamwiseIcon matches snapshot. 4`] = `
 
 exports[`SamwiseIcon matches snapshot. 5`] = `
 <span
-  title="checked"
+  title="Checked"
 >
   <svg
-    alt="checked"
+    alt="Checked"
     height="1em"
     onKeyUp={[Function]}
     tabIndex={0}
-    title="checked"
+    title="Checked"
     width="1em"
   >
     checked.svg
@@ -104,14 +104,14 @@ exports[`SamwiseIcon matches snapshot. 6`] = `
 
 exports[`SamwiseIcon matches snapshot. 7`] = `
 <span
-  title="grabber"
+  title="Reorder"
 >
   <svg
-    alt="grabber"
+    alt="Reorder"
     height="1em"
     onKeyUp={[Function]}
     tabIndex={0}
-    title="grabber"
+    title="Reorder"
     width="1em"
   >
     grabbers.svg
@@ -121,14 +121,14 @@ exports[`SamwiseIcon matches snapshot. 7`] = `
 
 exports[`SamwiseIcon matches snapshot. 8`] = `
 <span
-  title="hide"
+  title="Hide"
 >
   <svg
-    alt="hide"
+    alt="Hide"
     height="1em"
     onKeyUp={[Function]}
     tabIndex={0}
-    title="hide"
+    title="Hide"
     width="1em"
   >
     hide.svg
@@ -138,14 +138,14 @@ exports[`SamwiseIcon matches snapshot. 8`] = `
 
 exports[`SamwiseIcon matches snapshot. 9`] = `
 <span
-  title="pin-filled"
+  title="Unpin from Focus"
 >
   <svg
-    alt="pin-filled"
+    alt="Unpin from Focus"
     height="1em"
     onKeyUp={[Function]}
     tabIndex={0}
-    title="pin-filled"
+    title="Unpin from Focus"
     width="1em"
   >
     pin-2-dark-filled.svg
@@ -155,14 +155,14 @@ exports[`SamwiseIcon matches snapshot. 9`] = `
 
 exports[`SamwiseIcon matches snapshot. 10`] = `
 <span
-  title="pin-outline"
+  title="Pin to Focus"
 >
   <svg
-    alt="pin-outline"
+    alt="Pin to Focus"
     height="1em"
     onKeyUp={[Function]}
     tabIndex={0}
-    title="pin-outline"
+    title="Pin to Focus"
     width="1em"
   >
     pin-2-dark-outline.svg
@@ -172,14 +172,14 @@ exports[`SamwiseIcon matches snapshot. 10`] = `
 
 exports[`SamwiseIcon matches snapshot. 11`] = `
 <span
-  title="pin-filled"
+  title="Unpin from Focus"
 >
   <svg
-    alt="pin-filled"
+    alt="Unpin from Focus"
     height="1em"
     onKeyUp={[Function]}
     tabIndex={0}
-    title="pin-filled"
+    title="Unpin from Focus"
     width="1em"
   >
     pin-2-light-filled.svg
@@ -189,14 +189,14 @@ exports[`SamwiseIcon matches snapshot. 11`] = `
 
 exports[`SamwiseIcon matches snapshot. 12`] = `
 <span
-  title="pin-outline"
+  title="Pin to Focus"
 >
   <svg
-    alt="pin-outline"
+    alt="Pin to Focus"
     height="1em"
     onKeyUp={[Function]}
     tabIndex={0}
-    title="pin-outline"
+    title="Pin to Focus"
     width="1em"
   >
     pin-2-light-outline.svg
@@ -206,14 +206,14 @@ exports[`SamwiseIcon matches snapshot. 12`] = `
 
 exports[`SamwiseIcon matches snapshot. 13`] = `
 <span
-  title="settings"
+  title="Settings"
 >
   <svg
-    alt="settings"
+    alt="Settings"
     height="1em"
     onKeyUp={[Function]}
     tabIndex={0}
-    title="settings"
+    title="Settings"
     width="1em"
   >
     settings.svg
@@ -223,14 +223,14 @@ exports[`SamwiseIcon matches snapshot. 13`] = `
 
 exports[`SamwiseIcon matches snapshot. 14`] = `
 <span
-  title="hide"
+  title="Show"
 >
   <svg
-    alt="hide"
+    alt="Show"
     height="1em"
     onKeyUp={[Function]}
     tabIndex={0}
-    title="hide"
+    title="Show"
     width="1em"
   >
     show.svg
@@ -240,14 +240,14 @@ exports[`SamwiseIcon matches snapshot. 14`] = `
 
 exports[`SamwiseIcon matches snapshot. 15`] = `
 <span
-  title="tag"
+  title="Tag"
 >
   <svg
-    alt="tag"
+    alt="Tag"
     height="1em"
     onKeyUp={[Function]}
     tabIndex={0}
-    title="tag"
+    title="Tag"
     width="1em"
   >
     tag.svg
@@ -274,14 +274,14 @@ exports[`SamwiseIcon matches snapshot. 16`] = `
 
 exports[`SamwiseIcon matches snapshot. 17`] = `
 <span
-  title="dropdown"
+  title="More"
 >
   <svg
-    alt="dropdown"
+    alt="More"
     height="1em"
     onKeyUp={[Function]}
     tabIndex={0}
-    title="dropdown"
+    title="More"
     width="1em"
   >
     v.svg
@@ -291,14 +291,14 @@ exports[`SamwiseIcon matches snapshot. 17`] = `
 
 exports[`SamwiseIcon matches snapshot. 18`] = `
 <span
-  title="delete"
+  title="Delete"
 >
   <svg
-    alt="delete"
+    alt="Delete"
     height="1em"
     onKeyUp={[Function]}
     tabIndex={0}
-    title="delete"
+    title="Delete"
     width="1em"
   >
     XDark.svg
@@ -308,14 +308,14 @@ exports[`SamwiseIcon matches snapshot. 18`] = `
 
 exports[`SamwiseIcon matches snapshot. 19`] = `
 <span
-  title="delete"
+  title="Delete"
 >
   <svg
-    alt="delete"
+    alt="Delete"
     height="1em"
     onKeyUp={[Function]}
     tabIndex={0}
-    title="delete"
+    title="Delete"
     width="1em"
   >
     XLight.svg

--- a/frontend/src/components/UI/samwise-icon-types.tsx
+++ b/frontend/src/components/UI/samwise-icon-types.tsx
@@ -18,4 +18,5 @@ export type IconName =
   | 'unchecked'
   | 'dropdown'
   | 'x-dark'
-  | 'x-light';
+  | 'x-light'
+  | 'x-light-settings';

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7023,7 +7023,7 @@ jest-worker@^24.6.0, jest-worker@^24.9.0:
     merge-stream "^2.0.0"
     supports-color "^6.1.0"
 
-jest@24.9.0:
+jest@24.9.0, jest@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-24.9.0.tgz#987d290c05a08b52c56188c1002e368edb007171"
   integrity sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request adds more descriptive and user-friendly tooltip alt texts (as well as a new icon type to describe the Close Settings button as it is the same as the delete 'x' buttons).


### Screenshots of fixes <!-- Required -->
![image](https://user-images.githubusercontent.com/7517829/66420314-a65d1480-e9d3-11e9-9a96-94ba32e859a3.png)
![image](https://user-images.githubusercontent.com/7517829/66420353-b5dc5d80-e9d3-11e9-973b-3e3f6d93b2c8.png)
![image](https://user-images.githubusercontent.com/7517829/66420386-c260b600-e9d3-11e9-9b9c-b1620a7211d9.png)
![image](https://user-images.githubusercontent.com/7517829/66420392-c7256a00-e9d3-11e9-81d8-eaf9f0bb703e.png)
![image](https://user-images.githubusercontent.com/7517829/66420410-d0163b80-e9d3-11e9-8f10-cb1dfffdcbdd.png)
![image](https://user-images.githubusercontent.com/7517829/66420438-ddcbc100-e9d3-11e9-8410-322a01c1d43a.png)
![image](https://user-images.githubusercontent.com/7517829/66420454-e2907500-e9d3-11e9-8ec3-6d400439b006.png)
![image](https://user-images.githubusercontent.com/7517829/66420504-f8059f00-e9d3-11e9-82b2-cf73038f6feb.png)



<!-- Provide screenshots or point out the additional unit tests -->

