### PR TITLE
Last Day of Class button gets its style

### DIFF
--- a/frontend/src/components/TaskCreator/DatePicker.tsx
+++ b/frontend/src/components/TaskCreator/DatePicker.tsx
@@ -245,7 +245,7 @@ export default function DatePicker(props: Props): ReactElement {
               onChange={handleSetRepeatEndDate}
               calendarType="US"
             />
-            <p>
+            <p className={styles.RepeatSpecialEndDate}>
               <button type="button" onClick={() => testSetEndSem(LAST_DAY_OF_CLASS)}>
                 Last Day of Class (
                 {LAST_DAY_OF_CLASS.toLocaleDateString()}

--- a/frontend/src/components/TaskCreator/Picker.module.css
+++ b/frontend/src/components/TaskCreator/Picker.module.css
@@ -240,3 +240,22 @@
 .RepeatPickEndWrap input[type="radio"]{
   margin-right:5px;
 }
+
+.RepeatSpecialEndDate{
+  padding:0;
+  text-align:left;
+}
+
+.RepeatSpecialEndDate button{
+  padding-top: 3px;
+  padding-bottom: 3px;
+  margin-top:3px;
+  background:none;
+  border-radius:3px;
+  border:none;
+  cursor:pointer;
+  border: 1.2px #5a5a5a solid;
+  color:#5a5a5a;
+  text-align:center;
+  font-weight: normal;
+ }


### PR DESCRIPTION
# Summary <!-- Required -->
- [x] fixed #305 

Added CSS class "RepeatSpecialEndDate" and child "RepeatSpecialEndDate button"
Added aforementioned styling to the <p> containing last day of class and last day of finals buttons
### Test Plan <!-- Required -->

![image](https://user-images.githubusercontent.com/33106747/66974297-a8287700-f068-11e9-8735-d3e768bf415c.png)


### Notes <!-- Optional -->

Fix the CSS itself however you want; maybe I added too much margin. I used 3px, but 2px is probably ok.
