### PR TITLE
Start to unify usage of current time for deterministic testing

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,6 @@
     "react-dom": "^16.10.0",
     "react-dom-confetti": "^0.1.1",
     "react-firebaseui": "^4.0.0",
-    "react-live-clock": "^3.1.0",
     "react-modal": "^3.10.1",
     "react-redux": "^7.1.1",
     "react-search-box": "^2.0.1",

--- a/frontend/src/components/TaskView/FutureView/FutureViewControl.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewControl.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
 import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
+import { useTodayLastSecondTime } from 'hooks/time-hook';
 import { FutureViewContainerType, FutureViewDisplayOption } from './future-view-types';
 import SquareTextButton from '../../UI/SquareTextButton';
 import SquareIconToggle from '../../UI/SquareIconToggle';
@@ -49,6 +50,7 @@ const Title = ({ text }: { readonly text: string }): ReactElement => (
  */
 
 type NavControlProps = {
+  readonly today: Date;
   readonly containerType: FutureViewContainerType;
   readonly futureViewOffset: number;
   readonly changeOffset: (instruction: ChangeOffsetInstruction) => () => void;
@@ -58,17 +60,18 @@ type NavControlProps = {
 /**
  * Returns a suitable title for the backlog header title.
  *
+ * @param {Date} today today from React hooks.
  * @param {number} monthOffset offset of displaying months.
  * @return {string} a suitable title for the backlog header title.
  */
-function getMonthlyViewHeaderTitle(monthOffset: number): string {
-  const d = new Date();
+function getMonthlyViewHeaderTitle(today: Date, monthOffset: number): string {
+  const d = new Date(today);
   d.setMonth(d.getMonth() + monthOffset, 1);
   return date2YearMonth(d);
 }
 
-function getBiWeeklyViewHeaderTitle(biweeklyOffset: number): string {
-  const s = new Date();
+function getBiWeeklyViewHeaderTitle(today: Date, biweeklyOffset: number): string {
+  const s = new Date(today);
   s.setDate(s.getDate() + biweeklyOffset * 14 - s.getDay()); // minus day offset
   const e = new Date(s);
   e.setDate(e.getDate() + 13);
@@ -81,7 +84,7 @@ function getBiWeeklyViewHeaderTitle(biweeklyOffset: number): string {
  * The component to control nav.
  */
 function NavControl(props: NavControlProps): ReactElement {
-  const { containerType, futureViewOffset, changeOffset, isSmallScreen } = props;
+  const { today, containerType, futureViewOffset, changeOffset, isSmallScreen } = props;
   const prevHandler = changeOffset(-1);
   const nextHandler = changeOffset(+1);
   if (containerType === 'N_DAYS') {
@@ -130,7 +133,7 @@ function NavControl(props: NavControlProps): ReactElement {
     return (
       <>
         {futureViewOffset >= 0 && prev}
-        <Title text={getBiWeeklyViewHeaderTitle(futureViewOffset)} />
+        <Title text={getBiWeeklyViewHeaderTitle(today, futureViewOffset)} />
         {next}
       </>
     );
@@ -140,7 +143,7 @@ function NavControl(props: NavControlProps): ReactElement {
       <>
         {!isSmallScreen && <Padding />}
         {futureViewOffset >= 0 && prev}
-        <Title text={getMonthlyViewHeaderTitle(futureViewOffset)} />
+        <Title text={getMonthlyViewHeaderTitle(today, futureViewOffset)} />
         {next}
       </>
     );
@@ -240,6 +243,7 @@ function DisplayOptionControl({ nDays, displayOption, offset, onChange }: Props)
  */
 export default function FutureViewControl(props: Props): ReactElement {
   const { nDays, displayOption, offset, onChange } = props;
+  const todayTime = useTodayLastSecondTime();
   const isSmallScreen = useMappedWindowSize(({ width }) => width <= 600);
   const { containerType } = displayOption;
   const changeOffset = (instruction: ChangeOffsetInstruction): (() => void) => (): void => {
@@ -266,6 +270,7 @@ export default function FutureViewControl(props: Props): ReactElement {
         <div className={styles.FutureViewControl}>
           <Padding />
           <NavControl
+            today={todayTime}
             containerType={containerType}
             futureViewOffset={offset}
             changeOffset={changeOffset}
@@ -280,6 +285,7 @@ export default function FutureViewControl(props: Props): ReactElement {
     <div className={styles.FutureViewControl}>
       <Title text="Future" />
       <NavControl
+        today={todayTime}
         containerType={containerType}
         futureViewOffset={offset}
         changeOffset={changeOffset}

--- a/frontend/src/components/TaskView/FutureView/FutureViewDayTaskContainer.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewDayTaskContainer.tsx
@@ -4,7 +4,6 @@ import { CalendarPosition, FloatingPosition } from '../../Util/TaskEditors/edito
 import FutureViewTask from './FutureViewTask';
 import styles from './FutureViewDayTaskContainer.module.css';
 import { useWindowSizeCallback } from '../../../hooks/window-size-hook';
-import { error } from '../../../util/general-util';
 import { State } from '../../../store/store-types';
 import { createGetIdOrderListByDate } from '../../../store/selectors';
 
@@ -42,7 +41,10 @@ function FutureViewDayTaskContainer(
 
   // Subscribes to it, but don't use the value. Force rerender when window size changes.
   useWindowSizeCallback(() => {
-    const containerNode = containerRef.current || error();
+    const containerNode = containerRef.current;
+    if (containerNode == null) {
+      return;
+    }
     const tasksHeight = containerNode.scrollHeight;
     const containerHeight = containerNode.clientHeight;
     const [prevTasksHeight, prevContainerHeight] = prevHeights;

--- a/frontend/src/components/TaskView/FutureView/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/TaskView/FutureView/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,3759 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FutureView with config biweekly, hide-completed matches snapshot. 1`] = `
+<div>
+  <div
+    className="FutureViewControl"
+  >
+    <h3
+      className="Title"
+    >
+      Future
+    </h3>
+    <span
+      title="Go back"
+    >
+      <svg
+        alt="More"
+        className="NavButtonPrev"
+        height="1em"
+        onClick={[Function]}
+        onKeyUp={[Function]}
+        tabIndex={0}
+        title="More"
+        width="1em"
+      >
+        v.svg
+      </svg>
+    </span>
+    <h3
+      className="Title"
+    >
+      1/10/27 - 1/23/27
+    </h3>
+    <span
+      title="Go forward"
+    >
+      <svg
+        alt="More"
+        className="NavButtonNext"
+        height="1em"
+        onClick={[Function]}
+        onKeyUp={[Function]}
+        tabIndex={0}
+        title="More"
+        width="1em"
+      >
+        v.svg
+      </svg>
+    </span>
+    <span
+      className="ControlPadding"
+    />
+    <button
+      className="SquareButton SquareButtonIconButton active"
+      onClick={[Function]}
+      title="Hide/unhide completed tasks"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        className="svg-inline--fa fa-eye fa-w-18 SquareButtonText"
+        data-icon="eye"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        style={Object {}}
+        viewBox="0 0 576 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M572.52 241.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400a144 144 0 1 1 144-144 143.93 143.93 0 0 1-144 144zm0-240a95.31 95.31 0 0 0-25.31 3.79 47.85 47.85 0 0 1-66.9 66.9A95.78 95.78 0 1 0 288 160z"
+          fill="currentColor"
+          style={Object {}}
+        />
+      </svg>
+    </button>
+    <div
+      className="ContainerTypeSwitcher"
+    >
+      <button
+        className="ContainerTypeSwitcherButton"
+        onClick={[Function]}
+        title="Change to 4D view"
+        type="button"
+      >
+        <span
+          className="ContainerTypeSwitcherButtonText"
+        >
+          4D
+        </span>
+      </button>
+      <button
+        className="ContainerTypeSwitcherButton ContainerTypeSwitcherActiveButton"
+        onClick={[Function]}
+        title="Change to 2W view"
+        type="button"
+      >
+        <span
+          className="ContainerTypeSwitcherButtonText"
+        >
+          2W
+        </span>
+      </button>
+      <button
+        className="ContainerTypeSwitcherButton"
+        onClick={[Function]}
+        title="Change to M view"
+        type="button"
+      >
+        <span
+          className="ContainerTypeSwitcherButtonText"
+        >
+          M
+        </span>
+      </button>
+    </div>
+  </div>
+  <div
+    className="FutureViewSevenColumns"
+    style={
+      Object {
+        "gridTemplateRows": "minmax(0, 0.5fr) minmax(0, 0.5fr)",
+      }
+    }
+  >
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SUN
+        </div>
+        <div
+          className="DateNum"
+        >
+          10
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          MON
+        </div>
+        <div
+          className="DateNum"
+        >
+          11
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          TUE
+        </div>
+        <div
+          className="DateNum"
+        >
+          12
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          WED
+        </div>
+        <div
+          className="DateNum"
+        >
+          13
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          THU
+        </div>
+        <div
+          className="DateNum"
+        >
+          14
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          FRI
+        </div>
+        <div
+          className="DateNum"
+        >
+          15
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SAT
+        </div>
+        <div
+          className="DateNum"
+        >
+          16
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SUN
+        </div>
+        <div
+          className="DateNum"
+        >
+          17
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          MON
+        </div>
+        <div
+          className="DateNum"
+        >
+          18
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          TUE
+        </div>
+        <div
+          className="DateNum"
+        >
+          19
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          WED
+        </div>
+        <div
+          className="DateNum"
+        >
+          20
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          THU
+        </div>
+        <div
+          className="DateNum"
+        >
+          21
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          FRI
+        </div>
+        <div
+          className="DateNum"
+        >
+          22
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SAT
+        </div>
+        <div
+          className="DateNum"
+        >
+          23
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FutureView with config biweekly, show-completed matches snapshot. 1`] = `
+<div>
+  <div
+    className="FutureViewControl"
+  >
+    <h3
+      className="Title"
+    >
+      Future
+    </h3>
+    <span
+      title="Go back"
+    >
+      <svg
+        alt="More"
+        className="NavButtonPrev"
+        height="1em"
+        onClick={[Function]}
+        onKeyUp={[Function]}
+        tabIndex={0}
+        title="More"
+        width="1em"
+      >
+        v.svg
+      </svg>
+    </span>
+    <h3
+      className="Title"
+    >
+      1/10/27 - 1/23/27
+    </h3>
+    <span
+      title="Go forward"
+    >
+      <svg
+        alt="More"
+        className="NavButtonNext"
+        height="1em"
+        onClick={[Function]}
+        onKeyUp={[Function]}
+        tabIndex={0}
+        title="More"
+        width="1em"
+      >
+        v.svg
+      </svg>
+    </span>
+    <span
+      className="ControlPadding"
+    />
+    <button
+      className="SquareButton SquareButtonIconButton"
+      onClick={[Function]}
+      title="Hide/unhide completed tasks"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        className="svg-inline--fa fa-eye-slash fa-w-20 SquareButtonText"
+        data-icon="eye-slash"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        style={Object {}}
+        viewBox="0 0 640 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M320 400c-75.85 0-137.25-58.71-142.9-133.11L72.2 185.82c-13.79 17.3-26.48 35.59-36.72 55.59a32.35 32.35 0 0 0 0 29.19C89.71 376.41 197.07 448 320 448c26.91 0 52.87-4 77.89-10.46L346 397.39a144.13 144.13 0 0 1-26 2.61zm313.82 58.1l-110.55-85.44a331.25 331.25 0 0 0 81.25-102.07 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64a308.15 308.15 0 0 0-147.32 37.7L45.46 3.37A16 16 0 0 0 23 6.18L3.37 31.45A16 16 0 0 0 6.18 53.9l588.36 454.73a16 16 0 0 0 22.46-2.81l19.64-25.27a16 16 0 0 0-2.82-22.45zm-183.72-142l-39.3-30.38A94.75 94.75 0 0 0 416 256a94.76 94.76 0 0 0-121.31-92.21A47.65 47.65 0 0 1 304 192a46.64 46.64 0 0 1-1.54 10l-73.61-56.89A142.31 142.31 0 0 1 320 112a143.92 143.92 0 0 1 144 144c0 21.63-5.29 41.79-13.9 60.11z"
+          fill="currentColor"
+          style={Object {}}
+        />
+      </svg>
+    </button>
+    <div
+      className="ContainerTypeSwitcher"
+    >
+      <button
+        className="ContainerTypeSwitcherButton"
+        onClick={[Function]}
+        title="Change to 4D view"
+        type="button"
+      >
+        <span
+          className="ContainerTypeSwitcherButtonText"
+        >
+          4D
+        </span>
+      </button>
+      <button
+        className="ContainerTypeSwitcherButton ContainerTypeSwitcherActiveButton"
+        onClick={[Function]}
+        title="Change to 2W view"
+        type="button"
+      >
+        <span
+          className="ContainerTypeSwitcherButtonText"
+        >
+          2W
+        </span>
+      </button>
+      <button
+        className="ContainerTypeSwitcherButton"
+        onClick={[Function]}
+        title="Change to M view"
+        type="button"
+      >
+        <span
+          className="ContainerTypeSwitcherButtonText"
+        >
+          M
+        </span>
+      </button>
+    </div>
+  </div>
+  <div
+    className="FutureViewSevenColumns"
+    style={
+      Object {
+        "gridTemplateRows": "minmax(0, 0.5fr) minmax(0, 0.5fr)",
+      }
+    }
+  >
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SUN
+        </div>
+        <div
+          className="DateNum"
+        >
+          10
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          MON
+        </div>
+        <div
+          className="DateNum"
+        >
+          11
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          TUE
+        </div>
+        <div
+          className="DateNum"
+        >
+          12
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          WED
+        </div>
+        <div
+          className="DateNum"
+        >
+          13
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          THU
+        </div>
+        <div
+          className="DateNum"
+        >
+          14
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          FRI
+        </div>
+        <div
+          className="DateNum"
+        >
+          15
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SAT
+        </div>
+        <div
+          className="DateNum"
+        >
+          16
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SUN
+        </div>
+        <div
+          className="DateNum"
+        >
+          17
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          MON
+        </div>
+        <div
+          className="DateNum"
+        >
+          18
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          TUE
+        </div>
+        <div
+          className="DateNum"
+        >
+          19
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          WED
+        </div>
+        <div
+          className="DateNum"
+        >
+          20
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          THU
+        </div>
+        <div
+          className="DateNum"
+        >
+          21
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          FRI
+        </div>
+        <div
+          className="DateNum"
+        >
+          22
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SAT
+        </div>
+        <div
+          className="DateNum"
+        >
+          23
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FutureView with config monthly, hide-completed matches snapshot. 1`] = `
+<div>
+  <div
+    className="FutureViewControl"
+  >
+    <h3
+      className="Title"
+    >
+      Future
+    </h3>
+    <span
+      className="ControlPadding"
+    />
+    <span
+      title="Go back"
+    >
+      <svg
+        alt="More"
+        className="NavButtonPrev"
+        height="1em"
+        onClick={[Function]}
+        onKeyUp={[Function]}
+        tabIndex={0}
+        title="More"
+        width="1em"
+      >
+        v.svg
+      </svg>
+    </span>
+    <h3
+      className="Title"
+    >
+      January 2027
+    </h3>
+    <span
+      title="Go forward"
+    >
+      <svg
+        alt="More"
+        className="NavButtonNext"
+        height="1em"
+        onClick={[Function]}
+        onKeyUp={[Function]}
+        tabIndex={0}
+        title="More"
+        width="1em"
+      >
+        v.svg
+      </svg>
+    </span>
+    <span
+      className="ControlPadding"
+    />
+    <button
+      className="SquareButton SquareButtonIconButton active"
+      onClick={[Function]}
+      title="Hide/unhide completed tasks"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        className="svg-inline--fa fa-eye fa-w-18 SquareButtonText"
+        data-icon="eye"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        style={Object {}}
+        viewBox="0 0 576 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M572.52 241.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400a144 144 0 1 1 144-144 143.93 143.93 0 0 1-144 144zm0-240a95.31 95.31 0 0 0-25.31 3.79 47.85 47.85 0 0 1-66.9 66.9A95.78 95.78 0 1 0 288 160z"
+          fill="currentColor"
+          style={Object {}}
+        />
+      </svg>
+    </button>
+    <div
+      className="ContainerTypeSwitcher"
+    >
+      <button
+        className="ContainerTypeSwitcherButton"
+        onClick={[Function]}
+        title="Change to 4D view"
+        type="button"
+      >
+        <span
+          className="ContainerTypeSwitcherButtonText"
+        >
+          4D
+        </span>
+      </button>
+      <button
+        className="ContainerTypeSwitcherButton"
+        onClick={[Function]}
+        title="Change to 2W view"
+        type="button"
+      >
+        <span
+          className="ContainerTypeSwitcherButtonText"
+        >
+          2W
+        </span>
+      </button>
+      <button
+        className="ContainerTypeSwitcherButton ContainerTypeSwitcherActiveButton"
+        onClick={[Function]}
+        title="Change to M view"
+        type="button"
+      >
+        <span
+          className="ContainerTypeSwitcherButtonText"
+        >
+          M
+        </span>
+      </button>
+    </div>
+  </div>
+  <div
+    className="FutureViewSevenColumns"
+    style={
+      Object {
+        "gridTemplateRows": "minmax(0, 0.16666666666666666fr) minmax(0, 0.16666666666666666fr) minmax(0, 0.16666666666666666fr) minmax(0, 0.16666666666666666fr) minmax(0, 0.16666666666666666fr) minmax(0, 0.16666666666666666fr)",
+      }
+    }
+  >
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SUN
+        </div>
+        <div
+          className="DateNum"
+        >
+          27
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          MON
+        </div>
+        <div
+          className="DateNum"
+        >
+          28
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          TUE
+        </div>
+        <div
+          className="DateNum"
+        >
+          29
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          WED
+        </div>
+        <div
+          className="DateNum"
+        >
+          30
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          THU
+        </div>
+        <div
+          className="DateNum"
+        >
+          31
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          FRI
+        </div>
+        <div
+          className="DateNum"
+        >
+          1
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SAT
+        </div>
+        <div
+          className="DateNum"
+        >
+          2
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SUN
+        </div>
+        <div
+          className="DateNum"
+        >
+          3
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          MON
+        </div>
+        <div
+          className="DateNum"
+        >
+          4
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          TUE
+        </div>
+        <div
+          className="DateNum"
+        >
+          5
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          WED
+        </div>
+        <div
+          className="DateNum"
+        >
+          6
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          THU
+        </div>
+        <div
+          className="DateNum"
+        >
+          7
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          FRI
+        </div>
+        <div
+          className="DateNum"
+        >
+          8
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SAT
+        </div>
+        <div
+          className="DateNum"
+        >
+          9
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SUN
+        </div>
+        <div
+          className="DateNum"
+        >
+          10
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          MON
+        </div>
+        <div
+          className="DateNum"
+        >
+          11
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          TUE
+        </div>
+        <div
+          className="DateNum"
+        >
+          12
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          WED
+        </div>
+        <div
+          className="DateNum"
+        >
+          13
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          THU
+        </div>
+        <div
+          className="DateNum"
+        >
+          14
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          FRI
+        </div>
+        <div
+          className="DateNum"
+        >
+          15
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SAT
+        </div>
+        <div
+          className="DateNum"
+        >
+          16
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SUN
+        </div>
+        <div
+          className="DateNum"
+        >
+          17
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          MON
+        </div>
+        <div
+          className="DateNum"
+        >
+          18
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          TUE
+        </div>
+        <div
+          className="DateNum"
+        >
+          19
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          WED
+        </div>
+        <div
+          className="DateNum"
+        >
+          20
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          THU
+        </div>
+        <div
+          className="DateNum"
+        >
+          21
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          FRI
+        </div>
+        <div
+          className="DateNum"
+        >
+          22
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SAT
+        </div>
+        <div
+          className="DateNum"
+        >
+          23
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SUN
+        </div>
+        <div
+          className="DateNum"
+        >
+          24
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          MON
+        </div>
+        <div
+          className="DateNum"
+        >
+          25
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          TUE
+        </div>
+        <div
+          className="DateNum"
+        >
+          26
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          WED
+        </div>
+        <div
+          className="DateNum"
+        >
+          27
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          THU
+        </div>
+        <div
+          className="DateNum"
+        >
+          28
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          FRI
+        </div>
+        <div
+          className="DateNum"
+        >
+          29
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SAT
+        </div>
+        <div
+          className="DateNum"
+        >
+          30
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SUN
+        </div>
+        <div
+          className="DateNum"
+        >
+          31
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FutureView with config monthly, show-completed matches snapshot. 1`] = `
+<div>
+  <div
+    className="FutureViewControl"
+  >
+    <h3
+      className="Title"
+    >
+      Future
+    </h3>
+    <span
+      className="ControlPadding"
+    />
+    <span
+      title="Go back"
+    >
+      <svg
+        alt="More"
+        className="NavButtonPrev"
+        height="1em"
+        onClick={[Function]}
+        onKeyUp={[Function]}
+        tabIndex={0}
+        title="More"
+        width="1em"
+      >
+        v.svg
+      </svg>
+    </span>
+    <h3
+      className="Title"
+    >
+      January 2027
+    </h3>
+    <span
+      title="Go forward"
+    >
+      <svg
+        alt="More"
+        className="NavButtonNext"
+        height="1em"
+        onClick={[Function]}
+        onKeyUp={[Function]}
+        tabIndex={0}
+        title="More"
+        width="1em"
+      >
+        v.svg
+      </svg>
+    </span>
+    <span
+      className="ControlPadding"
+    />
+    <button
+      className="SquareButton SquareButtonIconButton"
+      onClick={[Function]}
+      title="Hide/unhide completed tasks"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        className="svg-inline--fa fa-eye-slash fa-w-20 SquareButtonText"
+        data-icon="eye-slash"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        style={Object {}}
+        viewBox="0 0 640 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M320 400c-75.85 0-137.25-58.71-142.9-133.11L72.2 185.82c-13.79 17.3-26.48 35.59-36.72 55.59a32.35 32.35 0 0 0 0 29.19C89.71 376.41 197.07 448 320 448c26.91 0 52.87-4 77.89-10.46L346 397.39a144.13 144.13 0 0 1-26 2.61zm313.82 58.1l-110.55-85.44a331.25 331.25 0 0 0 81.25-102.07 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64a308.15 308.15 0 0 0-147.32 37.7L45.46 3.37A16 16 0 0 0 23 6.18L3.37 31.45A16 16 0 0 0 6.18 53.9l588.36 454.73a16 16 0 0 0 22.46-2.81l19.64-25.27a16 16 0 0 0-2.82-22.45zm-183.72-142l-39.3-30.38A94.75 94.75 0 0 0 416 256a94.76 94.76 0 0 0-121.31-92.21A47.65 47.65 0 0 1 304 192a46.64 46.64 0 0 1-1.54 10l-73.61-56.89A142.31 142.31 0 0 1 320 112a143.92 143.92 0 0 1 144 144c0 21.63-5.29 41.79-13.9 60.11z"
+          fill="currentColor"
+          style={Object {}}
+        />
+      </svg>
+    </button>
+    <div
+      className="ContainerTypeSwitcher"
+    >
+      <button
+        className="ContainerTypeSwitcherButton"
+        onClick={[Function]}
+        title="Change to 4D view"
+        type="button"
+      >
+        <span
+          className="ContainerTypeSwitcherButtonText"
+        >
+          4D
+        </span>
+      </button>
+      <button
+        className="ContainerTypeSwitcherButton"
+        onClick={[Function]}
+        title="Change to 2W view"
+        type="button"
+      >
+        <span
+          className="ContainerTypeSwitcherButtonText"
+        >
+          2W
+        </span>
+      </button>
+      <button
+        className="ContainerTypeSwitcherButton ContainerTypeSwitcherActiveButton"
+        onClick={[Function]}
+        title="Change to M view"
+        type="button"
+      >
+        <span
+          className="ContainerTypeSwitcherButtonText"
+        >
+          M
+        </span>
+      </button>
+    </div>
+  </div>
+  <div
+    className="FutureViewSevenColumns"
+    style={
+      Object {
+        "gridTemplateRows": "minmax(0, 0.16666666666666666fr) minmax(0, 0.16666666666666666fr) minmax(0, 0.16666666666666666fr) minmax(0, 0.16666666666666666fr) minmax(0, 0.16666666666666666fr) minmax(0, 0.16666666666666666fr)",
+      }
+    }
+  >
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SUN
+        </div>
+        <div
+          className="DateNum"
+        >
+          27
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          MON
+        </div>
+        <div
+          className="DateNum"
+        >
+          28
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          TUE
+        </div>
+        <div
+          className="DateNum"
+        >
+          29
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          WED
+        </div>
+        <div
+          className="DateNum"
+        >
+          30
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          THU
+        </div>
+        <div
+          className="DateNum"
+        >
+          31
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          FRI
+        </div>
+        <div
+          className="DateNum"
+        >
+          1
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SAT
+        </div>
+        <div
+          className="DateNum"
+        >
+          2
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SUN
+        </div>
+        <div
+          className="DateNum"
+        >
+          3
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          MON
+        </div>
+        <div
+          className="DateNum"
+        >
+          4
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          TUE
+        </div>
+        <div
+          className="DateNum"
+        >
+          5
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          WED
+        </div>
+        <div
+          className="DateNum"
+        >
+          6
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          THU
+        </div>
+        <div
+          className="DateNum"
+        >
+          7
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          FRI
+        </div>
+        <div
+          className="DateNum"
+        >
+          8
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SAT
+        </div>
+        <div
+          className="DateNum"
+        >
+          9
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SUN
+        </div>
+        <div
+          className="DateNum"
+        >
+          10
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          MON
+        </div>
+        <div
+          className="DateNum"
+        >
+          11
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          TUE
+        </div>
+        <div
+          className="DateNum"
+        >
+          12
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          WED
+        </div>
+        <div
+          className="DateNum"
+        >
+          13
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          THU
+        </div>
+        <div
+          className="DateNum"
+        >
+          14
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          FRI
+        </div>
+        <div
+          className="DateNum"
+        >
+          15
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SAT
+        </div>
+        <div
+          className="DateNum"
+        >
+          16
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SUN
+        </div>
+        <div
+          className="DateNum"
+        >
+          17
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          MON
+        </div>
+        <div
+          className="DateNum"
+        >
+          18
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          TUE
+        </div>
+        <div
+          className="DateNum"
+        >
+          19
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          WED
+        </div>
+        <div
+          className="DateNum"
+        >
+          20
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          THU
+        </div>
+        <div
+          className="DateNum"
+        >
+          21
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          FRI
+        </div>
+        <div
+          className="DateNum"
+        >
+          22
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SAT
+        </div>
+        <div
+          className="DateNum"
+        >
+          23
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SUN
+        </div>
+        <div
+          className="DateNum"
+        >
+          24
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          MON
+        </div>
+        <div
+          className="DateNum"
+        >
+          25
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          TUE
+        </div>
+        <div
+          className="DateNum"
+        >
+          26
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          WED
+        </div>
+        <div
+          className="DateNum"
+        >
+          27
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          THU
+        </div>
+        <div
+          className="DateNum"
+        >
+          28
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          FRI
+        </div>
+        <div
+          className="DateNum"
+        >
+          29
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SAT
+        </div>
+        <div
+          className="DateNum"
+        >
+          30
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+    <div
+      className="OtherViews"
+    >
+      <div
+        className="DateInfo"
+        style={Object {}}
+      >
+        <div
+          className="DateInfoDay"
+        >
+          SUN
+        </div>
+        <div
+          className="DateNum"
+        >
+          31
+        </div>
+      </div>
+      <div
+        className="Container"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FutureView with config n-days, hide-completed matches snapshot. 1`] = `
+<div>
+  <div
+    className="FutureViewControl"
+  >
+    <h3
+      className="Title"
+    >
+      Future
+    </h3>
+    <span
+      title="Go back"
+    >
+      <svg
+        alt="More"
+        className="NavButtonPrev NavButtonNDays"
+        height="1em"
+        onClick={[Function]}
+        onKeyUp={[Function]}
+        style={
+          Object {
+            "left": -10,
+          }
+        }
+        tabIndex={0}
+        title="More"
+        width="1em"
+      >
+        v.svg
+      </svg>
+    </span>
+    <span
+      title="Go forward"
+    >
+      <svg
+        alt="More"
+        className="NavButtonNext NavButtonNDays"
+        height="1em"
+        onClick={[Function]}
+        onKeyUp={[Function]}
+        style={
+          Object {
+            "right": -10,
+          }
+        }
+        tabIndex={0}
+        title="More"
+        width="1em"
+      >
+        v.svg
+      </svg>
+    </span>
+    <span
+      className="ControlPadding"
+    />
+    <button
+      className="SquareButton SquareButtonIconButton active"
+      onClick={[Function]}
+      title="Hide/unhide completed tasks"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        className="svg-inline--fa fa-eye fa-w-18 SquareButtonText"
+        data-icon="eye"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        style={Object {}}
+        viewBox="0 0 576 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M572.52 241.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400a144 144 0 1 1 144-144 143.93 143.93 0 0 1-144 144zm0-240a95.31 95.31 0 0 0-25.31 3.79 47.85 47.85 0 0 1-66.9 66.9A95.78 95.78 0 1 0 288 160z"
+          fill="currentColor"
+          style={Object {}}
+        />
+      </svg>
+    </button>
+    <div
+      className="ContainerTypeSwitcher"
+    >
+      <button
+        className="ContainerTypeSwitcherButton ContainerTypeSwitcherActiveButton"
+        onClick={[Function]}
+        title="Change to 4D view"
+        type="button"
+      >
+        <span
+          className="ContainerTypeSwitcherButtonText"
+        >
+          4D
+        </span>
+      </button>
+      <button
+        className="ContainerTypeSwitcherButton"
+        onClick={[Function]}
+        title="Change to 2W view"
+        type="button"
+      >
+        <span
+          className="ContainerTypeSwitcherButtonText"
+        >
+          2W
+        </span>
+      </button>
+      <button
+        className="ContainerTypeSwitcherButton"
+        onClick={[Function]}
+        title="Change to M view"
+        type="button"
+      >
+        <span
+          className="ContainerTypeSwitcherButtonText"
+        >
+          M
+        </span>
+      </button>
+    </div>
+  </div>
+  <div
+    className="FutureViewNDays"
+    style={
+      Object {
+        "gridTemplateColumns": "repeat(4, minmax(0, 1fr))",
+      }
+    }
+  >
+    <div
+      className="Column"
+    >
+      <div
+        className="NDaysView"
+      >
+        <div
+          className="DateInfo"
+          style={
+            Object {
+              "paddingTop": "1em",
+            }
+          }
+        >
+          <div
+            className="DateInfoDay"
+          >
+            FRI
+          </div>
+          <div
+            className="DateNum"
+          >
+            15
+          </div>
+        </div>
+        <div
+          className="Container"
+          style={
+            Object {
+              "overflow": "hidden",
+            }
+          }
+        />
+      </div>
+    </div>
+    <div
+      className="Column"
+    >
+      <div
+        className="NDaysView"
+      >
+        <div
+          className="DateInfo"
+          style={
+            Object {
+              "paddingTop": "1em",
+            }
+          }
+        >
+          <div
+            className="DateInfoDay"
+          >
+            SAT
+          </div>
+          <div
+            className="DateNum"
+          >
+            16
+          </div>
+        </div>
+        <div
+          className="Container"
+          style={
+            Object {
+              "overflow": "hidden",
+            }
+          }
+        />
+      </div>
+    </div>
+    <div
+      className="Column"
+    >
+      <div
+        className="NDaysView"
+      >
+        <div
+          className="DateInfo"
+          style={
+            Object {
+              "paddingTop": "1em",
+            }
+          }
+        >
+          <div
+            className="DateInfoDay"
+          >
+            SUN
+          </div>
+          <div
+            className="DateNum"
+          >
+            17
+          </div>
+        </div>
+        <div
+          className="Container"
+          style={
+            Object {
+              "overflow": "hidden",
+            }
+          }
+        />
+      </div>
+    </div>
+    <div
+      className="Column"
+    >
+      <div
+        className="NDaysView"
+      >
+        <div
+          className="DateInfo"
+          style={
+            Object {
+              "paddingTop": "1em",
+            }
+          }
+        >
+          <div
+            className="DateInfoDay"
+          >
+            MON
+          </div>
+          <div
+            className="DateNum"
+          >
+            18
+          </div>
+        </div>
+        <div
+          className="Container"
+          style={
+            Object {
+              "overflow": "hidden",
+            }
+          }
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FutureView with config n-days, show-completed matches snapshot. 1`] = `
+<div>
+  <div
+    className="FutureViewControl"
+  >
+    <h3
+      className="Title"
+    >
+      Future
+    </h3>
+    <span
+      title="Go back"
+    >
+      <svg
+        alt="More"
+        className="NavButtonPrev NavButtonNDays"
+        height="1em"
+        onClick={[Function]}
+        onKeyUp={[Function]}
+        style={
+          Object {
+            "left": -10,
+          }
+        }
+        tabIndex={0}
+        title="More"
+        width="1em"
+      >
+        v.svg
+      </svg>
+    </span>
+    <span
+      title="Go forward"
+    >
+      <svg
+        alt="More"
+        className="NavButtonNext NavButtonNDays"
+        height="1em"
+        onClick={[Function]}
+        onKeyUp={[Function]}
+        style={
+          Object {
+            "right": -10,
+          }
+        }
+        tabIndex={0}
+        title="More"
+        width="1em"
+      >
+        v.svg
+      </svg>
+    </span>
+    <span
+      className="ControlPadding"
+    />
+    <button
+      className="SquareButton SquareButtonIconButton"
+      onClick={[Function]}
+      title="Hide/unhide completed tasks"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        className="svg-inline--fa fa-eye-slash fa-w-20 SquareButtonText"
+        data-icon="eye-slash"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        style={Object {}}
+        viewBox="0 0 640 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M320 400c-75.85 0-137.25-58.71-142.9-133.11L72.2 185.82c-13.79 17.3-26.48 35.59-36.72 55.59a32.35 32.35 0 0 0 0 29.19C89.71 376.41 197.07 448 320 448c26.91 0 52.87-4 77.89-10.46L346 397.39a144.13 144.13 0 0 1-26 2.61zm313.82 58.1l-110.55-85.44a331.25 331.25 0 0 0 81.25-102.07 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64a308.15 308.15 0 0 0-147.32 37.7L45.46 3.37A16 16 0 0 0 23 6.18L3.37 31.45A16 16 0 0 0 6.18 53.9l588.36 454.73a16 16 0 0 0 22.46-2.81l19.64-25.27a16 16 0 0 0-2.82-22.45zm-183.72-142l-39.3-30.38A94.75 94.75 0 0 0 416 256a94.76 94.76 0 0 0-121.31-92.21A47.65 47.65 0 0 1 304 192a46.64 46.64 0 0 1-1.54 10l-73.61-56.89A142.31 142.31 0 0 1 320 112a143.92 143.92 0 0 1 144 144c0 21.63-5.29 41.79-13.9 60.11z"
+          fill="currentColor"
+          style={Object {}}
+        />
+      </svg>
+    </button>
+    <div
+      className="ContainerTypeSwitcher"
+    >
+      <button
+        className="ContainerTypeSwitcherButton ContainerTypeSwitcherActiveButton"
+        onClick={[Function]}
+        title="Change to 4D view"
+        type="button"
+      >
+        <span
+          className="ContainerTypeSwitcherButtonText"
+        >
+          4D
+        </span>
+      </button>
+      <button
+        className="ContainerTypeSwitcherButton"
+        onClick={[Function]}
+        title="Change to 2W view"
+        type="button"
+      >
+        <span
+          className="ContainerTypeSwitcherButtonText"
+        >
+          2W
+        </span>
+      </button>
+      <button
+        className="ContainerTypeSwitcherButton"
+        onClick={[Function]}
+        title="Change to M view"
+        type="button"
+      >
+        <span
+          className="ContainerTypeSwitcherButtonText"
+        >
+          M
+        </span>
+      </button>
+    </div>
+  </div>
+  <div
+    className="FutureViewNDays"
+    style={
+      Object {
+        "gridTemplateColumns": "repeat(4, minmax(0, 1fr))",
+      }
+    }
+  >
+    <div
+      className="Column"
+    >
+      <div
+        className="NDaysView"
+      >
+        <div
+          className="DateInfo"
+          style={
+            Object {
+              "paddingTop": "1em",
+            }
+          }
+        >
+          <div
+            className="DateInfoDay"
+          >
+            FRI
+          </div>
+          <div
+            className="DateNum"
+          >
+            15
+          </div>
+        </div>
+        <div
+          className="Container"
+          style={
+            Object {
+              "overflow": "hidden",
+            }
+          }
+        />
+      </div>
+    </div>
+    <div
+      className="Column"
+    >
+      <div
+        className="NDaysView"
+      >
+        <div
+          className="DateInfo"
+          style={
+            Object {
+              "paddingTop": "1em",
+            }
+          }
+        >
+          <div
+            className="DateInfoDay"
+          >
+            SAT
+          </div>
+          <div
+            className="DateNum"
+          >
+            16
+          </div>
+        </div>
+        <div
+          className="Container"
+          style={
+            Object {
+              "overflow": "hidden",
+            }
+          }
+        />
+      </div>
+    </div>
+    <div
+      className="Column"
+    >
+      <div
+        className="NDaysView"
+      >
+        <div
+          className="DateInfo"
+          style={
+            Object {
+              "paddingTop": "1em",
+            }
+          }
+        >
+          <div
+            className="DateInfoDay"
+          >
+            SUN
+          </div>
+          <div
+            className="DateNum"
+          >
+            17
+          </div>
+        </div>
+        <div
+          className="Container"
+          style={
+            Object {
+              "overflow": "hidden",
+            }
+          }
+        />
+      </div>
+    </div>
+    <div
+      className="Column"
+    >
+      <div
+        className="NDaysView"
+      >
+        <div
+          className="DateInfo"
+          style={
+            Object {
+              "paddingTop": "1em",
+            }
+          }
+        >
+          <div
+            className="DateInfoDay"
+          >
+            MON
+          </div>
+          <div
+            className="DateNum"
+          >
+            18
+          </div>
+        </div>
+        <div
+          className="Container"
+          style={
+            Object {
+              "overflow": "hidden",
+            }
+          }
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/components/TaskView/FutureView/index.test.tsx
+++ b/frontend/src/components/TaskView/FutureView/index.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { ProviderForTesting } from 'store';
+import { enableTestMode, disableTestMode } from 'hooks/time-hook';
+import FutureView, { FutureViewConfig } from '.';
+import { FutureViewContainerType } from './future-view-types';
+
+const createFutureViewConfig = (
+  containerType: FutureViewContainerType, doesShowCompletedTasks: boolean,
+): FutureViewConfig => ({
+  displayOption: { containerType, doesShowCompletedTasks },
+  offset: 0,
+});
+
+const dummyOnConfigChange = (): void => { };
+
+const createTest = (configName: string, config: FutureViewConfig): void => {
+  it(`FutureView with config ${configName} matches snapshot.`, () => {
+    enableTestMode(1800000000000); // around 2027-01-15
+    const tree = renderer.create(
+      <ProviderForTesting>
+        <FutureView config={config} onConfigChange={dummyOnConfigChange} />
+      </ProviderForTesting>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+    disableTestMode();
+  });
+};
+
+createTest('n-days, show-completed', createFutureViewConfig('N_DAYS', true));
+createTest('biweekly, show-completed', createFutureViewConfig('BIWEEKLY', true));
+createTest('monthly, show-completed', createFutureViewConfig('MONTHLY', true));
+createTest('n-days, hide-completed', createFutureViewConfig('N_DAYS', false));
+createTest('biweekly, hide-completed', createFutureViewConfig('BIWEEKLY', false));
+createTest('monthly, hide-completed', createFutureViewConfig('MONTHLY', false));

--- a/frontend/src/components/TaskView/FutureView/index.tsx
+++ b/frontend/src/components/TaskView/FutureView/index.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import { useTodayLastSecondTime } from 'hooks/time-hook';
 import FutureViewControl from './FutureViewControl';
 import FutureViewNDays from './FutureViewNDays';
 import FutureViewSevenColumns from './FutureViewSevenColumns';
@@ -32,16 +33,17 @@ export const futureViewConfigProvider: FutureViewConfigProvider = {
 /**
  * Compute the start date and end date.
  *
+ * @param {Date} today today object from React hooks.
  * @param {number} nDays number of days in n-days view.
  * @param {FutureViewContainerType} containerType the container type.
  * @param {number} offset offset of displaying days.
  * @return {{startDate: Date, endDate: Date}} the start date and end date.
  */
 function computeStartAndEndDay(
-  nDays: number, containerType: FutureViewContainerType, offset: number,
+  today: Date, nDays: number, containerType: FutureViewContainerType, offset: number,
 ): { readonly startDate: Date; readonly endDate: Date } {
   // Compute start date (the first date to display)
-  const startDate = new Date();
+  const startDate = new Date(today);
   let hasAdditionalDays = false;
   switch (containerType) {
     case 'N_DAYS':
@@ -82,13 +84,16 @@ function computeStartAndEndDay(
 /**
  * Returns an array of future view days given the current props and the display option.
  *
+ * @param {Date} today today object from React hooks.
  * @param {number} nDays number of days in n-days view.
  * @param {FutureViewConfig} config the display config.
  * @return {Date[]} an array of backlog days information.
  */
-function buildDaysInFutureView(nDays: number, config: FutureViewConfig): readonly SimpleDate[] {
+function buildDaysInFutureView(
+  today: Date, nDays: number, config: FutureViewConfig,
+): readonly SimpleDate[] {
   const { displayOption: { containerType }, offset } = config;
-  const { startDate, endDate } = computeStartAndEndDay(nDays, containerType, offset);
+  const { startDate, endDate } = computeStartAndEndDay(today, nDays, containerType, offset);
   // Adding the days to array
   const days: SimpleDate[] = [];
   for (let d = startDate; d < endDate; d.setDate(d.getDate() + 1)) {
@@ -112,6 +117,8 @@ type Props = {
 export default function FutureView(
   { config, onConfigChange }: Props,
 ): ReactElement {
+  const today = useTodayLastSecondTime();
+
   // the number of days in n-days mode.
   const nDays = useMappedWindowSize(({ width }) => {
     if (width > 1280) { return 5; }
@@ -123,7 +130,7 @@ export default function FutureView(
     onConfigChange({ ...config, ...change });
   };
 
-  const days = buildDaysInFutureView(nDays, config);
+  const days = buildDaysInFutureView(today, nDays, config);
   const { displayOption, offset } = config;
   const { containerType, doesShowCompletedTasks } = displayOption;
   const daysContainer = containerType === 'N_DAYS'

--- a/frontend/src/components/TitleBar/index.tsx
+++ b/frontend/src/components/TitleBar/index.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from 'react';
-// @ts-ignore this module does not have a ts definition file.
-import Clock from 'react-live-clock';
+import { useTime } from 'hooks/time-hook';
 import Banner from './Banner';
 import { date2FullDateString } from '../../util/datetime-util';
 import styles from './index.module.css';
@@ -11,11 +10,20 @@ import SettingsButton from './Settings/SettingsButton';
  *
  * @type {function(): Node}
  */
-export default (): ReactElement => (
-  <header className={styles.Main}>
-    <Banner />
-    <span title="time" className={styles.Time}><Clock format="h:mm A" ticking /></span>
-    <span title="date" className={styles.Date}>{date2FullDateString(new Date())}</span>
-    <span className={styles.Links}><SettingsButton /></span>
-  </header>
-);
+export default (): ReactElement => {
+  const time = useTime();
+  const date = new Date(time);
+  const dateString = date2FullDateString(date);
+  const timeString = date.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: 'numeric',
+  });
+  return (
+    <header className={styles.Main}>
+      <Banner />
+      <span title="time" className={styles.Time}>{timeString}</span>
+      <span title="date" className={styles.Date}>{dateString}</span>
+      <span className={styles.Links}><SettingsButton /></span>
+    </header>
+  );
+};

--- a/frontend/src/hooks/time-hook.ts
+++ b/frontend/src/hooks/time-hook.ts
@@ -1,0 +1,95 @@
+import { useState, useEffect } from 'react';
+
+const INTERVAL = 1000;
+
+let currentTime: number = new Date().getTime();
+
+let testTime: number | null = null;
+
+type Handler = (time: number) => void;
+
+const handlers: Set<Handler> = new Set();
+
+setInterval(() => {
+  if (testTime === null) {
+    currentTime = new Date().getTime();
+    handlers.forEach((handler) => handler(currentTime));
+  }
+}, INTERVAL);
+
+/**
+ * Enable test mode for components that uses or indirectly uses the time hooks.
+ * The test mode disables:
+ * - Current time real time update.
+ * - Reporting updated time to components.
+ *
+ * @param timeForTesting the value of current time used for deterministic time.
+ */
+export const enableTestMode = (timeForTesting: number): void => {
+  testTime = timeForTesting;
+  currentTime = testTime;
+};
+
+/**
+ * Restart realtime time update when the test ends.
+ */
+export const disableTestMode = (): void => {
+  testTime = null;
+};
+
+/**
+ * A react state hooks that returns the current time every 1 second.
+ * It will cause a re-render when a new value is returned.
+ *
+ * @returns the current time.
+ */
+export const useTime = (): number => {
+  const [time, setTime] = useState(currentTime);
+
+  useEffect(() => {
+    const handler = (newTime: number): void => setTime(newTime);
+    handlers.add(handler);
+    return (): void => {
+      handlers.delete(handler);
+    };
+  }, []);
+
+  return time;
+};
+
+/**
+ * A react state hooks that returns the current date every one day.
+ * It will cause a re-render when a new value is returned.
+ *
+ * @returns a date object that falls within today's range.
+ */
+const useDate = (): Date => {
+  const [currentDateString, setCurrentDateString] = useState(new Date(currentTime).toDateString());
+
+  useEffect(() => {
+    const handler = (newTime: number): void => {
+      const newTimeDateString = new Date(newTime).toDateString();
+      if (newTimeDateString !== currentDateString) {
+        setCurrentDateString(newTimeDateString);
+      }
+    };
+    handlers.add(handler);
+    return (): void => {
+      handlers.delete(handler);
+    };
+  }, [currentDateString]);
+
+  return new Date(currentDateString);
+};
+
+/**
+ * A react state hooks that returns the current date every one day.
+ * It will cause a re-render when a new value is returned.
+ *
+ * @returns today at 23:59:59 (in user's browser's reported timezone) as a date object.
+ */
+export const useTodayLastSecondTime = (): Date => {
+  const date = new Date(useDate());
+  date.setHours(23, 59, 59);
+  return date;
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2227,7 +2227,7 @@ as-array@^2.0.0:
   resolved "https://registry.yarnpkg.com/as-array/-/as-array-2.0.0.tgz#4f04805d87f8fce8e511bc2108f8e5e3a287d547"
   integrity sha1-TwSAXYf4/OjlEbwhCPjl46KH1Uc=
 
-asap@~2.0.3, asap@~2.0.6:
+asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
@@ -3523,11 +3523,6 @@ core-js@3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.2.1.tgz#cd41f38534da6cc59f7db050fe67307de9868b09"
   integrity sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==
-
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
 core-js@^2.4.0, core-js@^2.6.5:
   version "2.6.9"
@@ -4992,19 +4987,6 @@ fb-watchman@^2.0.0:
   integrity sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=
   dependencies:
     bser "^2.0.0"
-
-fbjs@^0.8.9:
-  version "0.8.17"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
-  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.18"
 
 figgy-pudding@^3.5.1:
   version "3.5.1"
@@ -6598,7 +6580,7 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-isomorphic-fetch@2.2.1, isomorphic-fetch@^2.1.1:
+isomorphic-fetch@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
   integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
@@ -7668,7 +7650,7 @@ long@~3:
   resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
   integrity sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -8077,23 +8059,6 @@ mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdi
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
-
-moment-timezone@0.5.13:
-  version "0.5.13"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.13.tgz#99ce5c7d827262eb0f1f702044177f60745d7b90"
-  integrity sha1-mc5cfYJyYusPH3AgRBd/YHRde5A=
-  dependencies:
-    moment ">= 2.9.0"
-
-moment@2.19.3:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.3.tgz#bdb99d270d6d7fda78cc0fbace855e27fe7da69f"
-  integrity sha1-vbmdJw1tf9p4zA+6zoVeJ/59pp8=
-
-"moment@>= 2.9.0":
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
-  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 morgan@^1.8.2:
   version "1.9.1"
@@ -9820,13 +9785,6 @@ promise@8.0.3:
   dependencies:
     asap "~2.0.6"
 
-promise@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
-  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
-  dependencies:
-    asap "~2.0.3"
-
 prompts@^2.0.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.2.1.tgz#f901dd2a2dfee080359c0e20059b24188d75ad35"
@@ -9834,14 +9792,6 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.3"
-
-prop-types@15.5.10:
-  version "15.5.10"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
-  integrity sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
 
 prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
@@ -10168,15 +10118,6 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
-
-react-live-clock@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/react-live-clock/-/react-live-clock-3.1.0.tgz#172ea798f450e9f538a9e03252230b4595ddde86"
-  integrity sha512-oysXonS/8rOAIz5XDGT2kag1/W9xnofGSglN8zPN0OLKmqnGHUMtyLsn+De85hmOo/LgBDm7d6ae4IHQVDk3Og==
-  dependencies:
-    moment "2.19.3"
-    moment-timezone "0.5.13"
-    prop-types "15.5.10"
 
 react-modal@^3.10.1:
   version "3.10.1"
@@ -11015,7 +10956,7 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4, setimmediate@^1.0.5:
+setimmediate@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
@@ -12031,11 +11972,6 @@ typescript@^3.6.3:
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
   integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
-
-ua-parser-js@^0.7.18:
-  version "0.7.20"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.20.tgz#7527178b82f6a62a0f243d1f94fd30e3e3c21098"
-  integrity sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==
 
 uglify-js@3.4.x:
   version "3.4.10"


### PR DESCRIPTION
### Summary

Last time I tried to add more snapshot tests to increase the test coverage of samwise. The journey stops at `FutureView` because it uses `new Date()` all over the place. Using `new Date()` prevents effective snapshot testing because a snapshot taken on date A will fail on date B.

Unifying the usage of current time is a necessary step to solve the issue. If we can shield all usage of current time behind a framework, then we can easily dig some hole in the framework for overriding the system time with our hardcoded time for deterministic testing, as shown in this diff.

Unifying the usage also has another advantage: when we plan to support more specific time like `2019-10-30 17:00` in the future, we don't have to look all over the codebase to hunt down the usage of `new Date()` because it has already be resolved when we are pushing more deterministic time.

Surprisingly, it has the third advantage: now we can get rid of `react-live-clock` which does not have a typescript type definition. One less eslint warning!

This diff does not plan to solve all problems. More practices are left to our amazing members!

### Test Plan

- Added snapshot tests for the entire FutureView
- Manual Test: open the page, change your system time, now the live clock and future view layout should change