### PR TITLE
updated firestore types for group tasks

### DIFF
--- a/common/src/types/firestore-types.ts
+++ b/common/src/types/firestore-types.ts
@@ -47,10 +47,15 @@ export type FirestoreOneTimeTask = FirestoreCommonTask & {
   readonly type: 'ONE_TIME';
   readonly date: Date | firestore.Timestamp;
   readonly icalUID?: string;
-  readonly group?: string;
 };
 
-export type Group = {
+export type FirestoreGroupTask = FirestoreCommonTask & {
+  readonly type: 'GROUP';
+  readonly date: Date | firestore.Timestamp;
+  readonly group?: string;
+}
+
+export type FirestoreGroup = {
   readonly name: string;
   readonly members: string[];
   readonly deadline: Date;
@@ -58,4 +63,5 @@ export type Group = {
 
 // all these tasks stay in 'samwise-tasks'
 // FirestoreLegacyTask should eventually be converted to FirestoreOneTimeTask.
-export type FirestoreTask = FirestoreMasterTask | FirestoreOneTimeTask;
+export type FirestoreTask =
+  FirestoreMasterTask | FirestoreOneTimeTask | FirestoreGroupTask;

--- a/common/src/types/firestore-types.ts
+++ b/common/src/types/firestore-types.ts
@@ -47,7 +47,14 @@ export type FirestoreOneTimeTask = FirestoreCommonTask & {
   readonly type: 'ONE_TIME';
   readonly date: Date | firestore.Timestamp;
   readonly icalUID?: string;
+  readonly group?: string;
 };
+
+export type Group = {
+  readonly name: string;
+  readonly members: string[];
+  readonly deadline: Date;
+}
 
 // all these tasks stay in 'samwise-tasks'
 // FirestoreLegacyTask should eventually be converted to FirestoreOneTimeTask.

--- a/common/src/types/firestore-types.ts
+++ b/common/src/types/firestore-types.ts
@@ -52,7 +52,7 @@ export type FirestoreOneTimeTask = FirestoreCommonTask & {
 export type FirestoreGroupTask = FirestoreCommonTask & {
   readonly type: 'GROUP';
   readonly date: Date | firestore.Timestamp;
-  readonly group?: string;
+  readonly group: string;
 }
 
 export type FirestoreGroup = {

--- a/common/src/types/store-types.ts
+++ b/common/src/types/store-types.ts
@@ -28,8 +28,13 @@ export type OneTimeTaskMetadata = {
   readonly type: 'ONE_TIME';
   readonly date: Date;
   icalUID?: string;
-  group?: string; // documentid for associated group
 };
+
+export type GroupTaskMetadata = {
+  readonly type: 'GROUP';
+  readonly date: Date;
+  group?: string; // documentid for associated group
+}
 
 export type RepeatingPattern =
   | { readonly type: 'WEEKLY'; readonly bitSet: number /* 7-bit */ }
@@ -53,7 +58,8 @@ export type RepeatingTaskMetadata = {
   readonly forks: readonly ForkedTaskMetaData[];
 };
 
-export type TaskMetadata = OneTimeTaskMetadata | RepeatingTaskMetadata;
+export type TaskMetadata =
+  OneTimeTaskMetadata | RepeatingTaskMetadata | GroupTaskMetadata;
 
 export type Task<M = TaskMetadata> = {
   readonly id: string;

--- a/common/src/types/store-types.ts
+++ b/common/src/types/store-types.ts
@@ -33,7 +33,7 @@ export type OneTimeTaskMetadata = {
 export type GroupTaskMetadata = {
   readonly type: 'GROUP';
   readonly date: Date;
-  group?: string; // documentid for associated group
+  group: string; // documentid for associated group
 }
 
 export type RepeatingPattern =

--- a/common/src/types/store-types.ts
+++ b/common/src/types/store-types.ts
@@ -28,6 +28,7 @@ export type OneTimeTaskMetadata = {
   readonly type: 'ONE_TIME';
   readonly date: Date;
   icalUID?: string;
+  group?: string; // documentid for associated group
 };
 
 export type RepeatingPattern =

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/NewSubTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/NewSubTaskEditor.tsx
@@ -5,7 +5,7 @@ type Props = {
   readonly onFirstType: (change: string) => void;
   readonly onPressEnter: () => void;
   readonly needToBeFocused: boolean;
-  readonly type: 'MASTER_TEMPLATE' | 'ONE_TIME';
+  readonly type: 'MASTER_TEMPLATE' | 'ONE_TIME' | 'GROUP';
 };
 
 export default function NewSubTaskEditor(

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -41,7 +41,7 @@ type Actions = {
 };
 type OwnProps = DefaultProps & {
   readonly id: string;
-  readonly type: 'MASTER_TEMPLATE' | 'ONE_TIME';
+  readonly type: 'MASTER_TEMPLATE' | 'ONE_TIME' | 'GROUP';
   readonly icalUID?: string;
   // the date string that specifies when the task appears (useful for repeated task)
   readonly taskAppearedDate: string | null;

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -11,7 +11,6 @@ import {
   TaskMetadata,
   RepeatingTaskMetadata,
   OneTimeTaskMetadata,
-  GroupTaskMetadata,
 } from 'common/lib/types/store-types';
 import { error, ignore } from 'common/lib/util/general-util';
 import {

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -11,6 +11,7 @@ import {
   TaskMetadata,
   RepeatingTaskMetadata,
   OneTimeTaskMetadata,
+  GroupTaskMetadata,
 } from 'common/lib/types/store-types';
 import { error, ignore } from 'common/lib/util/general-util';
 import {
@@ -255,7 +256,7 @@ export const removeTask = (task: Task): void => {
   const batch = database.db().batch();
   batch.delete(database.tasksCollection().doc(task.id));
   task.children.forEach((subTask) => batch.delete(database.subTasksCollection().doc(subTask.id)));
-  if (task.metadata.type === 'ONE_TIME') {
+  if (task.metadata.type === 'ONE_TIME' || task.metadata.type === 'GROUP') {
     // remove fork mentions
     repeatedTaskSet.forEach((repeatedTaskId) => {
       const repeatedTask = tasks.get(repeatedTaskId) as Task<RepeatingTaskMetadata> | null;

--- a/frontend/src/firebase/listeners.ts
+++ b/frontend/src/firebase/listeners.ts
@@ -136,6 +136,10 @@ export default (onFirstFetched: () => void): (() => void) => {
           const { type, date: timestamp, icalUID, ...oneTimeTaskRest } = rest;
           const date = transformDate(timestamp);
           task = { ...taskCommon, ...oneTimeTaskRest, metadata: { type: 'ONE_TIME', date, icalUID } };
+        } else if (rest.type === 'GROUP') {
+          const { type, date: timestamp, group, ...groupTaskRest } = rest;
+          const date = transformDate(timestamp);
+          task = { ...taskCommon, ...groupTaskRest, metadata: { type: 'GROUP', date, group } };
         } else {
           const { type, forks: firestoreForks, date: firestoreRepeats, ...otherTaskProps } = rest;
           const forks = firestoreForks.map((firestoreFork) => ({


### PR DESCRIPTION
### Summary <!-- Required -->
Added optional groupfield to onetimetask and onetimetask metadata 
Added group type to firestore-types

### Test Plan <!-- Required -->

- [x] Will let PR deploy and play with app on staging to ensure that app is working and none of the associated functionality like uneditable canvas tasks breaks.

- Database schema change (anything that changes Firestore collection structure)
Added a samwise-groups that tracks its name : string , members : string[], and deadline: Date