### PR TITLE
Setup a GateKeeper that is easier to use

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import TaskCreator from './components/TaskCreator';
 import TaskView from './components/TaskView';
 import TitleBar from './components/TitleBar';
 import { ModalsContainer } from './components/Util/Modals';
+import { isGroupTaskEnabled } from './util/gate-keeper';
 
 type Views =
   | 'personal'
@@ -19,7 +20,7 @@ type Views =
  */
 const groups = ['CS 2110', 'CS 3110', 'INFO 3450'];
 
-const GROUP_TASK_ENABLED: boolean = localStorage.getItem('GROUP_TASK_ENABLED') != null;
+const GROUP_TASK_ENABLED: boolean = isGroupTaskEnabled();
 
 const PersonalMainView = (): React.ReactElement => (
   <div className={styles.MainView}>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -8,10 +8,12 @@ import './firebase'; // import and init firebase
 import ErrorBoundary from './components/Util/ErrorBoundary';
 import LoginBarrier from './components/Util/AppInit/LoginBarrier';
 import { initialize as initializeGA } from './util/ga-util';
+import { registerGateKeeper } from './util/gate-keeper';
 import { initModal } from './components/Util/Modals';
 import * as serviceWorker from './serviceWorker';
 
 initializeGA();
+registerGateKeeper();
 
 const appRenderer = (): ReactElement => (
   <ReactReduxProvider><App /></ReactReduxProvider>

--- a/frontend/src/util/gate-keeper.ts
+++ b/frontend/src/util/gate-keeper.ts
@@ -1,0 +1,18 @@
+const GK_GROUP_TASK = 'SAMWISE_GK-GROUP_TASK_ENABLED';
+
+export const isGroupTaskEnabled = (): boolean => localStorage.getItem(GK_GROUP_TASK) === 'true';
+
+const enableGroupTask = (): void => localStorage.setItem(GK_GROUP_TASK, 'true');
+const disableGroupTask = (): void => localStorage.removeItem(GK_GROUP_TASK);
+
+const GateKeeper = { enableGroupTask, disableGroupTask };
+
+declare global {
+  interface Window {
+    GateKeeper: typeof GateKeeper;
+  }
+}
+
+export const registerGateKeeper = (): void => {
+  window.GateKeeper = GateKeeper;
+};


### PR DESCRIPTION
### Summary <!-- Required -->

Out current gate keeping code works, but it's hard to switch it. You either need to memoize and type in a long, ALL_CAP string into developer console, or copy that from the source code (given that you know where it is).

Not surprisingly, this setup caused our developers (including me) becoming lazy in testing the gated code that they are not working on. This is probably what caused #483 to happen.

Instead of blaming individual developer or reviewer, let's make it easy to switch, so then there will be no excuse of not testing it thoroughly.

I added a `GateKeeper` module, which can be injected into the global scope. The injection happens in `src/index.tsx` to ensure that `GateKeeper` object with toggle methods is always available in global scope. In this way, we can easily toggle it in developer console without memorizing long names!

### Test Plan <!-- Required -->

Open developer console,

1. Type `GateKeeper.enableGroupTask();` and hit enter. Refresh the page, ensure group task UI is enabled.
2. Type `GateKeeper.disableGroupTask();` and hit enter. Refresh the page, ensure group task UI is disabled.
3. Enjoy autocompletion as you type.

<img width="921" alt="gk" src="https://user-images.githubusercontent.com/4290500/80561196-aa717380-89b1-11ea-8f6a-ce5ed9d89bcf.png">
