### PR TITLE
iCal resync

### DIFF
--- a/functions/src/iCalFunctions.ts
+++ b/functions/src/iCalFunctions.ts
@@ -79,5 +79,3 @@ export function parseICal(link: string, user: string): void {
     }
   });
 }
-
-parseICal('https://canvas.cornell.edu/feeds/calendars/user_EJtT79IyH5Dj22KZJX4oCD2UIXmMDPl2EOm4LQNP.ics', 'jt568@cornell.edu');

--- a/functions/src/iCalFunctions.ts
+++ b/functions/src/iCalFunctions.ts
@@ -62,6 +62,15 @@ export function parseICal(link: string, user: string): void {
                       icalUID: uid,
                     })
                     .catch((e: Error) => console.log(e));
+                } else {
+                  querySnapshot.forEach((doc) => {
+                    tasksCollection()
+                      .doc(doc.id)
+                      .update({
+                        name: taskName,
+                        date: endDate,
+                      });
+                  });
                 }
               });
           }
@@ -70,3 +79,5 @@ export function parseICal(link: string, user: string): void {
     }
   });
 }
+
+parseICal('https://canvas.cornell.edu/feeds/calendars/user_EJtT79IyH5Dj22KZJX4oCD2UIXmMDPl2EOm4LQNP.ics', 'jt568@cornell.edu');


### PR DESCRIPTION
### Summary <!-- Required -->
`parseICal` now updates existing tasks by updating the due date of the task and name of the task instead of doing nothing when the task already exists inside of a user's tasks.

### Test Plan <!-- Required -->
Passes yarn tsc and no linter errors
Observe that a hypothetical assignment: "NOT DEV ASSIGNMENT" is due on the 13th.
<img width="1246" alt="Greenshot 2019-12-08 18 00 05" src="https://user-images.githubusercontent.com/33106747/70398150-87382e80-19e6-11ea-822d-8ee10b028e21.png">
However, the professor decides that such an assignment due on the 13th is very unlucky, so they move the due date to the 14th and rename the assignment. After the next round of fetching ical information, such a change would be reflected as such:
<img width="1276" alt="Greenshot 2019-12-08 18 00 24" src="https://user-images.githubusercontent.com/33106747/70398232-56a4c480-19e7-11ea-8745-6515c0817f73.png">
Of course, this can be replicated by manually calling parseICal link after there is a desync between the canvas event on the iCal and the canvas event stored in firestore. 


### Notes <!-- Optional -->

I update name and date of the task only. More fields can be included/excluded, but if a user decides that they want to change the name of a task or move the due date themselves for some reason, the task will reset to its state on Canvas, effectively rendering the task "uneditable". 
