### PR TITLE
Disallow editing/deleting canvas task again

### DIFF
--- a/common/src/types/firestore-types.ts
+++ b/common/src/types/firestore-types.ts
@@ -46,6 +46,7 @@ export type FirestoreMasterTask = FirestoreCommonTask & {
 export type FirestoreOneTimeTask = FirestoreCommonTask & {
   readonly type: 'ONE_TIME';
   readonly date: Date | firestore.Timestamp;
+  readonly icalUID?: string;
 };
 
 // all these tasks stay in 'samwise-tasks'

--- a/frontend/src/firebase/listeners.ts
+++ b/frontend/src/firebase/listeners.ts
@@ -133,9 +133,9 @@ export default (onFirstFetched: () => void): (() => void) => {
         const taskCommon = { id, children: children.toArray() };
         let task: TaskWithChildrenId;
         if (rest.type === 'ONE_TIME') {
-          const { type, date: timestamp, ...oneTimeTaskRest } = rest;
+          const { type, date: timestamp, icalUID, ...oneTimeTaskRest } = rest;
           const date = transformDate(timestamp);
-          task = { ...taskCommon, ...oneTimeTaskRest, metadata: { type: 'ONE_TIME', date } };
+          task = { ...taskCommon, ...oneTimeTaskRest, metadata: { type: 'ONE_TIME', date, icalUID } };
         } else {
           const { type, forks: firestoreForks, date: firestoreRepeats, ...otherTaskProps } = rest;
           const forks = firestoreForks.map((firestoreFork) => ({


### PR DESCRIPTION
### Summary

During the refactoring of #427, we moved all non-common fields of tasks into the metadata object. The transformation is done in `src/firebase/listeners.ts`. The transformer forgets to put the `icalUID` field into `metadata` object, which makes a lot of canvas task check break.

The reason we didn't catch the bug or didn't notice it is that the field is not even declared in its firebase types! Now we declare the field and fix the transformer.

### Test Plan

Canvas tasks cannot be deleted anymore. See the screenshot.

<img width="231" alt="Screen Shot 2020-04-11 at 17 32 14" src="https://user-images.githubusercontent.com/4290500/79055358-66911700-7c1a-11ea-9441-f52726ef2a55.png">
