### PR TITLE
Add Canvas calendar field

### DIFF
--- a/frontend/src/components/TitleBar/Canvas/CanvasCalendar.module.css
+++ b/frontend/src/components/TitleBar/Canvas/CanvasCalendar.module.css
@@ -1,0 +1,13 @@
+.calendarInput {
+  display: block;
+  margin: 0;
+  width: 100%;
+  font-size: 14px;
+  height: 32px;
+  padding: 6px 12px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: rgba(202, 202, 202, 0.59);
+  border-image: initial;
+  border-radius: 5px;
+}

--- a/frontend/src/components/TitleBar/Canvas/CanvasCalendar.module.css
+++ b/frontend/src/components/TitleBar/Canvas/CanvasCalendar.module.css
@@ -1,4 +1,4 @@
-.calendarInput {
+.CalendarInput {
   display: block;
   margin: 0;
   width: 100%;
@@ -10,4 +10,18 @@
   border-color: rgba(202, 202, 202, 0.59);
   border-image: initial;
   border-radius: 5px;
+}
+
+.CalendarForm {
+  margin-top: 24px;
+}
+
+.HelpButton {
+  text-decoration: underline #83c1ff;
+  color: #83c1ff;
+}
+
+.HelpButton:hover,
+.HelpButton:focus {
+  color: #6bb5ff;
 }

--- a/frontend/src/components/TitleBar/Canvas/CanvasCalendar.module.css
+++ b/frontend/src/components/TitleBar/Canvas/CanvasCalendar.module.css
@@ -1,9 +1,9 @@
 .CalendarInput {
-  display: block;
+  flex-grow: 1;
   margin: 0;
+  margin-right: 16px;
   width: 100%;
   font-size: 14px;
-  height: 32px;
   padding: 6px 12px;
   border-width: 1px;
   border-style: solid;
@@ -13,6 +13,7 @@
 }
 
 .CalendarForm {
+  display: flex;
   margin-top: 24px;
 }
 
@@ -24,4 +25,11 @@
 .HelpButton:hover,
 .HelpButton:focus {
   color: #6bb5ff;
+}
+
+@media only screen and (max-width: 600px) {
+  .CalendarForm, 
+  .CalendarInput {
+    display: block;
+  }
 }

--- a/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
+++ b/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
@@ -51,15 +51,15 @@ function CanvasCalendar({ settings }: Props): ReactElement {
 
         <div
           className={settingStyles.SettingsButton}
-          style={{
-            marginTop: '12px',
-            display: linked ? 'block' : 'none',
-          }}
+          style={{ display: linked ? 'block' : 'none' }}
         >
-          Your Canvas calendar feed is linked.
+          <p style={{ wordBreak: 'break-all' }}>
+            Your Canvas calendar feed is linked.
+            <br />
+            {canvasCalendar}
+          </p>
           <button
             type="button"
-            style={{ marginLeft: '12px' }}
             onClick={removeCanvasiCal}
             title="Remove Canvas iCal Link"
           >

--- a/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
+++ b/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
@@ -1,7 +1,8 @@
 import React, { ReactElement, Component } from 'react';
-import styles from '../Settings/SettingsPage.module.css';
+import settingStyles from '../Settings/SettingsPage.module.css';
 import { settingsCollection } from '../../../firebase/db';
 import { getAppUser } from '../../../firebase/auth-util';
+import styles from './CanvasCalendar.module.css';
 
 type State = {
   canvasCalendar: string;
@@ -15,12 +16,11 @@ export default class CanvasCalendar extends Component<{}, State> {
   };
 
   componentWillMount(): void {
-    const self = this;
     settingsCollection().doc(getAppUser().email)
       .get().then((doc) => {
         const userSettings = doc.data();
         if (userSettings) {
-          self.setState({ linked: !(userSettings.canvasCalendar === null) });
+          this.setState({ linked: !(userSettings.canvasCalendar === null) });
         }
       });
   }
@@ -29,51 +29,64 @@ export default class CanvasCalendar extends Component<{}, State> {
     this.setState({ canvasCalendar: e.target.value });
   };
 
-  handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
+  addiCalToFirestore = (e: React.FormEvent<HTMLFormElement>): void => {
     e.preventDefault();
-    const self = this;
+    const { canvasCalendar } = this.state;
     settingsCollection().doc(getAppUser().email)
-      .update({ canvasCalendar: this.state.canvasCalendar })
+      .update({ canvasCalendar })
       .then(() => {
-        self.setState({ linked: true });
+        this.setState({ linked: true });
       });
   };
 
   removeCanvasiCal = (): void => {
-    const self = this;
     settingsCollection().doc(getAppUser().email)
       .update({ canvasCalendar: null })
       .then(() => {
-        self.setState({ linked: false });
+        this.setState({ linked: false });
       });
+  };
+
+  calendarState = (): State => {
+    const { canvasCalendar, linked } = this.state;
+    return { canvasCalendar, linked };
   };
 
   render(): ReactElement {
     return (
-      <div>
-        <div style={{ display: !this.state.linked ? 'block' : 'none' }}>
-          <form onSubmit={this.handleSubmit}>
-            <label>
-              Canvas Calendar Feed:
-              <input type="text" onChange={this.handleChange} />
-            </label>
-            <input type="submit" value="Submit" />
-          </form>
-        </div>
+      <div className={settingStyles.SettingsSection}>
+        <p className={settingStyles.SettingsSectionTitle}>Canvas Calendar</p>
+        <div className={settingStyles.SettingsSectionContent}>
 
-        <div
-          style={{ display: this.state.linked ? 'block' : 'none' }}
-          className={styles.SettingsButton}
-        >
-          Your Canvas calendar feed is linked.
-          <button
-            type="button"
-            style={{ marginLeft: '12px' }}
-            onClick={this.removeCanvasiCal}
-            title="Remove Canvas iCal Link"
+          <div
+            style={{ display: !this.calendarState().linked ? 'block' : 'none' }}
           >
-            Unlink
-          </button>
+            <form
+              onSubmit={this.addiCalToFirestore}
+            >
+              <input
+                placeholder="Link your Canvas iCal"
+                type="text"
+                onChange={this.handleChange}
+                className={styles.calendarInput}
+              />
+            </form>
+          </div>
+
+          <div
+            className={settingStyles.SettingsButton}
+            style={{ display: this.calendarState().linked ? 'block' : 'none' }}
+          >
+            Your Canvas calendar feed is linked.
+            <button
+              type="button"
+              style={{ marginLeft: '12px' }}
+              onClick={this.removeCanvasiCal}
+              title="Remove Canvas iCal Link"
+            >
+              Unlink
+            </button>
+          </div>
         </div>
       </div>
     );

--- a/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
+++ b/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
@@ -15,7 +15,7 @@ export default class CanvasCalendar extends Component<{}, State> {
     linked: false,
   };
 
-  componentWillMount(): void {
+  componentDidMount(): void {
     db().collection('samwise-settings').doc(getAppUser().email)
       .get()
       .then((doc) => {

--- a/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
+++ b/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
@@ -1,77 +1,75 @@
-import React, { ReactElement, Component } from 'react';
+import React, { ReactElement, useState } from 'react';
+import { connect } from 'react-redux';
+import { Settings, State } from '../../../store/store-types';
 import settingStyles from '../Settings/SettingsPage.module.css';
 import styles from './CanvasCalendar.module.css';
 import { setCanvasCalendar } from '../../../firebase/actions';
 
-type Props = { readonly linked: boolean }
+type Props = { readonly settings: Settings }
 
-type State = { canvasCalendar: string | null }
+function CanvasCalendar({ settings }: Props): ReactElement {
+  const { canvasCalendar } = settings;
+  const linked = canvasCalendar != null;
+  const [input, setInput] = useState('');
 
-export default class CanvasCalendar extends Component<Props, State> {
-  public state: State = { canvasCalendar: '' };
-
-  handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    this.setState({ canvasCalendar: e.target.value });
-  };
-
-  handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
     e.preventDefault();
-    const { canvasCalendar } = this.state;
-    if (canvasCalendar !== '') { setCanvasCalendar(canvasCalendar); }
+    const iCalLink = input;
+    setCanvasCalendar(iCalLink);
   };
 
-  removeCanvasiCal = (): void => {
+  const removeCanvasiCal = (): void => {
     setCanvasCalendar(null);
   };
 
-  render(): ReactElement {
-    const { linked } = this.props;
+  return (
+    <div className={settingStyles.SettingsSection}>
+      <p className={settingStyles.SettingsSectionTitle}>Canvas Calendar</p>
+      <div className={settingStyles.SettingsSectionContent}>
 
-    return (
-      <div className={settingStyles.SettingsSection}>
-        <p className={settingStyles.SettingsSectionTitle}>Canvas Calendar</p>
-        <div className={settingStyles.SettingsSectionContent}>
-
-          <div style={{ display: !linked ? 'block' : 'none' }}>
-            <form
-              className={styles.CalendarForm}
-              onSubmit={this.handleSubmit}
-            >
-              <input
-                placeholder="Paste your Canvas iCal link here"
-                type="text"
-                onChange={this.handleChange}
-                className={styles.CalendarInput}
-              />
-            </form>
-            <a
-              className={styles.HelpButton}
-              href="https://community.canvaslms.com/docs/DOC-10691-4212717348"
-              title="Link to Canvas iCal guide"
-            >
-              Having trouble finding the iCal link?
-            </a>
-          </div>
-
-          <div
-            className={settingStyles.SettingsButton}
-            style={{
-              marginTop: '12px',
-              display: linked ? 'block' : 'none',
-            }}
+        <div style={{ display: !linked ? 'block' : 'none' }}>
+          <form
+            className={styles.CalendarForm}
+            onSubmit={handleSubmit}
           >
-            Your Canvas calendar feed is linked.
-            <button
-              type="button"
-              style={{ marginLeft: '12px' }}
-              onClick={this.removeCanvasiCal}
-              title="Remove Canvas iCal Link"
-            >
-              Unlink
-            </button>
-          </div>
+            <input
+              placeholder="Paste your Canvas iCal link here"
+              type="text"
+              className={styles.CalendarInput}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+            />
+          </form>
+          <a
+            className={styles.HelpButton}
+            href="https://community.canvaslms.com/docs/DOC-10691-4212717348"
+            title="Link to Canvas iCal guide"
+          >
+            Having trouble finding the iCal link?
+          </a>
+        </div>
+
+        <div
+          className={settingStyles.SettingsButton}
+          style={{
+            marginTop: '12px',
+            display: linked ? 'block' : 'none',
+          }}
+        >
+          Your Canvas calendar feed is linked.
+          <button
+            type="button"
+            style={{ marginLeft: '12px' }}
+            onClick={removeCanvasiCal}
+            title="Remove Canvas iCal Link"
+          >
+            Unlink
+          </button>
         </div>
       </div>
-    );
-  }
+    </div>
+  );
 }
+
+const Connected = connect(({ settings }: State) => ({ settings }))(CanvasCalendar);
+export default Connected;

--- a/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
+++ b/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
@@ -1,18 +1,14 @@
 import React, { ReactElement, Component } from 'react';
 import settingStyles from '../Settings/SettingsPage.module.css';
 import styles from './CanvasCalendar.module.css';
-import { setCanvasCalendar, readCanvasCalendar } from '../../../firebase/actions';
+import { setCanvasCalendar } from '../../../firebase/actions';
 
-type State = {
-  canvasCalendar: string | null;
-  linked: boolean;
-}
+type Props = { readonly linked: boolean }
 
-export default class CanvasCalendar extends Component<{}, State> {
-  public state: State = {
-    canvasCalendar: '',
-    linked: readCanvasCalendar() != null,
-  };
+type State = { canvasCalendar: string | null }
+
+export default class CanvasCalendar extends Component<Props, State> {
+  public state: State = { canvasCalendar: '' };
 
   handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     this.setState({ canvasCalendar: e.target.value });
@@ -21,31 +17,22 @@ export default class CanvasCalendar extends Component<{}, State> {
   handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
     e.preventDefault();
     const { canvasCalendar } = this.state;
-    if (canvasCalendar !== '') {
-      setCanvasCalendar(canvasCalendar);
-      this.setState({ linked: true });
-    }
+    if (canvasCalendar !== '') { setCanvasCalendar(canvasCalendar); }
   };
 
   removeCanvasiCal = (): void => {
     setCanvasCalendar(null);
-    this.setState({ linked: false });
-  };
-
-  calendarState = (): State => {
-    const { canvasCalendar, linked } = this.state;
-    return { canvasCalendar, linked };
   };
 
   render(): ReactElement {
+    const { linked } = this.props;
+
     return (
       <div className={settingStyles.SettingsSection}>
         <p className={settingStyles.SettingsSectionTitle}>Canvas Calendar</p>
         <div className={settingStyles.SettingsSectionContent}>
 
-          <div
-            style={{ display: !this.calendarState().linked ? 'block' : 'none' }}
-          >
+          <div style={{ display: !linked ? 'block' : 'none' }}>
             <form
               className={styles.CalendarForm}
               onSubmit={this.handleSubmit}
@@ -70,7 +57,7 @@ export default class CanvasCalendar extends Component<{}, State> {
             className={settingStyles.SettingsButton}
             style={{
               marginTop: '12px',
-              display: this.calendarState().linked ? 'block' : 'none',
+              display: linked ? 'block' : 'none',
             }}
           >
             Your Canvas calendar feed is linked.

--- a/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
+++ b/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
@@ -29,7 +29,7 @@ function CanvasCalendar({ settings }: Props): ReactElement {
 
         <div style={{ display: !linked ? 'block' : 'none' }}>
           <form
-            className={styles.CalendarForm}
+            className={[styles.CalendarForm, settingStyles.SettingsButton].join(' ')}
             onSubmit={handleSubmit}
           >
             <input
@@ -39,6 +39,7 @@ function CanvasCalendar({ settings }: Props): ReactElement {
               value={input}
               onChange={(e) => setInput(e.target.value)}
             />
+            <button type="submit" title="Link Canvas iCal"> Save </button>
           </form>
           <a
             className={styles.HelpButton}

--- a/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
+++ b/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
@@ -1,0 +1,81 @@
+import React, { ReactElement, Component } from 'react';
+import styles from '../Settings/SettingsPage.module.css';
+import { settingsCollection } from '../../../firebase/db';
+import { getAppUser } from '../../../firebase/auth-util';
+
+type State = {
+  canvasCalendar: string;
+  linked: boolean;
+}
+
+export default class CanvasCalendar extends Component<{}, State> {
+  public state: State = {
+    canvasCalendar: '',
+    linked: false,
+  };
+
+  componentWillMount(): void {
+    const self = this;
+    settingsCollection().doc(getAppUser().email)
+      .get().then((doc) => {
+        const userSettings = doc.data();
+        if (userSettings) {
+          self.setState({ linked: !(userSettings.canvasCalendar === null) });
+        }
+      });
+  }
+
+  handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    this.setState({ canvasCalendar: e.target.value });
+  };
+
+  handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
+    e.preventDefault();
+    const self = this;
+    settingsCollection().doc(getAppUser().email)
+      .update({ canvasCalendar: this.state.canvasCalendar })
+      .then(() => {
+        self.setState({ linked: true });
+      });
+  };
+
+  removeCanvasiCal = (): void => {
+    const self = this;
+    settingsCollection().doc(getAppUser().email)
+      .update({ canvasCalendar: null })
+      .then(() => {
+        self.setState({ linked: false });
+      });
+  };
+
+  render(): ReactElement {
+    return (
+      <div>
+        <div style={{ display: !this.state.linked ? 'block' : 'none' }}>
+          <form onSubmit={this.handleSubmit}>
+            <label>
+              Canvas Calendar Feed:
+              <input type="text" onChange={this.handleChange} />
+            </label>
+            <input type="submit" value="Submit" />
+          </form>
+        </div>
+
+        <div
+          style={{ display: this.state.linked ? 'block' : 'none' }}
+          className={styles.SettingsButton}
+        >
+          Your Canvas calendar feed is linked.
+          <button
+            type="button"
+            style={{ marginLeft: '12px' }}
+            onClick={this.removeCanvasiCal}
+            title="Remove Canvas iCal Link"
+          >
+            Unlink
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
+++ b/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, Component } from 'react';
 import settingStyles from '../Settings/SettingsPage.module.css';
-import { settingsCollection } from '../../../firebase/db';
+import { db, settingsCollection } from '../../../firebase/db';
 import { getAppUser } from '../../../firebase/auth-util';
 import styles from './CanvasCalendar.module.css';
 
@@ -16,8 +16,9 @@ export default class CanvasCalendar extends Component<{}, State> {
   };
 
   componentWillMount(): void {
-    settingsCollection().doc(getAppUser().email)
-      .get().then((doc) => {
+    db().collection('samwise-settings').doc(getAppUser().email)
+      .get()
+      .then((doc) => {
         const userSettings = doc.data();
         if (userSettings) {
           this.setState({ linked: userSettings.canvasCalendar != null });

--- a/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
+++ b/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
@@ -20,7 +20,7 @@ export default class CanvasCalendar extends Component<{}, State> {
       .get().then((doc) => {
         const userSettings = doc.data();
         if (userSettings) {
-          this.setState({ linked: !(userSettings.canvasCalendar === null) });
+          this.setState({ linked: userSettings.canvasCalendar != null });
         }
       });
   }
@@ -66,7 +66,7 @@ export default class CanvasCalendar extends Component<{}, State> {
               onSubmit={this.addiCalToFirestore}
             >
               <input
-                placeholder="Link your Canvas iCal"
+                placeholder="Paste your Canvas iCal link here"
                 type="text"
                 onChange={this.handleChange}
                 className={styles.CalendarInput}
@@ -75,8 +75,6 @@ export default class CanvasCalendar extends Component<{}, State> {
             <a
               className={styles.HelpButton}
               href="https://community.canvaslms.com/docs/DOC-10691-4212717348"
-              target="_blank"
-              rel="noopener noreferrer"
               title="Link to Canvas iCal guide"
             >
               Having trouble finding the iCal link?

--- a/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
+++ b/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
@@ -62,15 +62,25 @@ export default class CanvasCalendar extends Component<{}, State> {
             style={{ display: !this.calendarState().linked ? 'block' : 'none' }}
           >
             <form
+              className={styles.CalendarForm}
               onSubmit={this.addiCalToFirestore}
             >
               <input
                 placeholder="Link your Canvas iCal"
                 type="text"
                 onChange={this.handleChange}
-                className={styles.calendarInput}
+                className={styles.CalendarInput}
               />
             </form>
+            <a
+              className={styles.HelpButton}
+              href="https://community.canvaslms.com/docs/DOC-10691-4212717348"
+              target="_blank"
+              rel="noopener noreferrer"
+              title="Link to Canvas iCal guide"
+            >
+              Having trouble finding the iCal link?
+            </a>
           </div>
 
           <div

--- a/frontend/src/components/TitleBar/Settings/SettingsPage.tsx
+++ b/frontend/src/components/TitleBar/Settings/SettingsPage.tsx
@@ -8,6 +8,7 @@ import styles from './SettingsPage.module.css';
 import { Tag, State } from '../../../store/store-types';
 import { completeOnboarding, importCourseExams } from '../../../firebase/actions';
 import { firebaseSignOut } from '../../../firebase/auth-util';
+import CanvasCalendar from '../Canvas/CanvasCalendar';
 
 /**
  * The class adder component.
@@ -88,6 +89,7 @@ export function SettingsPage({ tags }: Props): ReactElement {
         {renderTags(otherTags)}
         <OtherTagAdder />
       </TagsContainer>
+      <CanvasCalendar />
       <div className={styles.FinalRowButtonContainer}>
         <div className={styles.SettingsButton}>
           <button

--- a/frontend/src/components/TitleBar/Settings/SettingsPage.tsx
+++ b/frontend/src/components/TitleBar/Settings/SettingsPage.tsx
@@ -5,7 +5,7 @@ import TagItem from '../Tags/TagItem';
 import ClassTagAdder from '../Tags/ClassTagAdder';
 import OtherTagAdder from '../Tags/OtherTagAdder';
 import styles from './SettingsPage.module.css';
-import { Tag, Settings, State } from '../../../store/store-types';
+import { Tag, State } from '../../../store/store-types';
 import { completeOnboarding, importCourseExams } from '../../../firebase/actions';
 import { firebaseSignOut } from '../../../firebase/auth-util';
 import CanvasCalendar from '../Canvas/CanvasCalendar';
@@ -62,13 +62,12 @@ export const TagsContainer = ({ title, children }: TagsContainerProps): ReactEle
 
 type Props = {
   readonly tags: Map<string, Tag>;
-  readonly settings: Settings;
 };
 
 /**
  * The settings page.
  */
-export function SettingsPage({ tags, settings }: Props): ReactElement {
+export function SettingsPage({ tags }: Props): ReactElement {
   const classTags: Tag[] = [];
   const otherTags: Tag[] = [];
   tags.forEach((tag) => {
@@ -81,7 +80,6 @@ export function SettingsPage({ tags, settings }: Props): ReactElement {
   const renderTags = (arr: Tag[]): ReactNode => arr.map((tag: Tag) => (
     <TagItem key={tag.id} tag={tag} />
   ));
-  const { canvasCalendar } = settings;
 
   return (
     <div>
@@ -94,7 +92,7 @@ export function SettingsPage({ tags, settings }: Props): ReactElement {
         {renderTags(otherTags)}
         <OtherTagAdder />
       </TagsContainer>
-      <CanvasCalendar linked={canvasCalendar != null} />
+      <CanvasCalendar />
       <div className={styles.FinalRowButtonContainer}>
         <div className={styles.SettingsButton}>
           <button
@@ -134,5 +132,5 @@ export function SettingsPage({ tags, settings }: Props): ReactElement {
   );
 }
 
-const Connected = connect(({ tags, settings }: State) => ({ tags, settings }))(SettingsPage);
+const Connected = connect(({ tags }: State) => ({ tags }))(SettingsPage);
 export default Connected;

--- a/frontend/src/components/TitleBar/Settings/SettingsPage.tsx
+++ b/frontend/src/components/TitleBar/Settings/SettingsPage.tsx
@@ -5,7 +5,7 @@ import TagItem from '../Tags/TagItem';
 import ClassTagAdder from '../Tags/ClassTagAdder';
 import OtherTagAdder from '../Tags/OtherTagAdder';
 import styles from './SettingsPage.module.css';
-import { Tag, State } from '../../../store/store-types';
+import { Tag, Settings, State } from '../../../store/store-types';
 import { completeOnboarding, importCourseExams } from '../../../firebase/actions';
 import { firebaseSignOut } from '../../../firebase/auth-util';
 import CanvasCalendar from '../Canvas/CanvasCalendar';
@@ -60,12 +60,15 @@ export const TagsContainer = ({ title, children }: TagsContainerProps): ReactEle
   </div>
 );
 
-type Props = { readonly tags: Map<string, Tag> };
+type Props = {
+  readonly tags: Map<string, Tag>;
+  readonly settings: Settings;
+};
 
 /**
  * The settings page.
  */
-export function SettingsPage({ tags }: Props): ReactElement {
+export function SettingsPage({ tags, settings }: Props): ReactElement {
   const classTags: Tag[] = [];
   const otherTags: Tag[] = [];
   tags.forEach((tag) => {
@@ -78,6 +81,8 @@ export function SettingsPage({ tags }: Props): ReactElement {
   const renderTags = (arr: Tag[]): ReactNode => arr.map((tag: Tag) => (
     <TagItem key={tag.id} tag={tag} />
   ));
+  const { canvasCalendar } = settings;
+
   return (
     <div>
       <ClassAdder />
@@ -89,7 +94,7 @@ export function SettingsPage({ tags }: Props): ReactElement {
         {renderTags(otherTags)}
         <OtherTagAdder />
       </TagsContainer>
-      <CanvasCalendar />
+      <CanvasCalendar linked={canvasCalendar != null} />
       <div className={styles.FinalRowButtonContainer}>
         <div className={styles.SettingsButton}>
           <button
@@ -129,5 +134,5 @@ export function SettingsPage({ tags }: Props): ReactElement {
   );
 }
 
-const Connected = connect(({ tags }: State) => ({ tags }))(SettingsPage);
+const Connected = connect(({ tags, settings }: State) => ({ tags, settings }))(SettingsPage);
 export default Connected;

--- a/frontend/src/components/TitleBar/Settings/__snapshots__/SettingsPage.test.tsx.snap
+++ b/frontend/src/components/TitleBar/Settings/__snapshots__/SettingsPage.test.tsx.snap
@@ -356,7 +356,7 @@ exports[`SettingsPage matches snapshot. 1`] = `
         }
       >
         <form
-          className="CalendarForm"
+          className="CalendarForm SettingsButton"
           onSubmit={[Function]}
         >
           <input
@@ -366,6 +366,12 @@ exports[`SettingsPage matches snapshot. 1`] = `
             type="text"
             value=""
           />
+          <button
+            title="Link Canvas iCal"
+            type="submit"
+          >
+             Save 
+          </button>
         </form>
         <a
           className="HelpButton"

--- a/frontend/src/components/TitleBar/Settings/__snapshots__/SettingsPage.test.tsx.snap
+++ b/frontend/src/components/TitleBar/Settings/__snapshots__/SettingsPage.test.tsx.snap
@@ -338,6 +338,72 @@ exports[`SettingsPage matches snapshot. 1`] = `
     </div>
   </div>
   <div
+    className="SettingsSection"
+  >
+    <p
+      className="SettingsSectionTitle"
+    >
+      Canvas Calendar
+    </p>
+    <div
+      className="SettingsSectionContent"
+    >
+      <div
+        style={
+          Object {
+            "display": "block",
+          }
+        }
+      >
+        <form
+          className="CalendarForm"
+          onSubmit={[Function]}
+        >
+          <input
+            className="CalendarInput"
+            onChange={[Function]}
+            placeholder="Paste your Canvas iCal link here"
+            type="text"
+            value=""
+          />
+        </form>
+        <a
+          className="HelpButton"
+          href="https://community.canvaslms.com/docs/DOC-10691-4212717348"
+          title="Link to Canvas iCal guide"
+        >
+          Having trouble finding the iCal link?
+        </a>
+      </div>
+      <div
+        className="SettingsButton"
+        style={
+          Object {
+            "display": "none",
+          }
+        }
+      >
+        <p
+          style={
+            Object {
+              "wordBreak": "break-all",
+            }
+          }
+        >
+          Your Canvas calendar feed is linked.
+          <br />
+        </p>
+        <button
+          onClick={[Function]}
+          title="Remove Canvas iCal Link"
+          type="button"
+        >
+          Unlink
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
     className="FinalRowButtonContainer"
   >
     <div

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -459,7 +459,7 @@ export const completeOnboarding = (completedOnboarding: boolean): void => {
     .then(ignore);
 };
 
-export const setCanvasCalendar = (canvasCalendar: string | null): void => {
+export const setCanvasCalendar = (canvasCalendar: string | null | undefined): void => {
   settingsCollection().doc(getAppUser().email)
     .update({ canvasCalendar })
     .then(ignore);

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -459,6 +459,18 @@ export const completeOnboarding = (completedOnboarding: boolean): void => {
     .then(ignore);
 };
 
+export const setCanvasCalendar = (canvasCalendar: string | null): void => {
+  settingsCollection().doc(getAppUser().email)
+    .update({ canvasCalendar })
+    .then(ignore);
+};
+
+export const readCanvasCalendar = (): string | null => {
+  const { settings } = store.getState();
+  const { canvasCalendar } = settings;
+  return canvasCalendar;
+};
+
 export const readBannerMessage = (bannerMessageId: BannerMessageIds, isRead: boolean): void => {
   const docRef = bannerMessageStatusCollection().doc(getAppUser().email);
   db().runTransaction(async (transaction) => {

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -465,12 +465,6 @@ export const setCanvasCalendar = (canvasCalendar: string | null): void => {
     .then(ignore);
 };
 
-export const readCanvasCalendar = (): string | null => {
-  const { settings } = store.getState();
-  const { canvasCalendar } = settings;
-  return canvasCalendar;
-};
-
 export const readBannerMessage = (bannerMessageId: BannerMessageIds, isRead: boolean): void => {
   const docRef = bannerMessageStatusCollection().doc(getAppUser().email);
   db().runTransaction(async (transaction) => {

--- a/frontend/src/firebase/listeners.ts
+++ b/frontend/src/firebase/listeners.ts
@@ -185,7 +185,11 @@ export default (onFirstFetched: () => void): (() => void) => {
 
   const unmountSettingsListener = listenSettingsChange(ownerEmail, (snapshot) => {
     if (!snapshot.exists) {
-      const newSettings: Settings = { completedOnboarding: false, theme: 'light' };
+      const newSettings: Settings = {
+        canvasCalendar: null,
+        completedOnboarding: false,
+        theme: 'light',
+      };
       settingsCollection().doc(ownerEmail).set(newSettings).then(ignore);
       return;
     }
@@ -193,8 +197,8 @@ export default (onFirstFetched: () => void): (() => void) => {
     if (data === undefined) {
       return;
     }
-    const { completedOnboarding, theme } = data as Settings;
-    store.dispatch(patchSettings({ completedOnboarding, theme }));
+    const { canvasCalendar, completedOnboarding, theme } = data as Settings;
+    store.dispatch(patchSettings({ canvasCalendar, completedOnboarding, theme }));
     firstSettingsFetched = true;
     reportFirstFetchedIfAllFetched();
   });

--- a/frontend/src/store/state.ts
+++ b/frontend/src/store/state.ts
@@ -14,7 +14,7 @@ export const initialState: State = {
   dateTaskMap: Map(),
   repeatedTaskSet: Set(),
   taskChildrenMap: Map(),
-  settings: { completedOnboarding: true, theme: 'light' },
+  settings: { canvasCalendar: null, completedOnboarding: true, theme: 'light' },
   bannerMessageStatus: {},
   courses: Map(),
 };
@@ -82,7 +82,7 @@ export const initialStateForTesting: State = {
     bar: Set('bar'),
     baz: Set('baz'),
   }),
-  settings: { completedOnboarding: true, theme: 'light' },
+  settings: { canvasCalendar: null, completedOnboarding: true, theme: 'light' },
   bannerMessageStatus: {},
   courses: Map({
     CS2112: [{

--- a/frontend/src/store/store-types.ts
+++ b/frontend/src/store/store-types.ts
@@ -84,7 +84,7 @@ export type PartialMainTask = Partial<MainTask>;
  * The type of user settings.
  */
 export type Settings = {
-  readonly canvasCalendar: string | null;
+  readonly canvasCalendar: string | null | undefined;
   readonly completedOnboarding: boolean;
   readonly theme: 'light' | 'dark';
 };

--- a/frontend/src/store/store-types.ts
+++ b/frontend/src/store/store-types.ts
@@ -45,7 +45,7 @@ export type OneTimeTask = CommonTask<Date> & {
  * Fields that are filled represent differences from master template
  */
 
-export type PartialTask = Partial<Pick<FlexibleCommonTask, MainTaskProperties | 'children' >>;
+export type PartialTask = Partial<Pick<FlexibleCommonTask, MainTaskProperties | 'children'>>;
 
 export type RepeatingPattern =
   | { readonly type: 'WEEKLY'; readonly bitSet: number /* 7-bit */ }
@@ -84,6 +84,7 @@ export type PartialMainTask = Partial<MainTask>;
  * The type of user settings.
  */
 export type Settings = {
+  readonly canvasCalendar: string | null;
   readonly completedOnboarding: boolean;
   readonly theme: 'light' | 'dark';
 };


### PR DESCRIPTION
### Summary

Add a field at the bottom of Settings that allows users to add their Canvas calendar feed link. This calendar feed is able to be unlinked. A help link is included below the field in case users have trouble finding their Canvas calendar feed link.

- [x] Add Canvas calendar field to settings page

### Test Plan <!-- Required -->

![canvas calendar field link](https://user-images.githubusercontent.com/48143149/70173768-8c714280-16a1-11ea-9950-17711aa6c93b.png)
![canvas calendar field unlink](https://user-images.githubusercontent.com/48143149/70007707-561bb200-153f-11ea-8e3c-bb9a4aa75b30.png)

### Breaking Changes

Adds a _canvasCalendar_ field to documents in _samwise-settings_ in Firestore.
