### PR TITLE
Unbreak course scraper for SP20

### DIFF
--- a/course-info/fetch-exam.js
+++ b/course-info/fetch-exam.js
@@ -2,8 +2,8 @@ const fs = require('fs');
 const fetch = require('node-fetch');
 const { JSDOM } = require('jsdom');
 
-const fallPrelimUrl = 'https://registrar.cornell.edu/exams/fall-prelim-exam-schedule';
-const fallFinalUrl = 'https://registrar.cornell.edu/exams/fall-final-exam-schedule';
+const prelimUrl = 'https://registrar.cornell.edu/exams/spring-prelim-schedule';
+const finalUrl = 'https://registrar.cornell.edu/exams/spring-final-exam-schedule';
 
 const currentYear = new Date().getFullYear();
 
@@ -69,7 +69,7 @@ function getExamInfoList(rawText, isFinal) {
   const infoList = [];
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i].trim();
-    if (line !== '' && !line.startsWith('Class')) {
+    if (line !== '' && !line.startsWith('Class') && !line.startsWith('final exam')) {
       const info = isFinal ? parseFinalLine(line) : parsePrelimLine(line);
       infoList.push(info);
     }
@@ -84,8 +84,8 @@ function createJson(url, isFinal, outFilename) {
 }
 
 function main() {
-  createJson(fallFinalUrl, true, 'final-exams.json');
-  createJson(fallPrelimUrl, false, 'prelim-exams.json');
+  createJson(finalUrl, true, 'final-exams.json');
+  createJson(prelimUrl, false, 'prelim-exams.json');
 }
 
 main();

--- a/course-info/merge-json.js
+++ b/course-info/merge-json.js
@@ -49,11 +49,11 @@ function processExamInfoJson(map, json, type) {
 
 function main() {
   const map = new Map();
-  processCourseInfoJson(map, JSON.parse(fs.readFileSync('fa19-courses.json', 'utf8')));
+  processCourseInfoJson(map, JSON.parse(fs.readFileSync('sp20-courses.json', 'utf8')));
   processExamInfoJson(map, JSON.parse(fs.readFileSync('final-exams.json', 'utf8')), 'final');
   processExamInfoJson(map, JSON.parse(fs.readFileSync('prelim-exams.json', 'utf8')), 'prelim');
   const result = Array.from(map.values()).map((it) => it.plainJs);
-  fs.writeFile('fa19-courses-with-exams-min.json', JSON.stringify(result), () => {
+  fs.writeFile('sp20-courses-with-exams-min.json', JSON.stringify(result), () => {
     console.log('Done');
   });
 }

--- a/course-info/run
+++ b/course-info/run
@@ -13,8 +13,8 @@ function createCourseInfoJson() {
     cd cornell-api-libs
     gradle build -x test
     cd ../
-    java -jar cornell-api-libs/build/libs/cornell-api-lib-kotlin-0.4.jar \
-        print-all-courses-in FA19 | node simplify-json.js >./fa19-courses.json
+    java -jar cornell-api-libs/build/libs/cornell-api-libs-0.5-all.jar \
+        print-all-courses-in SP20 | node simplify-json.js >./sp20-courses.json
     rm -rf cornell-api-libs
 }
 
@@ -30,14 +30,14 @@ function mergeJson() {
 
 # Outcome: Cleanup all the intermediate json files.
 function cleanup() {
-    rm sp19-courses.json
+    rm sp20-courses.json
     rm final-exams.json
     rm prelim-exams.json
 }
 
 # Comment out those parts you don't need
 
-# createCourseInfoJson
-# createExamInfoJson
-# mergeJson
+createCourseInfoJson
+createExamInfoJson
+mergeJson
 cleanup


### PR DESCRIPTION
### Summary

This diff simply unbreaks it. Now it can generate a JSON we want. I forgot what's the process of putting the JSON to the right place and ensure there is no compatibility problems. Let's leave that to today's work session.

In the long term, we should think about how we can make this more maintainable. I'm happy to rewrite the script in TS and move my `cornell-api-libs` to DTI org.

### Test Plan

```bash
cd course-info
./run
# no errors, only warnings are printed.
```