### PR TITLE
Fix off screen save button in FutureView editor

### DIFF
--- a/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.module.css
+++ b/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.module.css
@@ -4,6 +4,8 @@
   z-index: 8;
   box-shadow: 0 5px 12px 0 rgba(0, 0, 0, 0.3);
   transition: width 0.1s linear;
+  max-height: 400px;
+  overflow-y: auto;
 }
 
 .BackgroundBlocker {

--- a/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
@@ -49,12 +49,12 @@ const updateFloatingEditorPosition = (
     }
   }
 
-  editorPosDiv.style.overflowY = `auto`;
+  editorPosDiv.style.overflowY = 'auto';
   editorPosDiv.style.top = `${posTop}px`;
   editorPosDiv.style.left = posLeft === undefined ? 'initial' : `${posLeft}px`;
   editorPosDiv.style.right = posRight === undefined ? 'initial' : `${posRight}px`;
   editorPosDiv.style.width = '300px';
-  editorPosDiv.style.maxHeight = `400px`;
+  editorPosDiv.style.maxHeight = '400px';
 };
 
 type OwnProps = {

--- a/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
@@ -48,10 +48,13 @@ const updateFloatingEditorPosition = (
       throw new Error('Bad floating position!');
     }
   }
+
+  editorPosDiv.style.overflowY = `auto`;
   editorPosDiv.style.top = `${posTop}px`;
   editorPosDiv.style.left = posLeft === undefined ? 'initial' : `${posLeft}px`;
   editorPosDiv.style.right = posRight === undefined ? 'initial' : `${posRight}px`;
   editorPosDiv.style.width = '300px';
+  editorPosDiv.style.maxHeight = `400px`;
 };
 
 type OwnProps = {

--- a/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
@@ -49,12 +49,10 @@ const updateFloatingEditorPosition = (
     }
   }
 
-  editorPosDiv.style.overflowY = 'auto';
   editorPosDiv.style.top = `${posTop}px`;
   editorPosDiv.style.left = posLeft === undefined ? 'initial' : `${posLeft}px`;
   editorPosDiv.style.right = posRight === undefined ? 'initial' : `${posRight}px`;
   editorPosDiv.style.width = '300px';
-  editorPosDiv.style.maxHeight = '400px';
 };
 
 type OwnProps = {


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

Added overflowY auto along with a maxHeight style to the editorPosDiv in future view which allows the user to scroll and see an unlimited number of subtasks, and be able to click the save button even with a large number of subtasks.

- [x] fixed issue #327 

### Test Plan <!-- Required -->

![efWeTLK](https://user-images.githubusercontent.com/7517829/67626942-0f8cb680-f821-11e9-8bf4-e2445756854f.gif)


<!-- Provide screenshots or point out the additional unit tests -->

