### PR TITLE
Fix no-unique key React warning for end option radios in DatePicker

### DIFF
--- a/frontend/src/components/TaskCreator/DatePicker.tsx
+++ b/frontend/src/components/TaskCreator/DatePicker.tsx
@@ -292,7 +292,8 @@ export default function DatePicker(props: Props): ReactElement {
         : internalDate.repeatEnd.type === 'weeks';
     }
     return (
-      <li>
+      // eslint-disable-next-line react/no-array-index-key
+      <li key={i}>
         <label htmlFor={`newTaskRepeatEndRadio${i}`}>
           <input
             type="radio"


### PR DESCRIPTION
### Summary <!-- Required -->

Missing this warning since it's hidden in repeating task date picker.

### Test Plan <!-- Required -->

Go to repeating task date picker in `TaskCreator`. No more warnings in console.

### Notes

I simply suppressed the eslint warning since the array is stable.