### PR TITLE
[editor][misc] Hide lastpass form fill overlay

### DIFF
--- a/frontend/src/components/Util/TaskEditors/TaskEditor/MainTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/MainTaskEditor.tsx
@@ -50,6 +50,8 @@ function MainTaskEditor(
         onChange={editComplete}
       />
       <input
+        type="text"
+        data-lpignore="true"
         className={styles.TaskEditorFlexibleInput}
         placeholder="Main Task"
         value={name}

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/NewSubTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/NewSubTaskEditor.tsx
@@ -41,6 +41,8 @@ export default function NewSubTaskEditor(
   return (
     <div className={styles.TaskEditorFlexibleContainer}>
       <input
+        type="text"
+        data-lpignore="true"
         ref={editorRef}
         className={styles.TaskEditorFlexibleInput}
         placeholder="Add a Subtask"

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/OneSubTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/OneSubTaskEditor.tsx
@@ -84,6 +84,8 @@ function OneSubTaskEditor(
         onChange={onCompleteChange}
       />
       <input
+        type="text"
+        data-lpignore="true"
         className={styles.TaskEditorFlexibleInput}
         placeholder="Your Subtask"
         value={subTask.name}


### PR DESCRIPTION
### Summary <!-- Required -->

This lastpass overlay is very annoying! Add new props to disable it according to https://stackoverflow.com/questions/50145270/hide-last-pass-icon-in-input-fields

### Test Plan <!-- Required -->

Before:
<img width="380" alt="Screen Shot 2019-10-08 at 16 43 07" src="https://user-images.githubusercontent.com/4290500/66431820-bb916d80-e9ea-11e9-9149-47e0af00dea4.png">

After:
<img width="374" alt="Screen Shot 2019-10-08 at 16 43 11" src="https://user-images.githubusercontent.com/4290500/66431829-bd5b3100-e9ea-11e9-826b-e2d68b4f2c2a.png">