### PR TITLE
Fix checking unsaved subtask. Close #354

### DIFF
--- a/frontend/src/components/Util/TaskEditors/TaskEditor/OneSubTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/OneSubTaskEditor.tsx
@@ -43,12 +43,16 @@ function OneSubTaskEditor(
   const replaceDateForFork = taskDate == null
     ? getDateWithDateString(taskDate, dateAppeared)
     : null;
-  const onCompleteChange = (): void => editSubTask(
-    mainTaskId, subTask.id, replaceDateForFork, { complete: !subTask.complete },
-  );
-  const onInFocusChange = (): void => editSubTask(
-    mainTaskId, subTask.id, replaceDateForFork, { inFocus: !subTask.inFocus },
-  );
+  const onCompleteChange = (): void => {
+    const complete = !subTask.complete;
+    editThisSubTask(subTask.id, { complete });
+    editSubTask(mainTaskId, subTask.id, replaceDateForFork, { complete });
+  };
+  const onInFocusChange = (): void => {
+    const inFocus = !subTask.inFocus;
+    editThisSubTask(subTask.id, { inFocus });
+    editSubTask(mainTaskId, subTask.id, replaceDateForFork, { inFocus });
+  };
   const onRemove = (): void => removeSubTask(subTask.id);
 
   const onKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {


### PR DESCRIPTION
### Summary

This bug is introduced a while ago while we added autosave back in #309.
The fix is simple: save the edit to the local reducer first. The call of `editSubTask` will just fail silently and harmlessly.

### Test Plan

Create a task, type one character in add subtask box and click checkbox very quickly. It's indeed saved.