### PR TITLE
Fix all linter warnings

### DIFF
--- a/functions/canvasFunctions/canvasFunctions.ts
+++ b/functions/canvasFunctions/canvasFunctions.ts
@@ -1,36 +1,30 @@
 import fetch, { Response } from 'node-fetch';
-// @ts-ignore
 import { parse } from 'json-bigint';
 
 function getUri(path: string, token: string): string {
   return `https://canvas.instructure.com/api/v1/${path}?access_token=${token}`;
 }
 
-async function canvasGetAssignments(token: string): Promise<any> {
-  await fetch(getUri('courses', token), {
+async function canvasGetAssignments(token: string): Promise<void> {
+  const response = await fetch(getUri('courses', token), {
     method: 'GET',
-  }).then((response: Response) => response.text())
-    .then((json) => {
-      getAssignments(token, parse(json));
-    }).catch((err) => {
-      console.log(err);
-    });
+  });
+  const json = await response.text();
+  await getAssignments(token, parse(json));
 }
 
-async function getAssignments(token: string, data: JSON[]): Promise<void> {
+type Course = { readonly id: number };
+
+async function getAssignments(token: string, data: readonly Course[]): Promise<void> {
   const assignmentList: JSON[] = [];
   await data.forEach((course) => {
-    // @ts-ignore
     fetch(getUri(`courses/${course.id.toString()}/assignments`, token), {
       method: 'GET',
     }).then((response: Response) => response.text())
       .then((json) => {
         assignmentList.push(parse(json));
-      }).catch((err) => {
-        console.log(err);
       });
   });
-  console.log(assignmentList);
 }
 
 canvasGetAssignments('9713~v6sFYkNFHbgXE3Bgo1JBLP7LO18t2aFCs6cvgbcLAOGPA6ejv51ozK8fV92Jq3Hs');

--- a/functions/json-bigint.d.ts
+++ b/functions/json-bigint.d.ts
@@ -1,0 +1,9 @@
+/**
+ * The package doesn't ship with a type definition.
+ * We will add the types of the functions we use here.
+ */
+
+declare module 'json-bigint' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const parse: (jsonString: string) => any;
+}

--- a/functions/src/ical-parser.ts
+++ b/functions/src/ical-parser.ts
@@ -1,11 +1,16 @@
-export default function icalParse(text: string): Array<Record<string, any>> {
+type Event = {
+  readonly uid: string;
+  readonly date: Date;
+  readonly name: string;
+};
+
+export default function icalParse(text: string): readonly Event[] {
   const lines = text.split('\n');
   let eventState = false;
   let uid = '';
   let date = new Date();
   let name = '';
-  const events = [];
-  // console.log(lines);
+  const events: Event[] = [];
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i].replace(/\s/g, '');
     if (line === 'BEGIN:VEVENT') {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3,14 +3,7 @@ import getICalLink from './iCalFunctions';
 import focusTasksDueToday from './focus-today-task';
 import removeOldTasks from './remove-old-tasks';
 
-export const iCalFunction = functions.pubsub.schedule('0 0 * * *').onRun(() => {
-  getICalLink()
-    .catch((err) => console.log(err))
-    .then(() => {
-      console.log('finished getICalLink()');
-    })
-    .catch((err) => console.log(err));
-});
+export const iCalFunction = functions.pubsub.schedule('0 0 * * *').onRun(getICalLink);
 
 export const FocusTasksDueToday = functions.pubsub.schedule('0 0 * * *').onRun(focusTasksDueToday);
 


### PR DESCRIPTION
### Summary

Fix linter warnings and strictify some types instead of `any`.

### Test Plan

Deployed it to staging and run it without any problems. However, I did notice a preexsting problem. The implementation removes all whitespaces in a line, which causes the task names to be very ugly. See issue #450.