### PR TITLE
Fix top padding of TaskEditor. Close #369

### DIFF
--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.module.css
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.module.css
@@ -27,7 +27,7 @@
 .TaskEditorFlexibleContainer {
   position: relative;
   display: flex;
-  margin: 16px 8px;
+  padding: 8px;
   align-content: center;
   align-items: center;
 }
@@ -169,7 +169,7 @@ input.TaskEditorFlexibleInput:focus-within::placeholder {
   max-height: 50px;
   transition: max-height 0.2s ease-in-out;
   overflow: hidden;
-  margin: -15px 0 20px 0;
+  margin: 0 0 8px 0;
   padding: 0;
 }
 
@@ -202,4 +202,3 @@ input.TaskEditorFlexibleInput:focus-within::placeholder {
   color: white;
   margin: 0 0.5em;
 }
-


### PR DESCRIPTION
### Summary <!-- Required -->

Fix problem in #369.

### Test Plan <!-- Required -->

<img width="1680" alt="Screen Shot 2019-11-25 at 12 41 17" src="https://user-images.githubusercontent.com/4290500/69564555-3570bc80-0f81-11ea-9aef-5785a01c3540.png">

### Notes <!-- Optional -->

We should really avoid using negative margin hack in CSS. It usually causes more trouble than it solves.
