### PR TITLE
Bring back autosave

### DIFF
--- a/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
@@ -101,7 +101,7 @@ function FloatingTaskEditor(
       initialTask,
       getDateWithDateString(mainTask.date instanceof Date ? mainTask.date : null, taskAppearedDate),
     ),
-    onSave: closePopup,
+    onSaveClicked: closePopup,
   };
 
   return (

--- a/frontend/src/components/Util/TaskEditors/InlineTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/InlineTaskEditor.tsx
@@ -26,7 +26,7 @@ export default function InlineTaskEditor(
   const onBlur = (): void => setDisabled(true);
   const actions = {
     removeTask: () => removeTaskWithPotentialPrompt(original, null),
-    onSave: onBlur,
+    onSaveClicked: onBlur,
   };
   return (
     <TaskEditor

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/MainTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/MainTaskEditor.tsx
@@ -1,4 +1,4 @@
-import React, { KeyboardEvent, ReactElement, SyntheticEvent, useState } from 'react';
+import React, { KeyboardEvent, ReactElement, SyntheticEvent } from 'react';
 import styles from './index.module.css';
 import CheckBox from '../../../UI/CheckBox';
 import SamwiseIcon from '../../../UI/SamwiseIcon';
@@ -19,11 +19,6 @@ type Props = NameCompleteInFocus & {
   readonly onPressEnter: (id: 'main-task' | number) => void;
 };
 
-type NameCache = {
-  readonly cached: string;
-  readonly originalPropsName: string;
-};
-
 const deleteIconClass = [styles.TaskEditorIcon, styles.TaskEditorIconLeftPad].join(' ');
 
 function MainTaskEditor(
@@ -31,10 +26,6 @@ function MainTaskEditor(
     id, taskDate, dateAppeared, name, complete, inFocus, onChange, onRemove, onPressEnter,
   }: Props,
 ): ReactElement {
-  const [nameCache, setNameCache] = useState<NameCache>({ cached: name, originalPropsName: name });
-  if (name !== nameCache.originalPropsName) {
-    setNameCache({ cached: name, originalPropsName: name });
-  }
   const replaceDateForFork = taskDate == null
     ? getDateWithDateString(taskDate, dateAppeared)
     : null;
@@ -51,13 +42,7 @@ function MainTaskEditor(
   const onInputChange = (event: SyntheticEvent<HTMLInputElement>): void => {
     event.stopPropagation();
     const newValue = event.currentTarget.value;
-    setNameCache((prev) => ({ ...prev, cached: newValue }));
-  };
-  const onBlur = (event: SyntheticEvent<HTMLInputElement>): void => {
-    event.stopPropagation();
-    if (name !== nameCache.cached) {
-      onChange({ name: nameCache.cached });
-    }
+    onChange({ name: newValue });
   };
 
   return (
@@ -73,9 +58,7 @@ function MainTaskEditor(
         className={complete
           ? styles.TaskEditorStrikethrough : styles.TaskEditorFlexibleInput}
         placeholder="Main Task"
-        value={nameCache.cached}
-        onBlur={onBlur}
-        onMouseLeave={onBlur}
+        value={name}
         onKeyDown={onKeyDown}
         onChange={onInputChange}
       />

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/NewSubTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/NewSubTaskEditor.tsx
@@ -12,7 +12,7 @@ export default function NewSubTaskEditor({ onEnter, needToBeFocused, type }: Pro
   const onInputChange = (event: SyntheticEvent<HTMLInputElement>): void => {
     event.stopPropagation();
     const newSubTaskValue: string = event.currentTarget.value;
-    if (type !== 'ONE_TIME' && newSubTaskValue.length > 0) {
+    if (newSubTaskValue.length > 0) {
       onEnter(newSubTaskValue);
     } else {
       setSubTaskValue(newSubTaskValue);

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/NewSubTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/NewSubTaskEditor.tsx
@@ -7,7 +7,7 @@ type Props = {
   readonly type: 'MASTER_TEMPLATE' | 'ONE_TIME';
 };
 
-export default function NewSubTaskEditor({ onEnter, needToBeFocused, type }: Props): ReactElement {
+export default function NewSubTaskEditor({ onEnter, needToBeFocused }: Props): ReactElement {
   const [subTaskValue, setSubTaskValue] = useState<string>('');
   const onInputChange = (event: SyntheticEvent<HTMLInputElement>): void => {
     event.stopPropagation();

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/NewSubTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/NewSubTaskEditor.tsx
@@ -21,9 +21,7 @@ export default function NewSubTaskEditor({ onEnter, needToBeFocused, type }: Pro
   const onKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
     if ((event.key === 'Enter' || event.key === 'Tab') && subTaskValue !== '') {
       onEnter(subTaskValue);
-      if (type === 'ONE_TIME') {
-        setSubTaskValue('');
-      }
+      setSubTaskValue('');
     }
   };
 

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/NewSubTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/NewSubTaskEditor.tsx
@@ -1,28 +1,29 @@
-import React, { KeyboardEvent, ReactElement, SyntheticEvent, useEffect, useRef } from 'react';
+import React, { KeyboardEvent, ReactElement, SyntheticEvent, useEffect, useRef, useState } from 'react';
 import styles from './index.module.css';
 
 type Props = {
-  readonly onChange: (change: string) => void;
+  readonly onEnter: (change: string) => void;
   readonly needToBeFocused: boolean;
-  readonly afterFocusedCallback: () => void;
-  readonly onPressEnter: () => void;
+  readonly type: 'MASTER_TEMPLATE' | 'ONE_TIME';
 };
 
-export default function NewSubTaskEditor(
-  {
-    onChange, needToBeFocused, afterFocusedCallback, onPressEnter,
-  }: Props,
-): ReactElement {
+export default function NewSubTaskEditor({ onEnter, needToBeFocused, type }: Props): ReactElement {
+  const [subTaskValue, setSubTaskValue] = useState<string>('');
   const onInputChange = (event: SyntheticEvent<HTMLInputElement>): void => {
     event.stopPropagation();
-    const newSubTaskValue: string = event.currentTarget.value.trim();
-    if (newSubTaskValue.length > 0) {
-      onChange(newSubTaskValue);
+    const newSubTaskValue: string = event.currentTarget.value;
+    if (type !== 'ONE_TIME' && newSubTaskValue.length > 0) {
+      onEnter(newSubTaskValue);
+    } else {
+      setSubTaskValue(newSubTaskValue);
     }
   };
   const onKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
-    if (event.key === 'Enter' || event.key === 'Tab') {
-      onPressEnter();
+    if ((event.key === 'Enter' || event.key === 'Tab') && subTaskValue !== '') {
+      onEnter(subTaskValue);
+      if (type === 'ONE_TIME') {
+        setSubTaskValue('');
+      }
     }
   };
 
@@ -33,7 +34,6 @@ export default function NewSubTaskEditor(
       const currentElement = editorRef.current;
       if (currentElement != null) {
         currentElement.focus();
-        afterFocusedCallback();
       }
     }
   });
@@ -46,7 +46,7 @@ export default function NewSubTaskEditor(
         ref={editorRef}
         className={styles.TaskEditorFlexibleInput}
         placeholder="Add a Subtask"
-        value=""
+        value={subTaskValue}
         onChange={onInputChange}
         onKeyDown={onKeyDown}
       />

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/NewSubTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/NewSubTaskEditor.tsx
@@ -1,27 +1,26 @@
-import React, { KeyboardEvent, ReactElement, SyntheticEvent, useEffect, useRef, useState } from 'react';
+import React, { KeyboardEvent, ReactElement, SyntheticEvent, useEffect, useRef } from 'react';
 import styles from './index.module.css';
 
 type Props = {
-  readonly onEnter: (change: string) => void;
+  readonly onFirstType: (change: string) => void;
+  readonly onPressEnter: () => void;
   readonly needToBeFocused: boolean;
   readonly type: 'MASTER_TEMPLATE' | 'ONE_TIME';
 };
 
-export default function NewSubTaskEditor({ onEnter, needToBeFocused }: Props): ReactElement {
-  const [subTaskValue, setSubTaskValue] = useState<string>('');
+export default function NewSubTaskEditor(
+  { onFirstType, onPressEnter, needToBeFocused }: Props,
+): ReactElement {
   const onInputChange = (event: SyntheticEvent<HTMLInputElement>): void => {
     event.stopPropagation();
-    const newSubTaskValue: string = event.currentTarget.value;
+    const newSubTaskValue: string = event.currentTarget.value.trim();
     if (newSubTaskValue.length > 0) {
-      onEnter(newSubTaskValue);
-    } else {
-      setSubTaskValue(newSubTaskValue);
+      onFirstType(newSubTaskValue);
     }
   };
   const onKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
-    if ((event.key === 'Enter' || event.key === 'Tab') && subTaskValue !== '') {
-      onEnter(subTaskValue);
-      setSubTaskValue('');
+    if (event.key === 'Enter' || event.key === 'Tab') {
+      onPressEnter();
     }
   };
 
@@ -44,7 +43,7 @@ export default function NewSubTaskEditor({ onEnter, needToBeFocused }: Props): R
         ref={editorRef}
         className={styles.TaskEditorFlexibleInput}
         placeholder="Add a Subtask"
-        value={subTaskValue}
+        value=""
         onChange={onInputChange}
         onKeyDown={onKeyDown}
       />

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/OneSubTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/OneSubTaskEditor.tsx
@@ -3,7 +3,8 @@ import React, {
   ReactElement,
   SyntheticEvent,
   useEffect,
-  useRef, useState,
+  useRef,
+  useState,
 } from 'react';
 import styles from './index.module.css';
 import CheckBox from '../../../UI/CheckBox';

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/OneSubTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/OneSubTaskEditor.tsx
@@ -4,7 +4,6 @@ import React, {
   SyntheticEvent,
   useEffect,
   useRef,
-  useState,
 } from 'react';
 import styles from './index.module.css';
 import CheckBox from '../../../UI/CheckBox';
@@ -25,8 +24,6 @@ type Props = {
   readonly onPressEnter: (id: 'main-task' | number) => void;
 };
 
-type NameCache = { readonly cached: string; readonly originalPropsName: string };
-
 const className = [styles.TaskEditorFlexibleContainer, styles.TaskEditorSubtaskCheckBox].join(' ');
 const deleteIconClass = [styles.TaskEditorIcon, styles.TaskEditorIconLeftPad].join(' ');
 
@@ -43,13 +40,6 @@ function OneSubTaskEditor(
     onPressEnter,
   }: Props,
 ): ReactElement {
-  const [nameCache, setNameCache] = useState<NameCache>({
-    cached: subTask.name,
-    originalPropsName: subTask.name,
-  });
-  if (subTask.name !== nameCache.originalPropsName) {
-    setNameCache({ cached: subTask.name, originalPropsName: subTask.name });
-  }
   const replaceDateForFork = taskDate == null
     ? getDateWithDateString(taskDate, dateAppeared)
     : null;
@@ -71,13 +61,10 @@ function OneSubTaskEditor(
   const onInputChange = (event: SyntheticEvent<HTMLInputElement>): void => {
     event.stopPropagation();
     const newValue = event.currentTarget.value;
-    setNameCache((prev) => ({ ...prev, cached: newValue }));
+    editThisSubTask(subTask.id, { name: newValue });
   };
   const onBlur = (event: SyntheticEvent<HTMLInputElement>): void => {
     event.stopPropagation();
-    if (subTask.name !== nameCache.cached) {
-      editThisSubTask(subTask.id, { name: nameCache.cached });
-    }
   };
 
   const editorRef = useRef<HTMLInputElement | null>(null);
@@ -105,7 +92,7 @@ function OneSubTaskEditor(
         className={subTask.complete || mainTaskComplete
           ? styles.TaskEditorStrikethrough : styles.TaskEditorFlexibleInput}
         placeholder="Your Subtask"
-        value={nameCache.cached}
+        value={subTask.name}
         ref={editorRef}
         onKeyDown={onKeyDown}
         onChange={onInputChange}

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -257,7 +257,8 @@ function TaskEditor(
           style={newSubTaskDisabled === true ? { maxHeight: 0 } : undefined}
         >
           <NewSubTaskEditor
-            onEnter={handleCreatedNewSubtask}
+            onFirstType={handleCreatedNewSubtask}
+            onPressEnter={onSaveButtonClicked}
             needToBeFocused={subTaskToFocus === 'new-subtask'}
             type={type}
           />

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -3,7 +3,7 @@
 // These components' API are NOT guaranteed to be stable.
 // You should only use this component from the outside.
 
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { MainTask, State, SubTask, Tag } from 'store/store-types';
 import OverdueAlert from 'components/UI/OverdueAlert';
@@ -20,6 +20,7 @@ import OneSubTaskEditor from './OneSubTaskEditor';
 import { CalendarPosition } from '../editors-types';
 import useTaskDiffReducer, { diffIsEmpty, Diff } from './task-diff-reducer';
 
+
 type DefaultProps = {
   readonly displayGrabber?: boolean;
   readonly className?: string;
@@ -33,7 +34,7 @@ type Actions = {
   // remove the entire task to be edited.
   readonly removeTask: () => void;
   // save all the edits.
-  readonly onSave: () => void;
+  readonly onSaveClicked: () => void;
 };
 type OwnProps = DefaultProps & {
   readonly id: string;
@@ -90,7 +91,7 @@ function TaskEditor(
   } = useTaskDiffReducer(initMainTask, initSubTasks);
 
   const { name, tag, date, complete, inFocus } = mainTask;
-  const { removeTask, onSave } = actions;
+  const { removeTask, onSaveClicked } = actions;
 
   const [subTaskToFocus, setSubTaskToFocus] = useState<TaskToFocus>(null);
 
@@ -99,11 +100,13 @@ function TaskEditor(
       onBlur();
     }
   };
-  const onSaveClicked = (): void => {
+  const onSave = (): boolean => {
+    if (diffIsEmpty(diff)) {
+      return false;
+    }
     if (type === 'ONE_TIME') {
       editTaskWithDiff(id, 'EDITING_ONE_TIME_TASK', diff);
-      onSave();
-      return;
+      return true;
     }
     if (taskAppearedDate === null) {
       confirmRepeatedTaskEditMaster().then((saveChoice) => {
@@ -143,12 +146,17 @@ function TaskEditor(
         }
       });
     }
-    onSave();
+    return true;
+  };
+  const onSaveButtonClicked = (): void => {
+    if (onSave() && type !== 'ONE_TIME') {
+      onSaveClicked();
+    }
   };
 
   // called when the user types in the first char in the new subtask box. We need to shift now.
-  const handleNewSubTaskFirstType = (firstTypedValue: string): void => {
-    const order = subTasks.reduce((acc, s) => Math.max(acc, s.order), 0) + 1;
+  const handleCreatedNewSubtask = (firstTypedValue: string): void => {
+    const order = subTasks.reduce((acc, s) => Math.max(acc, s.order), 0);
     dispatchAddSubTask({
       order, name: firstTypedValue, complete: false, inFocus: newSubTaskAutoFocused === true,
     });
@@ -177,7 +185,6 @@ function TaskEditor(
       setSubTaskToFocus('new-subtask');
     }
   };
-  const clearNeedToFocus = (): void => setSubTaskToFocus(null);
   if (taskAppearedDate === null) {
     throw new Error('Impossible');
   }
@@ -188,6 +195,16 @@ function TaskEditor(
     : { backgroundColor };
   const actualClassName = className == null
     ? styles.TaskEditor : `${styles.TaskEditor} ${className}`;
+
+  useEffect(() => {
+    const intervalID = setInterval(() => {
+      if (type === 'ONE_TIME') {
+        onSave();
+      }
+    }, 500);
+    return () => clearInterval(intervalID);
+  }, [type, onSave]);
+
   return (
     <form
       className={actualClassName}
@@ -230,7 +247,6 @@ function TaskEditor(
             dateAppeared={taskAppearedDate}
             mainTaskComplete={complete}
             needToBeFocused={subTaskToFocus === subTask.order}
-            afterFocusedCallback={clearNeedToFocus}
             editThisSubTask={dispatchEditSubTask}
             removeSubTask={dispatchDeleteSubTask}
             onPressEnter={pressEnterHandler}
@@ -241,22 +257,25 @@ function TaskEditor(
           style={newSubTaskDisabled === true ? { maxHeight: 0 } : undefined}
         >
           <NewSubTaskEditor
-            onChange={handleNewSubTaskFirstType}
+            onEnter={handleCreatedNewSubtask}
             needToBeFocused={subTaskToFocus === 'new-subtask'}
-            afterFocusedCallback={clearNeedToFocus}
-            onPressEnter={onSaveClicked}
+            type={type}
           />
         </div>
       </div>
-      <div
-        className={styles.SaveButtonRow}
-        style={diffIsEmpty(diff) ? { maxHeight: 0, padding: 0 } : undefined}
-      >
-        <span className={styles.TaskEditorFlexiblePadding} />
-        <div role="presentation" className={styles.SaveButton} onClick={onSaveClicked}>
-          <span className={styles.SaveButtonText}>Save</span>
-        </div>
-      </div>
+      {
+        type !== 'ONE_TIME' && (
+          <div
+            className={styles.SaveButtonRow}
+            style={diffIsEmpty(diff) ? { maxHeight: 0, padding: 0 } : undefined}
+          >
+            <span className={styles.TaskEditorFlexiblePadding} />
+            <div role="presentation" className={styles.SaveButton} onClick={onSaveButtonClicked}>
+              <span className={styles.SaveButtonText}>Save</span>
+            </div>
+          </div>
+        )
+      }
     </form>
   );
 }

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -156,7 +156,7 @@ function TaskEditor(
 
   // called when the user types in the first char in the new subtask box. We need to shift now.
   const handleCreatedNewSubtask = (firstTypedValue: string): void => {
-    const order = subTasks.reduce((acc, s) => Math.max(acc, s.order), 0);
+    const order = subTasks.reduce((acc, s) => Math.max(acc, s.order), 0) + 1;
     dispatchAddSubTask({
       order, name: firstTypedValue, complete: false, inFocus: newSubTaskAutoFocused === true,
     });

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -3,7 +3,7 @@
 // These components' API are NOT guaranteed to be stable.
 // You should only use this component from the outside.
 
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { ReactElement, useEffect, useState, useCallback } from 'react';
 import { connect } from 'react-redux';
 import { MainTask, State, SubTask, Tag } from 'store/store-types';
 import OverdueAlert from 'components/UI/OverdueAlert';
@@ -100,7 +100,7 @@ function TaskEditor(
       onBlur();
     }
   };
-  const onSave = (): boolean => {
+  const onSave = useCallback((): boolean => {
     if (diffIsEmpty(diff)) {
       return false;
     }
@@ -147,7 +147,7 @@ function TaskEditor(
       });
     }
     return true;
-  };
+  }, [date, diff, id, reset, taskAppearedDate, type]);
   const onSaveButtonClicked = (): void => {
     if (onSave() && type !== 'ONE_TIME') {
       onSaveClicked();


### PR DESCRIPTION
### Summary <!-- Required -->

![longmergerequest](https://user-images.githubusercontent.com/20008134/68563350-40710c00-041b-11ea-8ed1-4aeb5349b1db.jpeg)

Brought back autosave via a 0.5 second refresh after user adds/edits a one time task. Repeated subtask has save button which prompts whether to fork the task or edit master template.

Additionally resolved CLA problem from *John Doe* in #338 🤔

This pull request unblocks repeated task.

- [x] implemented autosave in one time task, and save button functionality in repeated task

### Test Plan <!-- Required -->

Create a one time task and focus it. Type a new subtask for that task and press enter or tab. Ensure that that subtask shows up under that task in future view like so (try adding multiple subtasks to be *really* sure). Notice that there is no save button.:

![Screen Recording 2019-11-11 at 12 02 28 AM](https://user-images.githubusercontent.com/20008134/68562524-179b4780-0418-11ea-8d26-3c0760472a45.gif)

Now try editing parts of the whole task (such as edit an existing subtask, change the date/class) ensure that these changes are propagated to the future view task.

![Screen Recording 2019-11-11 at 12 03 47 AM](https://user-images.githubusercontent.com/20008134/68562685-b3c54e80-0418-11ea-96d1-3ee5cf0f7e15.gif)

Create a repeating task and add a new subtask. Click the save button. In the modal that appears select edit all occurrences and ensure that this new subtask is added as a new subtask to all of the occurrences as so:

![Screen Recording 2019-11-11 at 12 21 11 AM 1](https://user-images.githubusercontent.com/20008134/68563106-8aa5bd80-041a-11ea-8f76-858ab8a8cc9a.gif)


