### PR TITLE
Canvas hotfix

### DIFF
--- a/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
@@ -1,7 +1,7 @@
 import React, { KeyboardEvent, ReactElement, SyntheticEvent, ReactNode } from 'react';
 import { connect } from 'react-redux';
 import FloatingTaskEditor from 'components/Util/TaskEditors/FloatingTaskEditor';
-import { State, SubTask, Task } from 'common/lib/types/store-types';
+import { Settings, State, SubTask, Task } from 'common/lib/types/store-types';
 import CheckBox from 'components/UI/CheckBox';
 import { FloatingPosition, CalendarPosition } from 'components/Util/TaskEditors/editors-types';
 import { getTodayAtZeroAM, getDateWithDateString } from 'common/lib/util/datetime-util';
@@ -34,6 +34,7 @@ type OwnProps = {
 
 type Props = OwnProps & {
   readonly compoundTask: CompoundTask | null;
+  readonly settings: Settings;
 };
 
 /**
@@ -49,6 +50,7 @@ function FutureViewTask(
     taskEditorPosition,
     isInMainList,
     calendarPosition,
+    settings,
   }: Props,
 ): ReactElement | null {
   const isSmallScreen = useMappedWindowSize(({ width }) => width <= 768);
@@ -58,8 +60,11 @@ function FutureViewTask(
   }
   const { original, filteredSubTasks, color } = compoundTask;
 
+  const { canvasCalendar } = settings;
+  const canvasLinked = canvasCalendar != null;
+
   const icalUID = original.metadata.type === 'ONE_TIME' ? original.metadata.icalUID : '';
-  const isCanvasTask = typeof icalUID === 'string' ? icalUID !== '' : false;
+  const isCanvasTask = canvasLinked && (typeof icalUID === 'string' ? icalUID !== '' : false);
 
   /**
    * Get an onClickHandler when the element is clicked.
@@ -225,8 +230,9 @@ const getCompoundTask = (
 
 const mapStateToProps = (
   state: State, ownProps: OwnProps,
-): { readonly compoundTask: CompoundTask | null } => ({
+): { readonly compoundTask: CompoundTask | null; readonly settings: Settings } => ({
   compoundTask: getCompoundTask(state, ownProps),
+  settings: state.settings,
 });
 
 const Connected = connect(mapStateToProps)(FutureViewTask);

--- a/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
+++ b/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useState } from 'react';
 import { connect } from 'react-redux';
+import { promptConfirm } from 'components/Util/Modals';
 import { Settings, State } from 'common/lib/types/store-types';
 import settingStyles from '../Settings/SettingsPage.module.css';
 import styles from './CanvasCalendar.module.css';
@@ -15,7 +16,12 @@ function CanvasCalendar({ settings }: Props): ReactElement {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
     e.preventDefault();
     const iCalLink = input;
-    setCanvasCalendar(iCalLink);
+
+    promptConfirm('This will sync all calendar items from your Canvas account. This may include assignments, as well as lectures, discussions, office hours, and more. Would you like to continue?').then((confirmed) => {
+      if (confirmed) {
+        setCanvasCalendar(iCalLink);
+      }
+    });
   };
 
   const removeCanvasiCal = (): void => {

--- a/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
+++ b/frontend/src/components/TitleBar/Canvas/CanvasCalendar.tsx
@@ -17,7 +17,7 @@ function CanvasCalendar({ settings }: Props): ReactElement {
     e.preventDefault();
     const iCalLink = input;
 
-    promptConfirm('This will sync all calendar items from your Canvas account. This may include assignments, as well as lectures, discussions, office hours, and more. Would you like to continue?').then((confirmed) => {
+    promptConfirm('This will sync all calendar items from your Canvas account. This may include assignments, as well as lectures, discussions, office hours, and more. These tasks can only be modified or deleted by your professor. If you wish to delete or edit these tasks, you will need to unlink your Canvas calendar. Would you like to continue?').then((confirmed) => {
       if (confirmed) {
         setCanvasCalendar(iCalLink);
       }
@@ -25,7 +25,11 @@ function CanvasCalendar({ settings }: Props): ReactElement {
   };
 
   const removeCanvasiCal = (): void => {
-    setCanvasCalendar(null);
+    promptConfirm('This will stop syncing new calendar updates from Canvas, but will not delete previously imported tasks. After unlinking, you will be able to delete any tasks previously imported from Canvas. Would you like to continue?').then((confirmed) => {
+      if (confirmed) {
+        setCanvasCalendar(null);
+      }
+    });
   };
 
   return (


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->
Per Matthew's request, Canvas tasks can now be deleted after unlinking Canvas. Also added better messaging.

### Test Plan <!-- Required -->

Linking Canvas:
![image](https://user-images.githubusercontent.com/6147405/80846135-5943c880-8bd9-11ea-9757-7d92796441ea.png)

Unlinking Canvas:
![image](https://user-images.githubusercontent.com/6147405/80846141-5cd74f80-8bd9-11ea-8707-6345480abfe3.png)

Task view after unlink:
![image](https://user-images.githubusercontent.com/6147405/80846156-6660b780-8bd9-11ea-856c-de82c088d50c.png)
