### PR TITLE
Add a test to remind ourselves to update date constants

### DIFF
--- a/common/src/util/const-util.test.ts
+++ b/common/src/util/const-util.test.ts
@@ -1,0 +1,5 @@
+import { LAST_DAY_OF_EXAMS } from './const-util';
+
+it('We have not passed the end day of exam yet. When this test fails, we should update the date!', () => {
+  expect(new Date() < LAST_DAY_OF_EXAMS).toBeTruthy();
+});


### PR DESCRIPTION
### Summary

Then we can avoid forgetting to update it until mid-semester, like #455.

### Test Plan

The test passes. You can try to set the date to 2020/1/1 to make it fail locally.