### PR TITLE
Warn against TODO/FIXME/XXX comments

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -8,6 +8,7 @@
     "ecmaFeatures": { "jsx": true }
   },
   "rules": {
+    "no-warning-comments": "warn",
     "object-curly-newline": [
       "error",
       {


### PR DESCRIPTION
### Summary

This is not intended to get rid of all of them. That's why I didn't set it to error.
However, I think we need a way to know how many TODOs there are in our codebase so that they will not be forgotten. Creating some warnings can make developers feel a little unconfortable so that they will eventually be resolved.

### Test Plan

`yarn lint`. You will see

```
/path/to/samwise/frontend/src/components/TaskCreator/DatePicker.tsx
  362:7  warning  Unexpected 'todo' comment  no-warning-comments
```

You can also see it in CI.