### PR TITLE
Fix deployment workflow

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -6,14 +6,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Print refs
+      - name: Print base ref and head ref
         run: |
           echo "Your base ref is ${{ github.base_ref }}."
-          echo "Your ref is ${{ github.ref }}."
+          echo "Your head ref is ${{ github.head_ref }}."
       - name: Fail if try to push release from non-master branch
-        if: github.base_ref != 'ref/head/master' && github.ref == 'ref/head/release'
+        if: github.base_ref != 'master' && github.head_ref == 'release'
         run: |
-          echo "Base ref must be master. Everything should go through staging first!"
+          echo "Base ref must be master for release. Everything should go through staging first!"
           exit 1
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -8,12 +8,12 @@ jobs:
       - uses: actions/checkout@master
       - name: Print base ref and head ref
         run: |
-          echo "Your base ref is ${{ github.base_ref }}."
           echo "Your head ref is ${{ github.head_ref }}."
+          echo "Your base ref is ${{ github.base_ref }}."
       - name: Fail if try to push release from non-master branch
-        if: github.base_ref != 'master' && github.head_ref == 'release'
+        if: github.base_ref != 'release' && github.head_ref == 'master'
         run: |
-          echo "Base ref must be master for release. Everything should go through staging first!"
+          echo "Head ref must be master for release. Everything should go through staging first!"
           exit 1
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -6,12 +6,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - name: Print refs
+        run: |
+          echo "Your base ref is ${{ github.base_ref }}."
+          echo "Your ref is ${{ github.ref }}."
       - name: Fail if try to push release from non-master branch
         if: github.base_ref != 'ref/head/master' && github.ref == 'ref/head/release'
         run: |
           echo "Base ref must be master. Everything should go through staging first!"
-          echo "Your base ref is ${{ github.base_ref }}."
-          echo "Your ref is ${{ github.ref }}."
           exit 1
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -2,6 +2,17 @@ name: CI
 on: pull_request
 
 jobs:
+  enforce-release-workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Fail if try to push release from non-master branch
+        if: github.base_ref != 'ref/head/master' && github.ref == 'ref/head/release'
+        run: |
+          echo "Base ref must be master. Everything should go through staging first!"
+          echo "Your base ref is ${{ github.base_ref }}."
+          echo "Your ref is ${{ github.ref }}."
+          exit 1
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -5,19 +5,8 @@ on:
       - release
 
 jobs:
-  check-base-ref:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - name: Fail if base-ref is not master
-        if: github.ref != 'ref/head/master'
-        run: |
-          echo "Base ref must be master. Everything should go through staging first!"
-          echo "Your base ref is ${{ github.ref }}."
-          exit 1
   deploy:
     runs-on: ubuntu-latest
-    needs: check-base-ref
     steps:
       - uses: actions/checkout@master
       - name: Set up Node


### PR DESCRIPTION
### Summary <!-- Required -->

Move the enforcement of `master -> release` workflow to the pull request CI job.

### Test Plan <!-- Required -->

See CI log for the enforcement workflow.
Unfortunately, the release job can still only be tested during release.

### Notes

Relevant Docs:
https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions