### PR TITLE
Fix deployment workflow

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -2,6 +2,19 @@ name: CI
 on: pull_request
 
 jobs:
+  enforce-release-workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Print base ref and head ref
+        run: |
+          echo "Your head ref is ${{ github.head_ref }}."
+          echo "Your base ref is ${{ github.base_ref }}."
+      - name: Fail if try to push release from non-master branch
+        if: github.base_ref != 'release' && github.head_ref == 'master'
+        run: |
+          echo "Head ref must be master for release. Everything should go through staging first!"
+          exit 1
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -5,19 +5,8 @@ on:
       - release
 
 jobs:
-  check-base-ref:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - name: Fail if base-ref is not master
-        if: github.ref != 'ref/head/master'
-        run: |
-          echo "Base ref must be master. Everything should go through staging first!"
-          echo "Your base ref is ${{ github.ref }}."
-          exit 1
   deploy:
     runs-on: ubuntu-latest
-    needs: check-base-ref
     steps:
       - uses: actions/checkout@master
       - name: Set up Node


### PR DESCRIPTION
* [release] Do not check github.ref in release

The original workflow is only tested in pull request context where `github.ref == 'ref/head/master'`. Hopefully we can still find a way to enforce the `master -> release` workflow but let's unblock the deploymennt first.

* [release] Enforce master -> release workflow

Trying to do the check in pull request workflow

* [ci] Always unconditionally print refs to help test the workflow

* [ci] Use head_ref instead of ref

* [ci] Flip base_ref and head_ref

### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

Unblock deployment

### Test Plan <!-- Required -->

Hope