### PR TITLE
Repeat task today

### DIFF
--- a/frontend/src/components/TaskCreator/DatePicker.tsx
+++ b/frontend/src/components/TaskCreator/DatePicker.tsx
@@ -357,8 +357,9 @@ export default function DatePicker(props: Props): ReactElement {
     } else {
       // TODO once database support exists, replace this with number of occurrances
       endDate = new Date(new Date(
-        new Date().getTime() + 1000 * 60 * 60 * 24 * 7 * internalDate.repeatEnd.weeks,
-      ).setHours(0, 0, 0, 0));
+        new Date().getTime() + 1000 * 60 * 60 * 24 * 7 * internalDate.repeatEnd.weeks
+        - 1000 * 60 * 60 * 24,
+      ).setHours(23, 59, 59, 999));
     }
 
     const repData: RepeatMetaData = {

--- a/frontend/src/components/TaskCreator/DatePicker.tsx
+++ b/frontend/src/components/TaskCreator/DatePicker.tsx
@@ -1,8 +1,9 @@
 import React, { ReactElement, SyntheticEvent, ChangeEvent } from 'react';
 import Calendar from 'react-calendar';
+import { useTodayLastSecondTime, useTodayFirstSecondTime } from 'hooks/time-hook';
 import styles from './Picker.module.css';
 import dateStyles from './DatePicker.module.css';
-import { date2String } from '../../util/datetime-util';
+import { date2String, getDateAfterXWeeks } from '../../util/datetime-util';
 import { NONE_TAG } from '../../util/tag-util';
 import { RepeatMetaData } from '../../store/store-types';
 import SamwiseIcon from '../UI/SamwiseIcon';
@@ -37,6 +38,9 @@ export default function DatePicker(props: Props): ReactElement {
   const {
     date, opened, datePicked, onDateChange, onPickerOpened, onClearPicker,
   } = props;
+  const todayFirstSecond = useTodayFirstSecondTime();
+  const todayLastSecond = useTodayLastSecondTime();
+
   // Controllers
   const clickPicker = (): void => { onPickerOpened(); };
   const reset = (e: SyntheticEvent<HTMLElement>): void => {
@@ -356,14 +360,11 @@ export default function DatePicker(props: Props): ReactElement {
       endDate = internalDate.repeatEnd.date;
     } else {
       // TODO once database support exists, replace this with number of occurrances
-      endDate = new Date(new Date(
-        new Date().getTime() + 1000 * 60 * 60 * 24 * 7 * internalDate.repeatEnd.weeks
-        - 1000 * 60 * 60 * 24,
-      ).setHours(23, 59, 59, 999));
+      endDate = getDateAfterXWeeks(todayLastSecond, internalDate.repeatEnd.weeks);
     }
 
     const repData: RepeatMetaData = {
-      startDate: new Date(new Date().setHours(0, 0, 0, 0)),
+      startDate: todayFirstSecond,
       endDate,
       pattern: { type: 'WEEKLY', bitSet },
     };

--- a/frontend/src/hooks/time-hook.ts
+++ b/frontend/src/hooks/time-hook.ts
@@ -93,3 +93,15 @@ export const useTodayLastSecondTime = (): Date => {
   date.setHours(23, 59, 59);
   return date;
 };
+
+/**
+ * A react state hooks that returns the current date every one day.
+ * It will cause a re-render when a new value is returned.
+ *
+ * @returns today at 00:00:00 (in user's browser's reported timezone) as a date object.
+ */
+export const useTodayFirstSecondTime = (): Date => {
+  const date = new Date(useDate());
+  date.setHours(0, 0, 0);
+  return date;
+};

--- a/frontend/src/util/datetime-util.test.ts
+++ b/frontend/src/util/datetime-util.test.ts
@@ -1,4 +1,4 @@
-import { day2String, isToday, getTodayAtZeroAM } from './datetime-util';
+import { day2String, isToday, getTodayAtZeroAM, getDateAfterXWeeks } from './datetime-util';
 
 it('day2String works', () => {
   expect(day2String(0)).toBe('SUN');
@@ -20,4 +20,10 @@ it('getTodayAtZeroAM works', () => {
   expect(t.getMinutes()).toBe(0);
   expect(t.getSeconds()).toBe(0);
   expect(t.getMilliseconds()).toBe(0);
+});
+
+it('getDateAfterXWeeks works', () => {
+  const t1 = new Date(Date.UTC(2019, 11, 1));
+  const expected = new Date(Date.UTC(2019, 11, 14));
+  expect(getDateAfterXWeeks(t1, 2).getTime()).toBe(expected.getTime());
 });

--- a/frontend/src/util/datetime-util.ts
+++ b/frontend/src/util/datetime-util.ts
@@ -89,3 +89,15 @@ export function getDateWithDateString(date: Date | null, dateString: string): Da
   }
   return newDate;
 }
+
+/**
+ * returns the same date x weeks - 1 day later
+ * example: monday oct 1, 2 weeks later returnes sunday the 14th
+ *
+ * @param date
+ * @param x
+ */
+export function getDateAfterXWeeks(date: Date, x: number): Date {
+  const oneDay = 1000 * 60 * 60 * 24;
+  return new Date(date.getTime() + oneDay * 7 * x - oneDay);
+}

--- a/frontend/src/util/task-util.ts
+++ b/frontend/src/util/task-util.ts
@@ -172,7 +172,7 @@ export function dateMatchRepeats(
     return false;
   }
   if (endDate instanceof Date) {
-    if (date >= endDate) {
+    if (date > endDate) {
       // after the end
       return false;
     }


### PR DESCRIPTION
### Summary <!-- Required -->
When creating a task to add to firebase/render, create the task start time as 00:00:00 and the end time 23:59:59. This solves the issues with respect to inclusivity and exclusivity on either end of the repeating task. 

- [x] fixed #341

### Test Plan <!-- Required -->
![image](https://user-images.githubusercontent.com/33106747/67712614-b8125600-f99a-11e9-8f19-a1859599f222.png)
![image](https://user-images.githubusercontent.com/33106747/67712629-bfd1fa80-f99a-11e9-9ed8-b97fea6b45b0.png)

### Notes <!-- Optional -->

Semantics can be improved/made more clear for "stops after x weeks".
Additionally fixes an issue that was not posted: creating repeating tasks does not exclude the first day after the repeat task duration when rendering the tasks. 