### PR TITLE
Implement mode-indicator

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import ModeIndicator from 'components/UI/ModeIndicator';
 import styles from './App.module.css';
 import AllComplete from './components/Popup/AllComplete';
 import Onboard from './components/TitleBar/Onboarding/Onboard';
@@ -13,6 +14,7 @@ import { ModalsContainer } from './components/Util/Modals';
 export default function App(): ReactElement {
   return (
     <>
+      <ModeIndicator />
       <Onboard />
       <ModalsContainer />
       <TitleBar />

--- a/frontend/src/components/UI/ModeIndicator.module.css
+++ b/frontend/src/components/UI/ModeIndicator.module.css
@@ -1,0 +1,9 @@
+.Indicator {
+  position: fixed;
+  z-index: 1000;
+  background: #f44336;
+  padding: 5px;
+  color: white;
+  top: 0;
+  left: 0;
+}

--- a/frontend/src/components/UI/ModeIndicator.test.tsx
+++ b/frontend/src/components/UI/ModeIndicator.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import ModeIndicator, { ConfigurableModeIndicator } from './ModeIndicator';
+
+it('ConfigurableModeIndicator DEV matches snapshot.', () => {
+  const tree = renderer.create(<ConfigurableModeIndicator mode="DEV" />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('ConfigurableModeIndicator STAGING matches snapshot.', () => {
+  const tree = renderer.create(<ConfigurableModeIndicator mode="STAGING" />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('ConfigurableModeIndicator PROD matches snapshot.', () => {
+  const tree = renderer.create(<ConfigurableModeIndicator mode="PROD" />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('ModeIndicator(DEV) matches snapshot.', () => {
+  const tree = renderer.create(<ModeIndicator />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/frontend/src/components/UI/ModeIndicator.tsx
+++ b/frontend/src/components/UI/ModeIndicator.tsx
@@ -1,0 +1,17 @@
+import React, { ReactElement } from 'react';
+import systemMode, { Mode } from 'util/mode-util';
+import styles from './ModeIndicator.module.css';
+
+type Props = { readonly mode: Mode };
+
+/**
+ * A mode indicator on the top-left corner to indicate whether a page is for DEV, STAGING or PROD.
+ */
+export const ConfigurableModeIndicator = ({ mode }: Props): ReactElement | null => {
+  if (mode === 'PROD') {
+    return null;
+  }
+  return <div className={styles.Indicator}>{mode}</div>;
+};
+
+export default (): ReactElement | null => <ConfigurableModeIndicator mode={systemMode} />;

--- a/frontend/src/components/UI/__snapshots__/ModeIndicator.test.tsx.snap
+++ b/frontend/src/components/UI/__snapshots__/ModeIndicator.test.tsx.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConfigurableModeIndicator DEV matches snapshot. 1`] = `
+<div
+  className="Indicator"
+>
+  DEV
+</div>
+`;
+
+exports[`ConfigurableModeIndicator PROD matches snapshot. 1`] = `null`;
+
+exports[`ConfigurableModeIndicator STAGING matches snapshot. 1`] = `
+<div
+  className="Indicator"
+>
+  STAGING
+</div>
+`;
+
+exports[`ModeIndicator(DEV) matches snapshot. 1`] = `
+<div
+  className="Indicator"
+>
+  DEV
+</div>
+`;

--- a/frontend/src/util/mode-util.test.ts
+++ b/frontend/src/util/mode-util.test.ts
@@ -1,0 +1,5 @@
+import mode from './mode-util';
+
+it('testing is always done in DEV.', () => {
+  expect(mode).toBe('DEV');
+});

--- a/frontend/src/util/mode-util.ts
+++ b/frontend/src/util/mode-util.ts
@@ -1,0 +1,14 @@
+/**
+ * The utility file to manage all modes.
+ */
+
+export type Mode = 'DEV' | 'STAGING' | 'PROD';
+
+const mode: Mode = (() => {
+  if (process.env.NODE_ENV === 'production') {
+    return process.env.REACT_APP_IS_STAGING !== 'true' ? 'PROD' : 'STAGING';
+  }
+  return 'DEV';
+})();
+
+export default mode;


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request implements the mode indicator for different environments.
I also take the opportunity to unify some of our environment detection code.

### Test Plan <!-- Required -->

Dev: `yarn start`
<img width="1089" alt="dev" src="https://user-images.githubusercontent.com/4290500/68503570-2d9ae380-0231-11ea-86c6-9d5efdc43dda.png">

Staging: `yarn build:stage && serve build/`
<img width="1089" alt="staging" src="https://user-images.githubusercontent.com/4290500/68503578-31c70100-0231-11ea-8a8e-e1168c26607d.png">

Prod: `yarn build && serve build/`
<img width="1089" alt="prod" src="https://user-images.githubusercontent.com/4290500/68503588-3a1f3c00-0231-11ea-8f3e-e1c55d0ad83b.png">
