### PR TITLE
Fix tab editor issue

### DIFF
--- a/frontend/src/components/TaskCreator/DatePicker.tsx
+++ b/frontend/src/components/TaskCreator/DatePicker.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, SyntheticEvent, ChangeEvent } from 'react';
+import React, { ReactElement, SyntheticEvent, ChangeEvent, KeyboardEvent } from 'react';
 import Calendar from 'react-calendar';
 import { useTodayLastSecondTime, useTodayFirstSecondTime } from 'hooks/time-hook';
 import { date2String, getDateAfterXWeeks } from 'common/lib/util/datetime-util';
@@ -44,6 +44,9 @@ export default function DatePicker(props: Props): ReactElement {
 
   // Controllers
   const clickPicker = (): void => { onPickerOpened(); };
+  const pressedPicker = (e: KeyboardEvent): void => {
+    if (e.key === 'Enter' || e.key === ' ') onPickerOpened();
+  };
   const reset = (e: SyntheticEvent<HTMLElement>): void => {
     e.stopPropagation();
     onClearPicker();
@@ -101,7 +104,13 @@ export default function DatePicker(props: Props): ReactElement {
         </>
       );
     return (
-      <span role="presentation" onClick={clickPicker} className={styles.Label} style={style}>
+      <span
+        role="presentation"
+        onClick={clickPicker}
+        onKeyPress={pressedPicker}
+        className={styles.Label}
+        style={style}
+      >
         {internal}
       </span>
     );

--- a/frontend/src/components/TaskCreator/FocusPicker.tsx
+++ b/frontend/src/components/TaskCreator/FocusPicker.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, SyntheticEvent } from 'react';
+import React, { ReactElement, SyntheticEvent, KeyboardEvent } from 'react';
 import styles from './Picker.module.css';
 import SamwiseIcon from '../UI/SamwiseIcon';
 
@@ -12,10 +12,21 @@ export default function FocusPicker({ pinned, onPinChange }: Props): ReactElemen
     e.stopPropagation();
     onPinChange(!pinned);
   };
+  const pressedPicker = (e: KeyboardEvent): void => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.stopPropagation();
+      onPinChange(!pinned);
+    }
+  };
   const pinIconName = pinned ? 'pin-dark-filled' : 'pin-dark-outline';
   return (
     <div className={styles.Main}>
-      <span role="presentation" onClick={clickPicker} className={styles.Label}>
+      <span
+        role="presentation"
+        onClick={clickPicker}
+        onKeyPress={pressedPicker}
+        className={styles.Label}
+      >
         <SamwiseIcon iconName={pinIconName} className={styles.CenterIcon} />
       </span>
     </div>

--- a/frontend/src/components/TaskCreator/TagPicker.tsx
+++ b/frontend/src/components/TaskCreator/TagPicker.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, KeyboardEvent } from 'react';
 import { connect } from 'react-redux';
 import { NONE_TAG, NONE_TAG_ID } from 'common/lib/util/tag-util';
 import { State, Tag } from 'common/lib/types/store-types';
@@ -20,6 +20,9 @@ type Props = OwnProps & {
 function TagPicker({ tag, opened, onTagChange, onPickerOpened, getTag }: Props): ReactElement {
   // Controllers
   const clickPicker = (): void => { onPickerOpened(); };
+  const pressedPicker = (e: KeyboardEvent): void => {
+    if (e.key === 'Enter' || e.key === ' ') onPickerOpened();
+  };
   const reset = (): void => onTagChange(NONE_TAG_ID);
   // Nodes
   const displayedNode = (isDefault: boolean): ReactElement => {
@@ -34,7 +37,13 @@ function TagPicker({ tag, opened, onTagChange, onPickerOpened, getTag }: Props):
         </>
       );
     return (
-      <span role="presentation" onClick={clickPicker} className={styles.Label} style={style}>
+      <span
+        role="presentation"
+        onClick={clickPicker}
+        onKeyPress={pressedPicker}
+        className={styles.Label}
+        style={style}
+      >
         {internal}
       </span>
     );

--- a/frontend/src/components/TaskCreator/__snapshots__/FocusPicker.test.tsx.snap
+++ b/frontend/src/components/TaskCreator/__snapshots__/FocusPicker.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Pinned FocusPicker matches snapshot 1`] = `
   <span
     className="Label"
     onClick={[Function]}
+    onKeyPress={[Function]}
     role="presentation"
   >
     <span
@@ -35,6 +36,7 @@ exports[`Unpinned FocusPicker matches snapshot 1`] = `
   <span
     className="Label"
     onClick={[Function]}
+    onKeyPress={[Function]}
     role="presentation"
   >
     <span

--- a/frontend/src/components/TaskCreator/__snapshots__/TagPicker.test.tsx.snap
+++ b/frontend/src/components/TaskCreator/__snapshots__/TagPicker.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`TagPicker(THE_GLORIOUS_NONE_TAG, false) matches snapshot 1`] = `
   <span
     className="Label"
     onClick={[Function]}
+    onKeyPress={[Function]}
     role="presentation"
     style={Object {}}
   >
@@ -36,6 +37,7 @@ exports[`TagPicker(THE_GLORIOUS_NONE_TAG, true) matches snapshot 1`] = `
   <span
     className="Label"
     onClick={[Function]}
+    onKeyPress={[Function]}
     role="presentation"
     style={Object {}}
   >
@@ -125,6 +127,7 @@ exports[`TagPicker(bar, false) matches snapshot 1`] = `
   <span
     className="Label"
     onClick={[Function]}
+    onKeyPress={[Function]}
     role="presentation"
     style={
       Object {
@@ -155,6 +158,7 @@ exports[`TagPicker(bar, true) matches snapshot 1`] = `
   <span
     className="Label"
     onClick={[Function]}
+    onKeyPress={[Function]}
     role="presentation"
     style={
       Object {
@@ -245,6 +249,7 @@ exports[`TagPicker(baz, false) matches snapshot 1`] = `
   <span
     className="Label"
     onClick={[Function]}
+    onKeyPress={[Function]}
     role="presentation"
     style={
       Object {
@@ -275,6 +280,7 @@ exports[`TagPicker(baz, true) matches snapshot 1`] = `
   <span
     className="Label"
     onClick={[Function]}
+    onKeyPress={[Function]}
     role="presentation"
     style={
       Object {
@@ -365,6 +371,7 @@ exports[`TagPicker(foo, false) matches snapshot 1`] = `
   <span
     className="Label"
     onClick={[Function]}
+    onKeyPress={[Function]}
     role="presentation"
     style={
       Object {
@@ -395,6 +402,7 @@ exports[`TagPicker(foo, true) matches snapshot 1`] = `
   <span
     className="Label"
     onClick={[Function]}
+    onKeyPress={[Function]}
     role="presentation"
     style={
       Object {


### PR DESCRIPTION
### Summary

Adds a `onKeyPress` event handler to each of the picker components (TagPicker, FocusPicker, and DatePicker).

- [x] fixed #435 

### Test Plan
- Open the create a new task editor
- Tab to one of the pickers (focus picker, tag picker, or date picker)
- Pressing the enter key or spacebar should activate the picker