### PR TITLE
Fix 840 Screen Width

### DIFF
--- a/frontend/src/components/TaskView/index.tsx
+++ b/frontend/src/components/TaskView/index.tsx
@@ -19,7 +19,7 @@ export default function TaskView({ className }: Props): ReactElement {
   const [doesShowFutureViewInSmallScreen, setDoesShowFutureViewInSmallScreen] = useState(false);
   const [config, setConfig] = useState<FutureViewConfig>(futureViewConfigProvider.initialValue);
 
-  const screenIsSmall = useMappedWindowSize((size) => size.width <= 840);
+  const screenIsSmall = useMappedWindowSize((size) => size.width < 840);
   const toggleFocusViewInWideScreen = (): void => setDoesShowFocusViewInWideScreen((prev) => !prev);
   const switchView = (): void => setDoesShowFutureViewInSmallScreen((prev) => !prev);
 


### PR DESCRIPTION
### Summary <!-- Required -->

Fixes #389. At 840px half of screen is focus view and half is one day of Future View

This pull request is the first step towards implementing feature Foo

- [x] fixed #389 

### Test Plan 

Set screen width to 840px. Ensure that half of screen is focus and half is future view:

![image](https://user-images.githubusercontent.com/20008134/71310862-1aaa3000-23e7-11ea-9f91-9b2ebadd9623.png)


