### PR TITLE
[editor] Guard implicit `onSave` call with `type === 'ONE_TIME'` check

### DIFF
--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -99,7 +99,9 @@ function TaskEditor(
   const [subTaskToFocus, setSubTaskToFocus] = useState<TaskToFocus>(null);
 
   const onMouseLeave = (): void => {
-    onSave();
+    if (type === 'ONE_TIME') {
+      onSave();
+    }
     if (onBlur) {
       onBlur();
     }


### PR DESCRIPTION
### Summary

This is a regression introduced in #373.
We shouldn't unconditionally call onSave because it will trigger a modal during repeating task edit. The current master will popup the modal whenever you type any character. (In other words, current master's repeating task is broken.)

### Test Plan

Observe the bug in current master. The bug is gone in this branch.