### PR TITLE
Cleaner bot comment

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -42,7 +42,8 @@ jobs:
           PERSONAL_TOKEN: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
         with:
           keepFiles: true
-      - uses: cornell-dti/dti-repo-tools@master
+      - name: Comment on pull request
+        uses: cornell-dti/dti-repo-tools@master
         env:
           BOT_TOKEN: '${{ secrets.BOT_TOKEN }}'
         with:

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -42,14 +42,9 @@ jobs:
           PERSONAL_TOKEN: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
         with:
           keepFiles: true
-      - name: Comment on Pull Request
-        uses: actions/github-script@0.2.0
+      - uses: cornell-dti/dti-repo-tools@master
+        env:
+          BOT_TOKEN: '${{ secrets.BOT_TOKEN }}'
         with:
-          github-token: ${{ github.token }}
-          script: |
-            github.issues.createComment({
-              owner: 'cornell-dti',
-              repo: 'samwise',
-              issue_number: ${{ github.event.number }},
-              body: 'Deployed to https://staging-pr.samwise.today/${{ github.event.number }}/index.html'
-            });
+          command: pr-comment
+          argument: '[deployment-bot] Deployed to https://staging-pr.samwise.today/${{ github.event.number }}/index.html'


### PR DESCRIPTION
### Summary

The previous setup will add a new comment whenever the PR has updated commits. That's quite annoying.

I wrote a new github actions in https://github.com/cornell-dti/dti-repo-tools to avoid this by editing the already posted commit. (In case the content is the same, it will be a no-op). This diff switches to use that github action.

### Test Plan

Added a second commit to test its effect. You will find that no more commits are posted by the bot.