### PR TITLE
[WIP] Assign tags to Canvas tasks

### DIFF
--- a/frontend/src/components/Util/TaskEditors/TaskEditor/EditorHeader.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/EditorHeader.tsx
@@ -1,6 +1,7 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useEffect } from 'react';
 import Calendar from 'react-calendar';
 import { Tag, RepeatMetaData } from 'common/lib/types/store-types';
+import { getCanvasTag } from 'firebase/actions';
 import styles from './index.module.css';
 import TagListPicker from '../../TagListPicker/TagListPicker';
 import { CalendarPosition } from '../editors-types';
@@ -17,6 +18,7 @@ type Props = TagAndDate & {
   readonly displayGrabber: boolean;
   readonly calendarPosition: CalendarPosition;
   readonly icalUID?: string;
+  readonly taskName: string;
 };
 
 type EditorDisplayStatus = {
@@ -27,7 +29,7 @@ type EditorDisplayStatus = {
 const calendarIconClass = [styles.TaskEditorIconButton, styles.TaskEditorIcon].join(' ');
 
 export default function EditorHeader(
-  { tag, date, onChange, getTag, displayGrabber, calendarPosition, icalUID }: Props,
+  { tag, date, onChange, getTag, displayGrabber, calendarPosition, icalUID, taskName }: Props,
 ): ReactElement {
   const [editorDisplayStatus, setEditorDisplayStatus] = React.useState<EditorDisplayStatus>({
     doesShowTagEditor: false,
@@ -81,6 +83,16 @@ export default function EditorHeader(
     />
   );
   const isCanvasTask = typeof icalUID === 'string' ? icalUID !== '' : false;
+
+  const assignCanvasTag = (): void => {
+    if (isCanvasTask) {
+      const id = getCanvasTag(taskName);
+      onChange({ tag: id });
+    }
+  };
+  // triggered when task in future view is clicked
+  const useEffectOnce = (func: () => void): void => useEffect(func, []);
+  useEffectOnce(assignCanvasTag);
 
   return (
     <div className={headerClassName}>

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -238,6 +238,7 @@ function TaskEditor(
           calendarPosition={calendarPosition}
           displayGrabber={displayGrabber == null ? false : displayGrabber}
           icalUID={icalUID}
+          taskName={name}
         />
         <MainTaskEditor
           id={id}

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -85,6 +85,23 @@ export const removeTag = (id: string): void => {
   actions.removeTag(id).then(reportDeleteTagEvent);
 };
 
+export const getCanvasTag = (taskName?: string): string => {
+  const { tags } = store.getState();
+  let tagId = 'THE_GLORIOUS_NONE_TAG';
+  tags.forEach((tag: Tag) => {
+    // tag names for imported classes have the form
+    // 'CS 4820: Intro Analysis of Algorithms'
+    const { id, name } = tag;
+    const tagName = name.split(':')[0].replace(/\s/g, '');
+    // canvas task names have the form 'HW 3 [MATH2930]'
+    const canvasName = taskName?.split('[')[1].replace(/]/g, '');
+    if (tagName === canvasName) {
+      tagId = id;
+    }
+  });
+  return tagId;
+};
+
 /*
  * --------------------------------------------------------------------------------
  * Section 2: Tasks Actions

--- a/functions/src/iCalFunctions.ts
+++ b/functions/src/iCalFunctions.ts
@@ -22,26 +22,6 @@ export default async function getICalLink(): Promise<void> {
     });
 }
 
-const assignCanvasTag = (user: string, taskName?: string): string => {
-  database.tagsCollection()
-    .where('owner', '==', user)
-    .get()
-    .then((querySnapshot) => {
-      querySnapshot.forEach((doc) => {
-        // tag names for imported classes have the form
-        // 'CS 4820: Intro Analysis of Algorithms'
-        const tagName = doc.data().name.split(':')[0].replace(/\s/g, '');
-        // canvas task names have the form 'HW 3 [MATH2930]'
-        const className = taskName?.split('[')[1].replace(/]/g, '');
-        if (tagName === className) return doc.id;
-        return 'THE_GLORIOUS_NONE_TAG';
-      });
-    })
-    .catch((error) => {
-      console.log('Error getting documents: ', error);
-    });
-};
-
 export function parseICal(link: string, user: string): void {
   const orderManager = new OrderManager(database, () => user);
   fromURL(link, {}, async (_, data) => {
@@ -59,7 +39,6 @@ export function parseICal(link: string, user: string): void {
           const endDate = endObject === null ? null : new Date(endObject.getTime());
           const taskID: string = database.tasksCollection().doc().id;
           const order: number = await orderManager.allocateNewOrder('tasks');
-          const canvasTag: string = assignCanvasTag(user, taskName);
           if (endDate === null) {
             // eslint-disable-next-line no-continue
             continue;
@@ -80,7 +59,7 @@ export function parseICal(link: string, user: string): void {
                       name: taskName,
                       order,
                       owner: user,
-                      tag: canvasTag,
+                      tag: 'THE_GLORIOUS_NONE_TAG',
                       type: 'ONE_TIME',
                       icalUID: uid,
                     })

--- a/functions/src/iCalFunctions.ts
+++ b/functions/src/iCalFunctions.ts
@@ -22,6 +22,26 @@ export default async function getICalLink(): Promise<void> {
     });
 }
 
+const assignCanvasTag = (user: string, taskName?: string): string => {
+  database.tagsCollection()
+    .where('owner', '==', user)
+    .get()
+    .then((querySnapshot) => {
+      querySnapshot.forEach((doc) => {
+        // tag names for imported classes have the form
+        // 'CS 4820: Intro Analysis of Algorithms'
+        const tagName = doc.data().name.split(':')[0].replace(/\s/g, '');
+        // canvas task names have the form 'HW 3 [MATH2930]'
+        const className = taskName?.split('[')[1].replace(/]/g, '');
+        if (tagName === className) return doc.id;
+        return 'THE_GLORIOUS_NONE_TAG';
+      });
+    })
+    .catch((error) => {
+      console.log('Error getting documents: ', error);
+    });
+};
+
 export function parseICal(link: string, user: string): void {
   const orderManager = new OrderManager(database, () => user);
   fromURL(link, {}, async (_, data) => {
@@ -39,6 +59,7 @@ export function parseICal(link: string, user: string): void {
           const endDate = endObject === null ? null : new Date(endObject.getTime());
           const taskID: string = database.tasksCollection().doc().id;
           const order: number = await orderManager.allocateNewOrder('tasks');
+          const canvasTag: string = assignCanvasTag(user, taskName);
           if (endDate === null) {
             // eslint-disable-next-line no-continue
             continue;
@@ -59,7 +80,7 @@ export function parseICal(link: string, user: string): void {
                       name: taskName,
                       order,
                       owner: user,
-                      tag: 'THE_GLORIOUS_NONE_TAG',
+                      tag: canvasTag,
                       type: 'ONE_TIME',
                       icalUID: uid,
                     })


### PR DESCRIPTION
### Summary 
When an iCal feed is linked to a user's calendar, the imported Canvas tasks have the default "None" tag. We want to choose a suitable tag from the user's current list of tags to assign to their Canvas tasks.

Names of class tags from imported classes have the form "CS 4820: Intro Analysis of Algorithms". Canvas task names have the form "HW 4 [ENGRD2700]". Regex is used to extract course codes (for example, "CS4820") from the Canvas task and tag names. 

Compare the course codes (for example "CS4820" and "ENGRD2700"). Course codes are case-sensitive. If the course codes match, then the tag id is assigned to the Canvas task. If the user has their own custom tag named "CS 2110" and also has a class tag "CS 2110", the custom tag takes precedence.

- [x] Tags are assigned to Canvas tasks when the task is pinned to focus view or if the task editor is opened.

### Test Plan
- Open the task editor for a Canvas task, or pin the Canvas task to the focus view. A tag matching the course code should automatically be assigned to the task.
- If the tag for a Canvas task is changed, reopening the task editor or pinning it to focus view will reset the tag to the assigned tag.

### Notes
- Canvas tasks should have suitable tags automatically assigned to them, but assignCanvasTag() is triggered only when the EditorHeader for task editors is rendered or when tasks in focus view are rendered.