### PR TITLE
Disable canvas editing

### DIFF
--- a/common/src/types/store-types.ts
+++ b/common/src/types/store-types.ts
@@ -38,7 +38,7 @@ type FlexibleCommonTask = CommonTask<Date | RepeatMetaData>;
 
 export type OneTimeTask = CommonTask<Date> & {
   readonly type: 'ONE_TIME';
-  readonly icalUID: string | null;
+  readonly icalUID?: string;
 };
 
 /**

--- a/common/src/types/store-types.ts
+++ b/common/src/types/store-types.ts
@@ -38,6 +38,7 @@ type FlexibleCommonTask = CommonTask<Date | RepeatMetaData>;
 
 export type OneTimeTask = CommonTask<Date> & {
   readonly type: 'ONE_TIME';
+  readonly icalUID: string | null;
 };
 
 /**

--- a/common/src/util/task-util.test.ts
+++ b/common/src/util/task-util.test.ts
@@ -12,7 +12,7 @@ const order = 0;
 const name = 'name';
 type MainTaskTestCommon = {
   readonly type: 'ONE_TIME';
-  readonly icalUID: string | null;
+  readonly icalUID?: string;
   readonly id: string;
   readonly order: number;
   readonly name: string;
@@ -21,7 +21,6 @@ type MainTaskTestCommon = {
 };
 const testTaskCommon: MainTaskTestCommon = {
   type: 'ONE_TIME',
-  icalUID: null,
   id: 'random-id',
   order,
   name,

--- a/common/src/util/task-util.test.ts
+++ b/common/src/util/task-util.test.ts
@@ -12,6 +12,7 @@ const order = 0;
 const name = 'name';
 type MainTaskTestCommon = {
   readonly type: 'ONE_TIME';
+  readonly icalUID: string | null;
   readonly id: string;
   readonly order: number;
   readonly name: string;
@@ -20,6 +21,7 @@ type MainTaskTestCommon = {
 };
 const testTaskCommon: MainTaskTestCommon = {
   type: 'ONE_TIME',
+  icalUID: null,
   id: 'random-id',
   order,
   name,

--- a/frontend/src/components/TaskCreator/index.tsx
+++ b/frontend/src/components/TaskCreator/index.tsx
@@ -127,7 +127,7 @@ export default class TaskCreator extends React.PureComponent<{}, State> {
       date.setHours(23);
       date.setMinutes(59);
       date.setSeconds(59);
-      newTask = { ...commonTask, type: 'ONE_TIME', icalUID: null, date };
+      newTask = { ...commonTask, type: 'ONE_TIME', date };
     } else {
       newTask = {
         ...commonTask,

--- a/frontend/src/components/TaskCreator/index.tsx
+++ b/frontend/src/components/TaskCreator/index.tsx
@@ -127,7 +127,7 @@ export default class TaskCreator extends React.PureComponent<{}, State> {
       date.setHours(23);
       date.setMinutes(59);
       date.setSeconds(59);
-      newTask = { ...commonTask, type: 'ONE_TIME', date };
+      newTask = { ...commonTask, type: 'ONE_TIME', icalUID: null, date };
     } else {
       newTask = {
         ...commonTask,

--- a/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
@@ -49,9 +49,6 @@ function FutureViewTask(
   }
   const { original, filteredSubTasks, color } = compoundTask;
 
-  const icalUID = original.type === 'ONE_TIME' ? original.icalUID : '';
-  const isCanvasTask = typeof icalUID === 'string' ? icalUID !== '' : false;
-
   /**
    * Get an onClickHandler when the element is clicked.
    * This methods ensure that only clicking on task text counts.
@@ -116,7 +113,7 @@ function FutureViewTask(
         <TaskCheckBox />
         <TaskName />
         <PinIcon />
-        {isCanvasTask ? null : <RemoveTaskIcon />}
+        <RemoveTaskIcon />
       </div>
     );
   };

--- a/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
@@ -49,6 +49,9 @@ function FutureViewTask(
   }
   const { original, filteredSubTasks, color } = compoundTask;
 
+  const icalUID = original.type === 'ONE_TIME' ? original.icalUID : '';
+  const isCanvasTask = typeof icalUID === 'string' ? icalUID !== '' : false;
+
   /**
    * Get an onClickHandler when the element is clicked.
    * This methods ensure that only clicking on task text counts.
@@ -113,7 +116,7 @@ function FutureViewTask(
         <TaskCheckBox />
         <TaskName />
         <PinIcon />
-        <RemoveTaskIcon />
+        {isCanvasTask ? null : <RemoveTaskIcon />}
       </div>
     );
   };

--- a/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
@@ -81,6 +81,8 @@ function FloatingTaskEditor(
     trigger,
   }: Props,
 ): ReactElement {
+  const icalUID = initialTask.type === 'ONE_TIME' ? initialTask.icalUID : null;
+
   const [open, setOpen] = React.useState<boolean>(false);
 
   const editorRef = React.useRef<HTMLFormElement>(null);
@@ -120,6 +122,7 @@ function FloatingTaskEditor(
           <TaskEditor
             id={task.id}
             type={type}
+            icalUID={icalUID}
             taskAppearedDate={taskAppearedDate}
             mainTask={mainTask}
             subTasks={subTasks}

--- a/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
@@ -81,7 +81,7 @@ function FloatingTaskEditor(
     trigger,
   }: Props,
 ): ReactElement {
-  const icalUID = initialTask.type === 'ONE_TIME' ? initialTask.icalUID : null;
+  const icalUID = initialTask.type === 'ONE_TIME' ? initialTask.icalUID : '';
 
   const [open, setOpen] = React.useState<boolean>(false);
 

--- a/frontend/src/components/Util/TaskEditors/InlineTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/InlineTaskEditor.tsx
@@ -20,6 +20,7 @@ export default function InlineTaskEditor(
   const [disabled, setDisabled] = useState(true);
   const { id } = original;
   const { id: _, type, subTasks, ...mainTask } = filtered;
+  const icalUID = original.type === 'ONE_TIME' ? original.icalUID : null;
   const taskAppearedDate = mainTask.date instanceof Date ? mainTask.date.toDateString() : null;
   // To un-mount the editor when finished editing.
   const onFocus = (): void => setDisabled(false);
@@ -32,6 +33,7 @@ export default function InlineTaskEditor(
     <TaskEditor
       id={id}
       type={type}
+      icalUID={icalUID}
       taskAppearedDate={taskAppearedDate}
       className={className}
       mainTask={mainTask}

--- a/frontend/src/components/Util/TaskEditors/InlineTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/InlineTaskEditor.tsx
@@ -20,7 +20,7 @@ export default function InlineTaskEditor(
   const [disabled, setDisabled] = useState(true);
   const { id } = original;
   const { id: _, type, subTasks, ...mainTask } = filtered;
-  const icalUID = original.type === 'ONE_TIME' ? original.icalUID : null;
+  const icalUID = original.type === 'ONE_TIME' ? original.icalUID : '';
   const taskAppearedDate = mainTask.date instanceof Date ? mainTask.date.toDateString() : null;
   // To un-mount the editor when finished editing.
   const onFocus = (): void => setDisabled(false);

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/EditorHeader.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/EditorHeader.tsx
@@ -16,6 +16,7 @@ type Props = TagAndDate & {
   readonly getTag: (id: string) => Tag;
   readonly displayGrabber: boolean;
   readonly calendarPosition: CalendarPosition;
+  readonly icalUID?: string;
 };
 
 type EditorDisplayStatus = {
@@ -26,7 +27,7 @@ type EditorDisplayStatus = {
 const calendarIconClass = [styles.TaskEditorIconButton, styles.TaskEditorIcon].join(' ');
 
 export default function EditorHeader(
-  { tag, date, onChange, getTag, displayGrabber, calendarPosition }: Props,
+  { tag, date, onChange, getTag, displayGrabber, calendarPosition, icalUID }: Props,
 ): ReactElement {
   const [editorDisplayStatus, setEditorDisplayStatus] = React.useState<EditorDisplayStatus>({
     doesShowTagEditor: false,
@@ -79,6 +80,8 @@ export default function EditorHeader(
       calendarType="US"
     />
   );
+  const isCanvasTask = typeof icalUID === 'string' ? icalUID !== '' : false;
+
   return (
     <div className={headerClassName}>
       {displayGrabber && (
@@ -87,12 +90,15 @@ export default function EditorHeader(
       {tagDisplay}
       {tagEditor}
       <span className={styles.TaskEditorFlexiblePadding} />
-      <SamwiseIcon
-        iconName="calendar-light"
-        className={calendarIconClass}
-        style={{ marginRight: '8px' }}
-        onClick={toggleDateEditor}
-      />
+      {isCanvasTask ? null
+        : (
+          <SamwiseIcon
+            iconName="calendar-light"
+            className={calendarIconClass}
+            style={{ marginRight: '8px' }}
+            onClick={toggleDateEditor}
+          />
+        )}
       {dateDisplay}
       {dateEditor}
     </div>

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/MainTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/MainTaskEditor.tsx
@@ -46,6 +46,8 @@ function MainTaskEditor(
     onChange({ name: newValue });
   };
 
+  const isCanvasTask = typeof icalUID === 'string' ? icalUID !== '' : false;
+
   return (
     <div className={styles.TaskEditorFlexibleContainer}>
       <CheckBox
@@ -55,7 +57,7 @@ function MainTaskEditor(
       />
       <input
         type="text"
-        disabled={typeof icalUID === 'string' ? icalUID !== '' : false}
+        disabled={isCanvasTask}
         data-lpignore="true"
         className={complete
           ? styles.TaskEditorStrikethrough : styles.TaskEditorFlexibleInput}
@@ -69,7 +71,8 @@ function MainTaskEditor(
         className={styles.TaskEditorIcon}
         onClick={editInFocus}
       />
-      <SamwiseIcon iconName="x-light" className={deleteIconClass} onClick={onRemove} />
+      {isCanvasTask ? null
+        : <SamwiseIcon iconName="x-light" className={deleteIconClass} onClick={onRemove} />}
     </div>
   );
 }

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/MainTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/MainTaskEditor.tsx
@@ -12,7 +12,7 @@ type NameCompleteInFocus = {
 };
 type Props = NameCompleteInFocus & {
   readonly id: string;
-  readonly icalUID: string | null;
+  readonly icalUID?: string;
   readonly taskDate: Date | null;
   readonly dateAppeared: string;
   readonly onChange: (change: Partial<NameCompleteInFocus>) => void;
@@ -55,7 +55,7 @@ function MainTaskEditor(
       />
       <input
         type="text"
-        disabled={icalUID == null}
+        disabled={typeof icalUID === 'string' ? icalUID !== '' : false}
         data-lpignore="true"
         className={complete
           ? styles.TaskEditorStrikethrough : styles.TaskEditorFlexibleInput}

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/MainTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/MainTaskEditor.tsx
@@ -46,8 +46,6 @@ function MainTaskEditor(
     onChange({ name: newValue });
   };
 
-  const isCanvasTask = typeof icalUID === 'string' ? icalUID !== '' : false;
-
   return (
     <div className={styles.TaskEditorFlexibleContainer}>
       <CheckBox
@@ -57,7 +55,7 @@ function MainTaskEditor(
       />
       <input
         type="text"
-        disabled={isCanvasTask}
+        disabled={typeof icalUID === 'string' ? icalUID !== '' : false}
         data-lpignore="true"
         className={complete
           ? styles.TaskEditorStrikethrough : styles.TaskEditorFlexibleInput}
@@ -71,8 +69,7 @@ function MainTaskEditor(
         className={styles.TaskEditorIcon}
         onClick={editInFocus}
       />
-      {isCanvasTask ? null
-        : <SamwiseIcon iconName="x-light" className={deleteIconClass} onClick={onRemove} />}
+      <SamwiseIcon iconName="x-light" className={deleteIconClass} onClick={onRemove} />
     </div>
   );
 }

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/MainTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/MainTaskEditor.tsx
@@ -12,6 +12,7 @@ type NameCompleteInFocus = {
 };
 type Props = NameCompleteInFocus & {
   readonly id: string;
+  readonly icalUID: string | null;
   readonly taskDate: Date | null;
   readonly dateAppeared: string;
   readonly onChange: (change: Partial<NameCompleteInFocus>) => void;
@@ -23,7 +24,7 @@ const deleteIconClass = [styles.TaskEditorIcon, styles.TaskEditorIconLeftPad].jo
 
 function MainTaskEditor(
   {
-    id, taskDate, dateAppeared, name, complete, inFocus, onChange, onRemove, onPressEnter,
+    id, icalUID, taskDate, dateAppeared, name, complete, inFocus, onChange, onRemove, onPressEnter,
   }: Props,
 ): ReactElement {
   const replaceDateForFork = taskDate == null
@@ -54,6 +55,7 @@ function MainTaskEditor(
       />
       <input
         type="text"
+        disabled={icalUID == null}
         data-lpignore="true"
         className={complete
           ? styles.TaskEditorStrikethrough : styles.TaskEditorFlexibleInput}

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -42,7 +42,7 @@ type Actions = {
 type OwnProps = DefaultProps & {
   readonly id: string;
   readonly type: 'MASTER_TEMPLATE' | 'ONE_TIME';
-  readonly icalUID: string | null;
+  readonly icalUID?: string;
   // the date string that specifies when the task appears (useful for repeated task)
   readonly taskAppearedDate: string | null;
   readonly mainTask: MainTask; // The task given to the editor.

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -237,6 +237,7 @@ function TaskEditor(
           getTag={getTag}
           calendarPosition={calendarPosition}
           displayGrabber={displayGrabber == null ? false : displayGrabber}
+          icalUID={icalUID}
         />
         <MainTaskEditor
           id={id}

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -42,6 +42,7 @@ type Actions = {
 type OwnProps = DefaultProps & {
   readonly id: string;
   readonly type: 'MASTER_TEMPLATE' | 'ONE_TIME';
+  readonly icalUID: string | null;
   // the date string that specifies when the task appears (useful for repeated task)
   readonly taskAppearedDate: string | null;
   readonly mainTask: MainTask; // The task given to the editor.
@@ -67,6 +68,7 @@ function TaskEditor(
   {
     id,
     type,
+    icalUID,
     taskAppearedDate,
     mainTask: initMainTask,
     subTasks: initSubTasks,
@@ -238,6 +240,7 @@ function TaskEditor(
         />
         <MainTaskEditor
           id={id}
+          icalUID={icalUID}
           taskDate={date instanceof Date ? date : null}
           dateAppeared={taskAppearedDate}
           name={name}


### PR DESCRIPTION
### Summary

Disabled editing of task name, due date, and delete option for tasks imported from canvas feed.
- [x] disabled editing of task name for canvas tasks
- [x] removed calendar icon and delete icon for canvas tasks

### Test Plan 
Before:
![canvas tasks before](https://user-images.githubusercontent.com/48143149/73615468-02c4ef00-45d6-11ea-8947-163e835868ca.png)

After:
![canvas tasks no edit](https://user-images.githubusercontent.com/48143149/73615477-140dfb80-45d6-11ea-95bd-4fa781a96110.png)
