### PR TITLE
Try to unbreak CI staging deploy

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -42,26 +42,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - name: Checkout gh-pages Branch
-        uses: actions/checkout@master
-        with:
-          ref: gh-pages
-      - name: Purge Old Static Assets
-        run: git rm -rf ${{ github.event.number }} || echo "Nothing to remove"
       - name: Download Built Static Assets
         uses: actions/download-artifact@master
         with:
           name: built-frontend-assets
           path: ${{ github.event.number }}
-      - name: Commit and Push New Static Assets
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v2.5.0
         env:
-          ACCESS_TOKEN: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
-        run: |
-          git config user.name "deployment-bot"
-          git config user.email "hello@cornelldti.org"
-          git add .
-          git commit -m "Deploy for ${{ github.event.number }}" || echo "Nothing to commit."
-          git push "https://${ACCESS_TOKEN}@github.com/cornell-dti/samwise.git" || echo "Nothing to push."
+          PUBLISH_DIR: '.'
+          PERSONAL_TOKEN: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
+        with:
+          keepFiles: true
       - name: Comment on Pull Request
         uses: actions/github-script@0.2.0
         with:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -51,6 +51,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v2.5.0
         env:
           PUBLISH_DIR: '.'
+          PUBLISH_BRANCH: gh-pages
           PERSONAL_TOKEN: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
         with:
           keepFiles: true


### PR DESCRIPTION
### Summary <!-- Required -->

Using this well-maintained github action instead of writing git magic on our own:
https://github.com/peaceiris/actions-gh-pages

If you see the source of that github action, it does some more sophisticated magic than mine original git scripts, which is probably the reason why using this action fixed the problem.

### Test Plan <!-- Required -->

If it works, `gh-pages` branch will show deployment status again.

It works: https://github.com/cornell-dti/samwise/commit/80716749153d3cc74ad26f87bbb96d99019baa45
See the green check. Previous commits do not have that.