### PR TITLE
Fix Canvas task misalignment resulting from obnoxiously long titles

### DIFF
--- a/frontend/src/components/TaskView/FutureView/FutureViewTask.module.css
+++ b/frontend/src/components/TaskView/FutureView/FutureViewTask.module.css
@@ -69,11 +69,12 @@
   cursor: not-allowed;
 }
 
-.TaskIconPlaceholder {
-  width: 1.2em;
-  margin: 0 0 0 0;
-  padding-top: 3px;
-  height: 16px;
+.hide {
+  visibility: hidden;
+}
+
+.hide:hover {
+  cursor: not-allowed;
 }
 
 .TaskIconPlaceholder:hover {

--- a/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
@@ -101,6 +101,9 @@ function FutureViewTask(
     const handler = (): void => removeTaskWithPotentialPrompt(original, replaceDateForFork);
     return <SamwiseIcon iconName="x-light" className={styles.TaskIcon} onClick={handler} />;
   };
+
+  const Placeholder = (): ReactElement => <div className={styles.hide}><RemoveTaskIcon /></div>;
+
   const PinIcon = (): ReactElement => {
     const { id, inFocus } = original;
     const handler = (): void => editMainTask(id, replaceDateForForkOpt, { inFocus: !inFocus });
@@ -116,11 +119,7 @@ function FutureViewTask(
   const RepeatingIcon = (): ReactElement => <SamwiseIcon iconName="repeat-light" className={styles.TaskIconNoHover} />;
   let Icon = (): ReactElement => <RepeatingIcon />;
   if (compoundTask.original.metadata.type === 'ONE_TIME') {
-    if (!isCanvasTask) {
-      Icon = DragIcon;
-    } else {
-      Icon = () => <div className={styles.TaskIconPlaceholder}> </div>;
-    }
+    Icon = isCanvasTask ? Placeholder : DragIcon;
   }
   const renderMainTaskInfo = (simplified = false): ReactElement => {
     if (simplified && isInMainList) {
@@ -133,7 +132,7 @@ function FutureViewTask(
         <TaskCheckBox />
         <TaskName />
         <PinIcon />
-        {isCanvasTask ? null : <RemoveTaskIcon />}
+        {isCanvasTask ? <Placeholder /> : <RemoveTaskIcon />}
       </div>
     );
   };


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request fixes a bug relating to the introduction of Canvas tasks. When the text for the task overflows, our previous placeholder icons for Canvas tasks did not properly align themselves and were shifted by the extra text. This PR introduces a better placeholder with identical attributes to the normal icons on non-Canvas tasks so that the checkboxes on the left are aligned again.

Before:
![image](https://user-images.githubusercontent.com/7517829/79076333-4f5c3300-7cc7-11ea-9cb4-139083ea191b.png)
After:
![image](https://user-images.githubusercontent.com/7517829/79076336-55521400-7cc7-11ea-8655-fc9d7f7c0bd6.png)


- [x] fixed bug mentioned in #460 before we release to production

### Test Plan <!-- Required -->

Check if any of your professors added a super long Canvas assignment that causes the text to overflow the `FutureViewTask` text. See that the checkboxes on the left are now aligned, no matter how long this text is.
