### PR TITLE
Generate sdk from secret for production release

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -24,7 +24,9 @@ jobs:
       - name: Deploy to Production
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          PRODUCTION_FIREBASE_ADMIN_SDK_CONTENTS: ${{ secrets.PRODUCTION_FIREBASE_ADMIN_SDK_CONTENTS }}
         run: |
+          echo $PRODUCTION_FIREBASE_ADMIN_SDK_CONTENTS > functions/src/firebase-adminsdk.json
           ./node_modules/.bin/firebase use production
           ./node_modules/.bin/firebase deploy --token=$FIREBASE_TOKEN --non-interactive --only hosting
           ./deploy-functions $FIREBASE_TOKEN production


### PR DESCRIPTION
### Summary

Following the change in `.github/workflows/cd-workflow.yml`.

### Test Plan

:eyes: or test in prod