### PR TITLE
Use `active` prop to decide whether to override state with props in `TaskEditor`

### DIFF
--- a/frontend/src/components/Util/TaskEditors/InlineTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/InlineTaskEditor.tsx
@@ -42,7 +42,7 @@ export default function InlineTaskEditor(
       displayGrabber
       calendarPosition={calendarPosition}
       newSubTaskAutoFocused={!original.inFocus}
-      newSubTaskDisabled={disabled}
+      active={disabled}
       onFocus={onFocus}
       onBlur={onBlur}
     />

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -26,7 +26,7 @@ type DefaultProps = {
   readonly displayGrabber?: boolean;
   readonly className?: string;
   readonly newSubTaskAutoFocused?: boolean; // whether to auto focus the new subtask
-  readonly newSubTaskDisabled?: boolean; // whether to disable new subtask creation
+  readonly active?: boolean; // whether the task is actively being edited.
   readonly onFocus?: () => void; // when the editor gets focus
   readonly onBlur?: () => void; // when the editor loses focus
   readonly editorRef?: { current: HTMLFormElement | null }; // the ref of the editor
@@ -77,7 +77,7 @@ function TaskEditor(
     getTag,
     className,
     newSubTaskAutoFocused,
-    newSubTaskDisabled,
+    active,
     onFocus,
     onBlur,
     editorRef,
@@ -94,7 +94,7 @@ function TaskEditor(
     dispatchEditSubTask,
     dispatchDeleteSubTask,
     reset,
-  } = useTaskDiffReducer(initMainTask, initSubTasks, onChange ?? ignore);
+  } = useTaskDiffReducer(initMainTask, initSubTasks, active ?? false, onChange ?? ignore);
 
   const { name, tag, date, complete, inFocus } = mainTask;
 
@@ -269,7 +269,7 @@ function TaskEditor(
         ))}
         <div
           className={styles.SubtaskHide}
-          style={newSubTaskDisabled === true ? { maxHeight: 0 } : undefined}
+          style={active === true ? { maxHeight: 0 } : undefined}
         >
           <NewSubTaskEditor
             onFirstType={handleCreatedNewSubtask}

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/task-diff-reducer.ts
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/task-diff-reducer.ts
@@ -134,13 +134,15 @@ function reducer(state: State, action: Action): State {
 export default function useTaskDiffReducer(
   initMainTask: MainTask,
   initSubTasks: readonly SubTask[],
+  active: boolean,
   onChange: () => void,
 ): TaskDiffActions {
   const [state, dispatch] = useReducer(reducer, [initMainTask, initSubTasks], initializer);
   const { mainTask, subTasks, prevFullTask, diff } = state;
   if (
-    !shallowEqual(prevFullTask.mainTask, initMainTask)
-    || !shallowArrayEqual(prevFullTask.subTasks, initSubTasks)
+    !active
+    && (!shallowEqual(prevFullTask.mainTask, initMainTask)
+      || !shallowArrayEqual(prevFullTask.subTasks, initSubTasks))
   ) {
     dispatch({ type: 'RESET', mainTask: initMainTask, subTasks: initSubTasks });
   }


### PR DESCRIPTION
### Summary

This is a partial attempt to make the TaskEditor more manageable, with some of the spirit in #351.

It still does not completely solve the problem of focus state getting lost while the DOM get nuked, but we can observe that the same problem also exists in the `FloatingTaskEditor` in the future view. Historically, `FloatingTaskEditor` breaks much less often than `InlineTaskEditor`, so I think the current approach is not complete nonsense. If we think about it carefully, we will find that the major difference between `FloatingTaskEditor` and `InlineEditor` is that `FloatingTaskEditor` is guaranteed to be active when the component got rendered, while the same is not true for `InlineTaskEditor`. This creates a problem where `FloatingTaskEditor` does not need to care about state getting overridden by props, but `InlineTaskEditor` does. In the past, there is some code written to hack around the problem for `InlineTaskEditor`, which makes it avoid an override when the state matches the props. This code has to be in the common `TaskEditor` to that code reuse can happen.

However, the above solution is still not satisfactory, because the common code is trying to solve a problem that is experienced by one of its user. This diff attempts to remove this entangled logic by introducing the `active` prop. With the active prop, the `TaskEditor` can know explicitly whether it's only used for rendering or for editing. Then the code of avoiding overriding state with props in reducer can start to make sense, because it now starts to depend on the value `active`.

While implementing the above approach, I found that we already have a property called `newSubTaskDisabled` and it's used essentially like `!active`, so I just replaced it with `active`. This is why you see all this diff does is changing the name of a prop and passing it to reducer.

Another interesting observation while I'm working on this: it looks like that majority of the complexity of `TaskEditor` comes from the state management of the name of the main task and a list of subtasks, and `active` actually only applies to the names of the tasks. We could refactor the code for these logic from `TaskEditor` into a smaller helper component in the future.

### Test Plan <!-- Required -->

Task Editor still works.

### Notes

Close #351, since I don't think there exists better approaches.