### PR TITLE
Reload on GK change

### DIFF
--- a/frontend/src/util/gate-keeper.ts
+++ b/frontend/src/util/gate-keeper.ts
@@ -2,8 +2,14 @@ const GK_GROUP_TASK = 'SAMWISE_GK-GROUP_TASK_ENABLED';
 
 export const isGroupTaskEnabled = (): boolean => localStorage.getItem(GK_GROUP_TASK) === 'true';
 
-const enableGroupTask = (): void => localStorage.setItem(GK_GROUP_TASK, 'true');
-const disableGroupTask = (): void => localStorage.removeItem(GK_GROUP_TASK);
+const enableGroupTask = (): void => {
+  localStorage.setItem(GK_GROUP_TASK, 'true');
+  window.location.reload();
+};
+const disableGroupTask = (): void => {
+  localStorage.removeItem(GK_GROUP_TASK);
+  window.location.reload();
+}
 
 const GateKeeper = { enableGroupTask, disableGroupTask };
 

--- a/frontend/src/util/gate-keeper.ts
+++ b/frontend/src/util/gate-keeper.ts
@@ -9,7 +9,7 @@ const enableGroupTask = (): void => {
 const disableGroupTask = (): void => {
   localStorage.removeItem(GK_GROUP_TASK);
   window.location.reload();
-}
+};
 
 const GateKeeper = { enableGroupTask, disableGroupTask };
 


### PR DESCRIPTION
### Summary

We always want to reload the page once GK changes, so let's just include it in GK function call.

### Test Plan

Try run `GateKeeper.enableGroupTask()` and `GateKeeper.disableGroupTask()`