### PR TITLE
Setup CI job to warn against big diff

### DIFF
--- a/.github/workflows/ci-policies.yml
+++ b/.github/workflows/ci-policies.yml
@@ -15,3 +15,10 @@ jobs:
         run: |
           echo "Head ref must be master for release. Everything should go through staging first!"
           exit 1
+  warn-big-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: cornell-dti/big-diff-warning@master
+        env:
+          BOT_TOKEN: '${{ secrets.DEPLOY_GH_PAGE_TOKEN }}'

--- a/.github/workflows/ci-policies.yml
+++ b/.github/workflows/ci-policies.yml
@@ -21,4 +21,4 @@ jobs:
       - uses: actions/checkout@master
       - uses: cornell-dti/big-diff-warning@master
         env:
-          BOT_TOKEN: '${{ secrets.DEPLOY_GH_PAGE_TOKEN }}'
+          BOT_TOKEN: '${{ secrets.BOT_TOKEN }}'


### PR DESCRIPTION
### Summary <!-- Required -->

Setup a CI job to warn against big diff, powered by [big-diff-warning](https://github.com/cornell-dti/big-diff-warning)

### Test Plan <!-- Required -->

See the PR comment. Bot comment should be there.