### PR TITLE
Make More Tasks button appear again + fix FloatingView position

### DIFF
--- a/frontend/src/components/TaskView/FutureView/FutureViewDay.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewDay.tsx
@@ -36,34 +36,16 @@ type PropsForPositionComputation = {
  */
 const computeFloatingViewStyle = (props: PropsForPositionComputation): PositionStyle => {
   const {
-    tasksHeight, inNDaysView, windowSize,
-    mainViewPosition: { width, height, top },
+    tasksHeight,
+    mainViewPosition: { width },
   } = props;
-  // Compute the height of inner content
+  // Compute the total height of inner content: the task container for a given day.
   const totalHeight = headerHeight + tasksHeight;
-  // Decide the maximum allowed height and the actual height
-  const maxAllowedHeight = inNDaysView ? 500 : 300;
-  const floatingViewHeight = Math.min(totalHeight, maxAllowedHeight);
-  // Compute ideal offset
-  let topOffset = (height - floatingViewHeight) / 2;
-  // Correct the offsets if they overflow.
-  {
-    const windowHeight = windowSize.height;
-    const topAbsolutePosition = top + topOffset;
-    if (topAbsolutePosition < 0) {
-      topOffset -= topAbsolutePosition;
-    } else {
-      const bottomAbsolutePosition = topAbsolutePosition + floatingViewHeight;
-      const diff = bottomAbsolutePosition - windowHeight;
-      if (diff > 0) {
-        topOffset -= diff;
-      }
-    }
-  }
+
   return {
     width: `${width}px`,
-    height: `${floatingViewHeight}px`,
-    top: `${topOffset}px`,
+    height: `${totalHeight}px`,
+    top: '0',
     left: '0',
   };
 };
@@ -136,6 +118,7 @@ export function FutureViewDay(props: Props & { readonly theme: Theme }): ReactEl
           calendarPosition={calendarPosition}
           doesShowCompletedTasks={doesShowCompletedTasks}
           theme={theme}
+          containerHeight={headerHeight}
         />
         {heightInfo.doesOverflow && (
           <button type="button" className={styles.MoreTasksBar} onClick={openFloatingView} tabIndex={0}>
@@ -180,6 +163,7 @@ export function FutureViewDay(props: Props & { readonly theme: Theme }): ReactEl
           calendarPosition={calendarPosition}
           doesShowCompletedTasks={doesShowCompletedTasks}
           theme={theme}
+          containerHeight={heightInfo.tasksHeight + headerHeight}
         />
       </div>
     </div>

--- a/frontend/src/components/TaskView/FutureView/FutureViewDay.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewDay.tsx
@@ -1,54 +1,11 @@
 import React, { ReactElement } from 'react';
 import { connect } from 'react-redux';
 import { getTodayAtZeroAM } from 'common/lib/util/datetime-util';
-import { error } from 'common/lib/util/general-util';
 import { State, Theme } from 'common/lib/types/store-types';
 import { SimpleDate } from './future-view-types';
 import { CalendarPosition, FloatingPosition } from '../../Util/TaskEditors/editors-types';
 import styles from './FutureViewDay.module.scss';
-import { headerHeight } from './future-view-css-props';
-import { useWindowSize, WindowSize } from '../../../hooks/window-size-hook';
 import FutureViewDayContent from './FutureViewDayContent';
-
-type Position = {
-  readonly width: number;
-  readonly height: number;
-  readonly top: number;
-  readonly left: number;
-};
-type PositionStyle = {
-  readonly width: string;
-  readonly height: string;
-  readonly top: string;
-  readonly left: string;
-};
-type PropsForPositionComputation = {
-  readonly tasksHeight: number;
-  readonly inNDaysView: boolean;
-  readonly windowSize: WindowSize;
-  readonly mainViewPosition: Position;
-};
-
-/**
- * Returns the computed floating view style from some properties.
- *
- * @return the computed style.
- */
-const computeFloatingViewStyle = (props: PropsForPositionComputation): PositionStyle => {
-  const {
-    tasksHeight,
-    mainViewPosition: { width },
-  } = props;
-  // Compute the total height of inner content: the task container for a given day.
-  const totalHeight = headerHeight + tasksHeight;
-
-  return {
-    width: `${width}px`,
-    height: `${totalHeight}px`,
-    top: '0',
-    left: '0',
-  };
-};
 
 type Props = {
   readonly date: SimpleDate;
@@ -73,9 +30,7 @@ export function FutureViewDay(props: Props & { readonly theme: Theme }): ReactEl
     calendarPosition,
     doesShowCompletedTasks,
   } = props;
-  const [floatingViewOpened, setFloatingViewOpened] = React.useState(false);
   const [heightInfo, setHeightInfo] = React.useState<HeightInfo>(dummyHeightInfo);
-  const windowSize = useWindowSize();
   const componentDivRef = React.useRef<HTMLDivElement>(null);
 
   const onHeightChange = (doesOverflow: boolean, tasksHeight: number): void => {
@@ -83,9 +38,6 @@ export function FutureViewDay(props: Props & { readonly theme: Theme }): ReactEl
       setHeightInfo({ doesOverflow, tasksHeight });
     }
   };
-
-  const openFloatingView = (): void => setFloatingViewOpened(true);
-  const closeFloatingView = (): void => setFloatingViewOpened(false);
 
   const isToday: boolean = getTodayAtZeroAM().toDateString() === date.text;
   const darkModeStyles = (() => {
@@ -106,64 +58,18 @@ export function FutureViewDay(props: Props & { readonly theme: Theme }): ReactEl
   } else {
     wrapperCssClass = isToday ? `${styles.OtherViews} ${styles.Today}` : styles.OtherViews;
   }
-  if (!floatingViewOpened) {
-    return (
-      <div className={wrapperCssClass} ref={componentDivRef} style={darkModeStyles}>
-        <FutureViewDayContent
-          inMainList
-          onHeightChange={onHeightChange}
-          date={date}
-          inNDaysView={inNDaysView}
-          taskEditorPosition={taskEditorPosition}
-          calendarPosition={calendarPosition}
-          doesShowCompletedTasks={doesShowCompletedTasks}
-          theme={theme}
-        />
-        {heightInfo.doesOverflow && (
-          <button type="button" className={styles.MoreTasksBar} onClick={openFloatingView} tabIndex={0}>
-            More Tasks...
-          </button>
-        )}
-      </div>
-    );
-  }
-  const computeFloatingViewPosition = (): PositionStyle => {
-    const componentDiv = componentDivRef.current ?? error();
-    const boundingRect = componentDiv.getBoundingClientRect();
-    if (!(boundingRect instanceof DOMRect)) {
-      throw new Error('Bad boundingRect!');
-    }
-    const {
-      width, height, top, left,
-    } = boundingRect;
-    const mainViewPosition = {
-      width, height, top, left,
-    };
-    const { tasksHeight } = heightInfo;
-    return computeFloatingViewStyle({
-      tasksHeight, inNDaysView, mainViewPosition, windowSize,
-    });
-  };
   return (
-    <div className={wrapperCssClass} ref={componentDivRef} style={darkModeStyles}>
-      <div className={styles.FloatingViewPrevPadding} />
-      <div
-        role="presentation"
-        className={styles.FloatingBackgroundBlocker}
-        onClick={closeFloatingView}
+    <div className={wrapperCssClass} ref={componentDivRef} style={{ ...darkModeStyles, overflowY: 'scroll' }}>
+      <FutureViewDayContent
+        inMainList
+        onHeightChange={onHeightChange}
+        date={date}
+        inNDaysView={inNDaysView}
+        taskEditorPosition={taskEditorPosition}
+        calendarPosition={calendarPosition}
+        doesShowCompletedTasks={doesShowCompletedTasks}
+        theme={theme}
       />
-      <div className={styles.FloatingView} style={computeFloatingViewPosition()}>
-        <FutureViewDayContent
-          inMainList={false}
-          onHeightChange={onHeightChange}
-          date={date}
-          inNDaysView={inNDaysView}
-          taskEditorPosition={taskEditorPosition}
-          calendarPosition={calendarPosition}
-          doesShowCompletedTasks={doesShowCompletedTasks}
-          theme={theme}
-        />
-      </div>
     </div>
   );
 }

--- a/frontend/src/components/TaskView/FutureView/FutureViewDay.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewDay.tsx
@@ -114,9 +114,9 @@ export function FutureViewDay(props: Props & { readonly theme: Theme }): ReactEl
       background: 'black',
       color: 'white',
     } : {
-        background: 'rgb(33,33,33)',
-        color: 'white',
-      };
+      background: 'rgb(33,33,33)',
+      color: 'white',
+    };
   })();
   let wrapperCssClass: string;
   if (inNDaysView) {

--- a/frontend/src/components/TaskView/FutureView/FutureViewDay.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewDay.tsx
@@ -118,7 +118,6 @@ export function FutureViewDay(props: Props & { readonly theme: Theme }): ReactEl
           calendarPosition={calendarPosition}
           doesShowCompletedTasks={doesShowCompletedTasks}
           theme={theme}
-          containerHeight={headerHeight}
         />
         {heightInfo.doesOverflow && (
           <button type="button" className={styles.MoreTasksBar} onClick={openFloatingView} tabIndex={0}>
@@ -163,7 +162,6 @@ export function FutureViewDay(props: Props & { readonly theme: Theme }): ReactEl
           calendarPosition={calendarPosition}
           doesShowCompletedTasks={doesShowCompletedTasks}
           theme={theme}
-          containerHeight={heightInfo.tasksHeight + headerHeight}
         />
       </div>
     </div>

--- a/frontend/src/components/TaskView/FutureView/FutureViewDay.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewDay.tsx
@@ -114,9 +114,9 @@ export function FutureViewDay(props: Props & { readonly theme: Theme }): ReactEl
       background: 'black',
       color: 'white',
     } : {
-      background: 'rgb(33,33,33)',
-      color: 'white',
-    };
+        background: 'rgb(33,33,33)',
+        color: 'white',
+      };
   })();
   let wrapperCssClass: string;
   if (inNDaysView) {

--- a/frontend/src/components/TaskView/FutureView/FutureViewDayContent.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewDayContent.tsx
@@ -33,6 +33,11 @@ function FutureViewDayContent(
     theme,
   }: Props,
 ): ReactElement {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const containerNode = containerRef.current;
+  const containerHeight = containerNode === null ? 0 : containerNode.clientHeight;
+  console.log(containerHeight);
+
   const containerStyle = (() => {
     const style = theme === 'dark' ? { color: 'white', opacity: 0.8 } : {};
     return (inNDaysView && inMainList) ? { paddingTop: '1em', ...style } : style;

--- a/frontend/src/components/TaskView/FutureView/FutureViewDayContent.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewDayContent.tsx
@@ -16,6 +16,7 @@ type Props = {
   readonly inMainList: boolean;
   readonly onHeightChange: (doesOverflow: boolean, tasksHeight: number) => void;
   readonly theme: Theme;
+  readonly containerHeight: number;
 };
 
 /**
@@ -31,6 +32,7 @@ function FutureViewDayContent(
     inMainList,
     onHeightChange,
     theme,
+    containerHeight,
   }: Props,
 ): ReactElement {
   const containerStyle = (() => {
@@ -58,6 +60,7 @@ function FutureViewDayContent(
               doesShowCompletedTasks={doesShowCompletedTasks}
               isInMainList={inMainList}
               onHeightChange={onHeightChange}
+              containerHeight={containerHeight}
             />
             {provided.placeholder}
           </div>

--- a/frontend/src/components/TaskView/FutureView/FutureViewDayContent.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewDayContent.tsx
@@ -33,11 +33,6 @@ function FutureViewDayContent(
     theme,
   }: Props,
 ): ReactElement {
-  const containerRef = React.useRef<HTMLDivElement>(null);
-  const containerNode = containerRef.current;
-  const containerHeight = containerNode === null ? 0 : containerNode.clientHeight;
-  console.log(containerHeight);
-
   const containerStyle = (() => {
     const style = theme === 'dark' ? { color: 'white', opacity: 0.8 } : {};
     return (inNDaysView && inMainList) ? { paddingTop: '1em', ...style } : style;

--- a/frontend/src/components/TaskView/FutureView/FutureViewDayContent.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewDayContent.tsx
@@ -16,7 +16,6 @@ type Props = {
   readonly inMainList: boolean;
   readonly onHeightChange: (doesOverflow: boolean, tasksHeight: number) => void;
   readonly theme: Theme;
-  readonly containerHeight: number;
 };
 
 /**
@@ -32,7 +31,6 @@ function FutureViewDayContent(
     inMainList,
     onHeightChange,
     theme,
-    containerHeight,
   }: Props,
 ): ReactElement {
   const containerStyle = (() => {
@@ -60,7 +58,6 @@ function FutureViewDayContent(
               doesShowCompletedTasks={doesShowCompletedTasks}
               isInMainList={inMainList}
               onHeightChange={onHeightChange}
-              containerHeight={containerHeight}
             />
             {provided.placeholder}
           </div>

--- a/frontend/src/components/TaskView/FutureView/FutureViewDayTaskContainer.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewDayTaskContainer.tsx
@@ -21,6 +21,7 @@ type OwnProps = {
   readonly doesShowCompletedTasks: boolean;
   readonly isInMainList: boolean;
   readonly onHeightChange: (doesOverflow: boolean, tasksHeight: number) => void;
+  readonly containerHeight: number;
 };
 
 type IdOrder = {
@@ -45,6 +46,7 @@ function FutureViewDayTaskContainer(
     calendarPosition,
     isInMainList,
     onHeightChange,
+    containerHeight,
   }: Props,
 ): ReactElement {
   const containerRef = React.useRef<HTMLDivElement>(null);
@@ -57,12 +59,11 @@ function FutureViewDayTaskContainer(
       return;
     }
     const tasksHeight = containerNode.scrollHeight;
-    const containerHeight = containerNode.clientHeight;
     const [prevTasksHeight, prevContainerHeight] = prevHeights;
     if (prevTasksHeight === tasksHeight && prevContainerHeight === containerHeight) {
       return;
     }
-    const vh = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+    const vh = Math.max(document.documentElement.clientHeight, window.innerHeight || 0) * 0.6;
     setPrevHeights([tasksHeight, containerHeight]);
     onHeightChange(tasksHeight > vh && containerHeight > 0, tasksHeight);
   });

--- a/frontend/src/components/TaskView/FutureView/FutureViewDayTaskContainer.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewDayTaskContainer.tsx
@@ -63,7 +63,7 @@ function FutureViewDayTaskContainer(
       return;
     }
     const vh = Math.max(document.documentElement.clientHeight || 0);
-    const overflowThreshold = vh * 0.58;
+    const overflowThreshold = vh;
     setPrevHeights([tasksHeight, containerHeight]);
     onHeightChange(tasksHeight > overflowThreshold && overflowThreshold > 0, tasksHeight);
   });

--- a/frontend/src/components/TaskView/FutureView/FutureViewDayTaskContainer.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewDayTaskContainer.tsx
@@ -62,8 +62,9 @@ function FutureViewDayTaskContainer(
     if (prevTasksHeight === tasksHeight && prevContainerHeight === containerHeight) {
       return;
     }
+    const vh = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
     setPrevHeights([tasksHeight, containerHeight]);
-    onHeightChange(tasksHeight > containerHeight && containerHeight > 0, tasksHeight);
+    onHeightChange(tasksHeight > vh && containerHeight > 0, tasksHeight);
   });
   const taskListComponent = idOrderList.map(({ id }, i) => (
     <FutureViewTask
@@ -79,11 +80,9 @@ function FutureViewDayTaskContainer(
     />
   ));
   if (isInMainList) {
-    const style = {};
     return (
       <div
         className={styles.Container}
-        style={style}
         ref={containerRef}
       >
         {taskListComponent}

--- a/frontend/src/components/TaskView/FutureView/FutureViewDayTaskContainer.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewDayTaskContainer.tsx
@@ -21,7 +21,6 @@ type OwnProps = {
   readonly doesShowCompletedTasks: boolean;
   readonly isInMainList: boolean;
   readonly onHeightChange: (doesOverflow: boolean, tasksHeight: number) => void;
-  readonly containerHeight: number;
 };
 
 type IdOrder = {
@@ -46,7 +45,6 @@ function FutureViewDayTaskContainer(
     calendarPosition,
     isInMainList,
     onHeightChange,
-    containerHeight,
   }: Props,
 ): ReactElement {
   const containerRef = React.useRef<HTMLDivElement>(null);
@@ -59,13 +57,15 @@ function FutureViewDayTaskContainer(
       return;
     }
     const tasksHeight = containerNode.scrollHeight;
+    const containerHeight = containerNode.clientHeight;
     const [prevTasksHeight, prevContainerHeight] = prevHeights;
     if (prevTasksHeight === tasksHeight && prevContainerHeight === containerHeight) {
       return;
     }
-    const vh = Math.max(document.documentElement.clientHeight, window.innerHeight || 0) * 0.6;
+    const vh = Math.max(document.documentElement.clientHeight || 0);
+    const overflowThreshold = vh * 0.58;
     setPrevHeights([tasksHeight, containerHeight]);
-    onHeightChange(tasksHeight > vh && containerHeight > 0, tasksHeight);
+    onHeightChange(tasksHeight > overflowThreshold && overflowThreshold > 0, tasksHeight);
   });
   const taskListComponent = idOrderList.map(({ id }, i) => (
     <FutureViewTask


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request fixes a bug present in production and development where if a user has many subtasks/tasks in a single day such that it overflows the viewport bottom, the `More Tasks...` button no longer appears to allow the user to enter `FloatingView`.

This bug was likely introduced by #376, as the `taskListComponent` in the `FutureViewDayTaskContainer` began to house `Draggable` tasks in its container, which do not conform to normal `scrollHeight` and `clientHeight` values. What ended up happening was that these values were both equal, and as a result the `onHeightChange` function call always passes `false` for `doesOverflow`, and now `FloatingView` cannot be accessed. This pull request solves that by ~~replacing the `containerHeight` with a calculated height based on the viewport and comparing that with `tasksHeight` instead~~ removing the FloatingView entirely due to suggestions for better UX and allow users to scroll on day containers by default. In case we may need to check for overflow in the future, my added calculations in `FutureViewDayTaskContainer` are preserved in this PR.

- [x] fixes #430 

### Test Plan <!-- Required -->
Try making a ton of subtasks and tasks in a certain day such that they overflow vertically for the day. Scroll.
![LRZE8Pk](https://user-images.githubusercontent.com/7517829/79054554-cfc15c00-7c13-11ea-969a-4af01f82941b.gif)


<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

The threshold height that determines whether a certain day task container is overflowing is calculated using the viewport height ratio right now. Ideally, this could be replaced by a definite height value of the container behind it.

