### PR TITLE
[ci] Fix cleanup workflow

### DIFF
--- a/.github/workflows/cleanup-workflow.yml
+++ b/.github/workflows/cleanup-workflow.yml
@@ -1,17 +1,17 @@
 name: Cleanup
-on: pull_request
+on:
+  pull_request:
+    types: [closed]
 
 jobs:
   clean-up:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages Branch
-        if: github.event.state == 'closed'
         uses: actions/checkout@master
         with:
           ref: gh-pages
       - name: Purge Static Assets
-        if: github.event.state == 'closed'
         env:
           ACCESS_TOKEN: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
         run: |


### PR DESCRIPTION
### Summary

The cleanup workflow doesn't actually cleanup. Try to fix it according to: https://github.community/t5/GitHub-Actions/Running-a-job-on-pull-request-merge-in-specific-branch/m-p/34192#M1829

### Test Plan

I will close the PR to see what happens.

After I closed the PR, this job is indeed triggered:
https://github.com/cornell-dti/samwise/commit/64cc4b50b014512871ff7266c28895296394e94e/checks?check_suite_id=258206304
Before close bot commit:
https://github.com/cornell-dti/samwise/commit/1e8282ca923de096f6e50ccb1a549c66c227f807
After close bot commit:
https://github.com/cornell-dti/samwise/commit/d99891f911a5338f27562a033e92db2d96066c9c