### PR TITLE
Search Box Optimization

### DIFF
--- a/frontend/src/components/TitleBar/Tags/ClassTagAdder.tsx
+++ b/frontend/src/components/TitleBar/Tags/ClassTagAdder.tsx
@@ -15,6 +15,7 @@ type SimpleCourse = {
   readonly courseNumber: string;
   readonly title: string;
   readonly classId: string;
+  readonly noSpaceName: string;
 };
 
 type Props = { readonly fuse: Fuse<SimpleCourse> | null };
@@ -36,7 +37,7 @@ function getCourseOptions(courseMap: Map<string, Course[]>): SimpleCourse[] {
       const id = `${classId} ${subject} ${courseNumber}`;
       const name = `${subject} ${courseNumber}: ${title}`;
       courseOptions.push({
-        key: i, value: name, subject, courseNumber, title, classId: id,
+        key: i, value: name, subject, courseNumber, title, classId: id, noSpaceName: name.replace(/[^a-zA-Z\d]/, ''),
       });
       i += 1;
     });
@@ -54,6 +55,7 @@ const fuseConfigs = {
     'subject', // useful for finding a list of all [subject] classes
     'courseNumber', // useful if the student just type the course number
     'title', // useful if the student just type the name
+    'noSpaceName', // useful if the student types the course code without a space (ex: "CS2112")
   ],
   location: 0, // since we have customized the stuff to search, we can just start at beginning.
   threshold: 0.2, // higher the threshold, more stuff will be matched.

--- a/frontend/src/components/Util/SearchBox/index.tsx
+++ b/frontend/src/components/Util/SearchBox/index.tsx
@@ -22,8 +22,12 @@ export default <T extends FuseItem>(
 
   const onSearchChange = (event: ChangeEvent<HTMLInputElement>): void => {
     const input = event.currentTarget.value;
-    const newResults = fuse.search(input);
-    setState({ searchInput: input, searchResults: newResults });
+    if (input.length > 2) {
+      const newResults = fuse.search(input);
+      setState({ searchInput: input, searchResults: newResults });
+    } else {
+      setState({ searchInput: input, searchResults: [] });
+    }
   };
 
   const onResultSelected = (item: T): void => {


### PR DESCRIPTION
### Summary <!-- Required -->

Make the search box much faster by only searching when at least 3 characters have been typed.

This is the same behavior as exhibited on the Cornell Course Roster.

On my development machine, this change entirely eliminated all lag when searching courses, down from the nearly two second delay on the current staging site when typing in a class name.

This is particularly nice because the nature of React means that until the search completes, the search input DOM doesn't actually update, which means users don't see the characters they've typed for multiple seconds. That's fixed.

Also updated the class search box to use the name of the course with all whitespace and non-alphanumeric characters stripped as one of the keys. This helps with students searching class names but getting the spacing wrong (for example searching `CS2112` instead of `CS 2112`). In theory the fuzzy searching should fix that, but the issue is that when the user types very few characters, fuse doesn't recognize the mismatch with high enough confidence to display it as a hit. This coupled with the new restrictions on not searching until at least 3 characters are typed caused some searches to not display until 5 or more characters in, which seemed too unresponsive to let slide. This solution seems to fix it.

### Test Plan <!-- Required -->

Tried searching a variety of classes. Marveled at the speed.