### PR TITLE
Call `onSave` when `TaskEditor` lose focus

### DIFF
--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -99,6 +99,7 @@ function TaskEditor(
   const [subTaskToFocus, setSubTaskToFocus] = useState<TaskToFocus>(null);
 
   const onMouseLeave = (): void => {
+    onSave();
     if (onBlur) {
       onBlur();
     }
@@ -204,7 +205,7 @@ function TaskEditor(
       if (type === 'ONE_TIME') {
         onSave();
       }
-    }, 500);
+    }, 1000);
     return () => clearInterval(intervalID);
   }, [type, onSave]);
 
@@ -215,7 +216,7 @@ function TaskEditor(
       onMouseEnter={onFocus}
       onMouseLeave={onMouseLeave}
       onFocus={onFocus}
-      onBlur={ignore}
+      onBlur={onMouseLeave}
       ref={editorRef}
     >
       {isOverdue && <OverdueAlert target="task-card" />}


### PR DESCRIPTION
### Summary

Suppose you exit before the TaskEditor can save, then the edit is forever lost.
This diff ensures that things are always saved by calling `onSave` before `onMouseLeave` and `onBlur`, two events that indicates that TaskEditor might exit.

With this change, we can increase the interval of running `onSave` to a higher value: 1000ms.

### Test Plan

Play with `TaskEditor`. Type something really fast and then let mouse leave the editor. Things should be saved.