### PR TITLE
Auto-focus tasks due today

### DIFF
--- a/functions/src/focus-today-task.ts
+++ b/functions/src/focus-today-task.ts
@@ -1,0 +1,18 @@
+import { db, tasksCollection } from './db';
+
+export default async (): Promise<void> => {
+  const todayAtZero = new Date();
+  todayAtZero.setHours(0, 0, 0, 0);
+  const todayAt235959 = new Date();
+  todayAt235959.setHours(23, 59, 59, 0);
+  const tasks = await tasksCollection()
+    .where('date', '>=', todayAtZero)
+    .where('date', '<', todayAt235959)
+    .get();
+  const taskIdList = tasks.docs.map((document) => document.id);
+  const batch = db().batch();
+  taskIdList.forEach((id) => {
+    batch.update(tasksCollection().doc(id), { inFocus: true });
+  });
+  batch.commit();
+};

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,7 +1,7 @@
 import * as functions from 'firebase-functions';
 import getICalLink from './iCalFunctions';
+import focusTasksDueToday from './focus-today-task';
 
-// eslint-disable-next-line import/prefer-default-export
 export const iCalFunction = functions.pubsub.schedule('0 0 * * *').onRun(() => {
   getICalLink()
     .catch((err) => console.log(err))
@@ -10,3 +10,5 @@ export const iCalFunction = functions.pubsub.schedule('0 0 * * *').onRun(() => {
     })
     .catch((err) => console.log(err));
 });
+
+export const FocusTasksDueToday = functions.pubsub.schedule('0 0 * * *').onRun(focusTasksDueToday);


### PR DESCRIPTION
### Summary

Automatically focus tasks due today with firebase functions.

I do not deal with potential timezone problem for the following reasons:

- We don't record user's timezone in the database.
- We assume users are in EST, and servers are in US. Having at most 3 hours off doesn't seem to be a big problem for this use case.

### Test Plan

Create a task due today and unfocus it in any staging or local env.
Go to firebase functions tab, find the function `FocusTasksDueToday`, click view on cloud schedular, and force trigger a run over there.
You should see your task got focused.

### Note

Auto focusing repeating task involves more math. We have the calculation code in the `frontend` package. I want to deal with it after we found a good way to avoid duplicating code in two packages.