### PR TITLE
Improve performance for useMappedWindowSize hook.

### DIFF
--- a/frontend/src/hooks/window-size-hook.ts
+++ b/frontend/src/hooks/window-size-hook.ts
@@ -26,7 +26,7 @@ const notifyAll = (): void => {
   }
 };
 
-const bindListener = (listener: Listener): () => void => {
+const bindListener = (listener: Listener): (() => void) => {
   const id = listenerSize;
   listeners.set(id, listener);
   listenerSize += 1;
@@ -66,7 +66,17 @@ export function useWindowSizeCallback(onChange: (windowSize: WindowSize) => void
  * @return the computed value.
  */
 export function useMappedWindowSize<T>(f: (windowSize: WindowSize) => T): T {
-  return f(useWindowSize());
+  const [mappedValue, setMappedValue] = useState(() => f(getWindowSize()));
+  useEffect(
+    () => bindListener((windowSize: WindowSize): void => {
+      const newMappedValue = f(windowSize);
+      if (newMappedValue !== mappedValue) {
+        setMappedValue(newMappedValue);
+      }
+    }),
+    [f, mappedValue],
+  );
+  return mappedValue;
 }
 
 /**


### PR DESCRIPTION
### Summary

Problem: right now resizing window is very expensive.

Whenever the size changes, the listener will be triggered. We have a bunch of places that call the hook; however, most of the places are only interested in whether the window size means a desktop or mobile view, in other words, a mapped value.

A mapped value changes less often than window size. Right now, we are unconditionally rerendering the view even if the mapped value does not change. This PR aims to change that.

This PR duplicates some code so that we will only call the `setMappedValue` function only if the mapped value actually change. In this way, we can avoid unnecessary rerenders.

### Test Plan

Try to resize. Nothing breaks. Things should be much faster.