### PR TITLE
Reduce course json update frequency

### DIFF
--- a/.github/workflows/e2e-course-info.yml
+++ b/.github/workflows/e2e-course-info.yml
@@ -1,6 +1,6 @@
 on:
   schedule:
-    - cron: '0 */12 * * *'
+    - cron: '0 0 * * 1/2'
   push:
     branches:
       - master


### PR DESCRIPTION
### Summary <!-- Required -->

Even if it's checking twice a day, we don't review code that often and sometimes we will batch json updates. Let's reduce the frequency to be only run on Mon/Wed/Fri to reduce the noise. I choose workdays because part json update record shows that cornell does not update these information on weekends.

### Test Plan <!-- Required -->

<img width="355" alt="cron" src="https://user-images.githubusercontent.com/4290500/75098322-91e47780-5582-11ea-9986-0f69855613c6.png">
Screenshot taken from github actions online editor, which shows that it does what's suppose to do.
