### PR TITLE
Automatically create PR to update JSON when E2E course-info failed

### DIFF
--- a/.github/workflows/e2e-course-info.yml
+++ b/.github/workflows/e2e-course-info.yml
@@ -49,7 +49,8 @@ jobs:
           rm a.json b.json
           cp course-info/sp20-courses-with-exams-min.json frontend/src/assets/json/
           git add .
-          git checkout -b "$BRANCH" master
+          git checkout master
+          git checkout -b "$BRANCH"
           git commit -m "[course-info][bot] Automatically update course JSON"
           git push "$ORIGIN" "$BRANCH" || git push --set-upstream "$ORIGIN" "$BRANCH"
       # Compare this against so that the later step can use the failure status

--- a/.github/workflows/e2e-course-info.yml
+++ b/.github/workflows/e2e-course-info.yml
@@ -54,7 +54,7 @@ jobs:
           git fetch --all
           git checkout master
           git checkout -b "$BRANCH"
-          git commit -m "[course-info][bot] Automatically update course JSON"
+          git commit -m "[course-info][bot] Automatically update course JSON" || echo "Empty commit."
           git push "$ORIGIN" "$BRANCH" || git push --set-upstream "$ORIGIN" "$BRANCH"
       # Compare this against so that the later step can use the failure status
       - name: Compare JSON against current JSON
@@ -70,8 +70,8 @@ jobs:
                 owner: 'cornell-dti',
                 repo: 'samwise',
                 title: '[course-info][bot] Automatically update course JSON',
-                head: 'master',
-                base: 'dti-github-bot/update-course-json'
+                base: 'master',
+                head: 'dti-github-bot/update-course-json'
               });
             } catch (error) {
               console.error(error);

--- a/.github/workflows/e2e-course-info.yml
+++ b/.github/workflows/e2e-course-info.yml
@@ -52,7 +52,8 @@ jobs:
           cp course-info/sp20-courses-with-exams-min.json frontend/src/assets/json/
           git add .
           git fetch --all
-          git checkout -b "$BRANCH" master
+          git checkout master
+          git checkout -b "$BRANCH"
           git commit -m "[course-info][bot] Automatically update course JSON"
           git push "$ORIGIN" "$BRANCH" || git push --set-upstream "$ORIGIN" "$BRANCH"
       # Compare this against so that the later step can use the failure status

--- a/.github/workflows/e2e-course-info.yml
+++ b/.github/workflows/e2e-course-info.yml
@@ -65,15 +65,10 @@ jobs:
         with:
           github-token: ${{ secrets.BOT_TOKEN }}
           script: |
-            try {
-              github.pulls.create({
-                owner: 'cornell-dti',
-                repo: 'samwise',
-                title: '[course-info][bot] Automatically update course JSON',
-                base: 'master',
-                head: 'dti-github-bot/update-course-json'
-              });
-            } catch (error) {
-              console.error(error);
-              console.error('Maybe the PR with the same branch is already created?');
-            }
+            github.pulls.create({
+              owner: 'cornell-dti',
+              repo: 'samwise',
+              title: '[course-info][bot] Automatically update course JSON',
+              base: 'master',
+              head: 'dti-github-bot/update-course-json'
+            });

--- a/.github/workflows/e2e-course-info.yml
+++ b/.github/workflows/e2e-course-info.yml
@@ -55,7 +55,7 @@ jobs:
           git checkout master
           git checkout -b "$BRANCH"
           git commit -m "[course-info][bot] Automatically update course JSON" || echo "Empty commit."
-          git push "$ORIGIN" "$BRANCH" || git push --set-upstream "$ORIGIN" "$BRANCH"
+          git push -f "$ORIGIN" "$BRANCH" || git push -f --set-upstream "$ORIGIN" "$BRANCH"
       # Compare this against so that the later step can use the failure status
       - name: Compare JSON against current JSON
         run: diff a.json b.json

--- a/.github/workflows/e2e-course-info.yml
+++ b/.github/workflows/e2e-course-info.yml
@@ -49,13 +49,13 @@ jobs:
           rm a.json b.json
           cp course-info/sp20-courses-with-exams-min.json frontend/src/assets/json/
           git add .
-          git checkout -b "$BRANCH"
+          git checkout -b "$BRANCH" master
           git commit -m "[course-info][bot] Automatically update course JSON"
           git push "$ORIGIN" "$BRANCH" || git push --set-upstream "$ORIGIN" "$BRANCH"
       # Compare this against so that the later step can use the failure status
       - name: Compare JSON against current JSON
         run: diff a.json b.json
-      - name: Comment on Pull Request
+      - name: Automatically create PR if JSON is different
         uses: actions/github-script@0.2.0
         if: failure()
         with:

--- a/.github/workflows/e2e-course-info.yml
+++ b/.github/workflows/e2e-course-info.yml
@@ -46,6 +46,9 @@ jobs:
           git config --global user.email "admin@cornelldti.org"
           ORIGIN="https://x-access-token:$BOT_TOKEN@github.com/cornell-dti/samwise.git"
           BRANCH="dti-github-bot/update-course-json"
+          rm a.json b.json
+          cp course-info/sp20-courses-with-exams-min.json frontend/src/assets/json/
+          git add .
           git checkout -b "$BRANCH"
           git commit -m "[course-info][bot] Automatically update course JSON"
           git push

--- a/.github/workflows/e2e-course-info.yml
+++ b/.github/workflows/e2e-course-info.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@master
         with:
           fetch-depth: 0
+          token: ${{ secrets.BOT_TOKEN }}
       - name: Set up Node 10
         uses: actions/setup-node@master
         with:
@@ -40,13 +41,10 @@ jobs:
       - name: Compare JSON against current JSON
         run: diff a.json b.json
       - name: Automatically create commit if JSON is different
-        env:
-          BOT_TOKEN: '${{ secrets.BOT_TOKEN }}'
         if: failure()
         run: |
           git config --global user.name "dti-github-bot"
           git config --global user.email "admin@cornelldti.org"
-          ORIGIN="https://x-access-token:$BOT_TOKEN@github.com/cornell-dti/samwise.git"
           BRANCH="dti-github-bot/update-course-json"
           rm a.json b.json
           cp course-info/sp20-courses-with-exams-min.json frontend/src/assets/json/
@@ -55,7 +53,7 @@ jobs:
           git checkout master
           git checkout -b "$BRANCH"
           git commit -m "[course-info][bot] Automatically update course JSON" || echo "Empty commit."
-          git push -f "$ORIGIN" "$BRANCH" || git push -f --set-upstream "$ORIGIN" "$BRANCH"
+          git push -f origin "$BRANCH" || git push -f --set-upstream origin "$BRANCH"
       # Compare this against so that the later step can use the failure status
       - name: Compare JSON against current JSON
         run: diff a.json b.json

--- a/.github/workflows/e2e-course-info.yml
+++ b/.github/workflows/e2e-course-info.yml
@@ -62,7 +62,7 @@ jobs:
           github-token: ${{ secrets.BOT_TOKEN }}
           script: |
             try {
-              octokit.pulls.create({
+              github.pulls.create({
                 owner: 'cornell-dti',
                 repo: 'samwise',
                 title: '[course-info][bot] Automatically update course JSON',

--- a/.github/workflows/e2e-course-info.yml
+++ b/.github/workflows/e2e-course-info.yml
@@ -37,3 +37,36 @@ jobs:
           cat frontend/src/assets/json/sp20-courses-with-exams-min.json | jq 'sort_by(.courseNumber)' > b.json
       - name: Compare JSON against current JSON
         run: diff a.json b.json
+      - name: Automatically create commit if JSON is different
+        env:
+          BOT_TOKEN: '${{ secrets.BOT_TOKEN }}'
+        if: failure()
+        run: |
+          git config --global user.name "dti-github-bot"
+          git config --global user.email "admin@cornelldti.org"
+          ORIGIN="https://x-access-token:$BOT_TOKEN@github.com/cornell-dti/samwise.git"
+          BRANCH="dti-github-bot/update-course-json"
+          git branch -b "$BRANCH"
+          git commit -m "[course-info][bot] Automatically update course JSON"
+          git push
+      # Compare this against so that the later step can use the failure status
+      - name: Compare JSON against current JSON
+        run: diff a.json b.json
+      - name: Comment on Pull Request
+        uses: actions/github-script@0.2.0
+        if: failure()
+        with:
+          github-token: ${{ secrets.BOT_TOKEN }}
+          script: |
+            try {
+              octokit.pulls.create({
+                owner: 'cornell-dti',
+                repo: 'samwise',
+                title: '[course-info][bot] Automatically update course JSON',
+                head: 'master',
+                base: 'dti-github-bot/update-course-json'
+              });
+            } catch (error) {
+              console.error(error);
+              console.error('Maybe the PR with the same branch is already created?');
+            }

--- a/.github/workflows/e2e-course-info.yml
+++ b/.github/workflows/e2e-course-info.yml
@@ -51,7 +51,7 @@ jobs:
           git add .
           git checkout -b "$BRANCH"
           git commit -m "[course-info][bot] Automatically update course JSON"
-          git push
+          git push "$ORIGIN" "$BRANCH" || git push --set-upstream "$ORIGIN" "$BRANCH"
       # Compare this against so that the later step can use the failure status
       - name: Compare JSON against current JSON
         run: diff a.json b.json

--- a/.github/workflows/e2e-course-info.yml
+++ b/.github/workflows/e2e-course-info.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
       - name: Set up Node 10
         uses: actions/setup-node@master
         with:
@@ -49,8 +51,8 @@ jobs:
           rm a.json b.json
           cp course-info/sp20-courses-with-exams-min.json frontend/src/assets/json/
           git add .
-          git checkout master
-          git checkout -b "$BRANCH"
+          git fetch --all
+          git checkout -b "$BRANCH" master
           git commit -m "[course-info][bot] Automatically update course JSON"
           git push "$ORIGIN" "$BRANCH" || git push --set-upstream "$ORIGIN" "$BRANCH"
       # Compare this against so that the later step can use the failure status

--- a/.github/workflows/e2e-course-info.yml
+++ b/.github/workflows/e2e-course-info.yml
@@ -46,7 +46,7 @@ jobs:
           git config --global user.email "admin@cornelldti.org"
           ORIGIN="https://x-access-token:$BOT_TOKEN@github.com/cornell-dti/samwise.git"
           BRANCH="dti-github-bot/update-course-json"
-          git branch -b "$BRANCH"
+          git checkout -b "$BRANCH"
           git commit -m "[course-info][bot] Automatically update course JSON"
           git push
       # Compare this against so that the later step can use the failure status


### PR DESCRIPTION
### Summary

This pull request tries to let @dti-github-bot automatically create a PR when the E2E test on course info json failed. I hope this can reduce our burden to update stuff.
Ideally, we can show the diff inline in the created PR comment, but it might us to switch the entire workflow to github actions. It's not too bad to look at the latest master E2E test failure to see what's changed, so I decide not to implement it, as least in this diff.

### Test Plan

See CI running result. The PR is created in https://github.com/cornell-dti/samwise/pull/412.
The consistency test is designed to fail, so that the PR creation job can be triggered. The create PR job also fails because the PR is already created. This error cannot be try-catched, but I don't think it's too big because it can remind people to review PRs. :)