### PR TITLE
[misc] Fix weird indentation in firestore.rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,6 +1,6 @@
 service cloud.firestore {
   match /databases/{database}/documents {
-  	function canCreate() {
+    function canCreate() {
     	return request.resource.data.owner == request.auth.token.email;
     }
     function canReadWriteDelete() {


### PR DESCRIPTION
### Summary

The changed line appears to have a mix of tabs and space before 🤔. Not sure what happened. Now unifying it to 2-space to be consistent with the rest of the codebase.

### Test Plan

eyes