### PR TITLE
Seamless drag-and-drop experience

### DIFF
--- a/frontend/src/components/TaskView/FocusView/index.tsx
+++ b/frontend/src/components/TaskView/FocusView/index.tsx
@@ -2,7 +2,7 @@
 import React, { ReactElement, useState, ReactNode } from 'react';
 import { DragDropContext, Droppable, DropResult } from 'react-beautiful-dnd';
 import { connect } from 'react-redux';
-import { computeReorderMap, getReorderedList } from 'common/lib/util/order-util';
+import { computeReorderMap } from 'common/lib/util/order-util';
 import styles from './index.module.css';
 import ClearFocus from './ClearFocus';
 import CompletedSeparator from './CompletedSeparator';
@@ -25,14 +25,10 @@ function renderTaskList(list: IdOrder[], filterCompleted: boolean): ReactNode {
  * The focus view component.
  */
 function FocusView({ tasks, progress }: FocusViewProps): ReactElement {
-  const [localTasks, setLocalTasks] = useState<FocusViewTaskMetaData[]>(tasks);
   const [doesShowCompletedTasks, setDoesShowCompletedTasks] = useState(true);
-  if (localTasks !== tasks) {
-    setLocalTasks(tasks);
-  }
   const localCompletedList: IdOrder[] = [];
   const localUncompletedList: IdOrder[] = [];
-  localTasks.forEach(({ id, order, inFocusView, inCompleteFocusView }: FocusViewTaskMetaData) => {
+  tasks.forEach(({ id, order, inFocusView, inCompleteFocusView }: FocusViewTaskMetaData) => {
     if (!inFocusView) {
       return;
     }
@@ -74,23 +70,14 @@ function FocusView({ tasks, progress }: FocusViewProps): ReactElement {
         && destination.droppableId === focusViewNotCompletedDroppableId)
     ) {
       // drag and drop completely with in completed/uncompleted region
-      const reorderMap = computeReorderMap(localTasks, sourceOrder, destinationOrder);
-      setLocalTasks(getReorderedList(localTasks, reorderMap));
+      const reorderMap = computeReorderMap(tasks, sourceOrder, destinationOrder);
       applyReorder('tasks', reorderMap);
     } else if (
       source.droppableId === focusViewNotCompletedDroppableId
       && destination.droppableId === focusViewCompletedDroppableId
     ) {
       // drag from not completed and drop to completed.
-      const completedTaskIdOrder: IdOrder = localUncompletedList[source.index];
-      const taskReplacer = (t: FocusViewTaskMetaData): FocusViewTaskMetaData => {
-        if (t.id !== completedTaskIdOrder.id) {
-          return t;
-        }
-        return { ...t, inCompleteFocusView: true };
-      };
-      setLocalTasks((prevTasks) => prevTasks.map(taskReplacer));
-      completeTaskInFocus(completedTaskIdOrder, localCompletedList);
+      completeTaskInFocus(localUncompletedList[source.index]);
     } else if (
       source.droppableId === focusViewCompletedDroppableId
       && destination.droppableId === focusViewNotCompletedDroppableId

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -436,7 +436,7 @@ export function applyReorder(orderFor: 'tags' | 'tasks', reorderMap: Map<string,
     const editedTags: Tag[] = [];
     Array.from(reorderMap.entries()).forEach(([id, order]) => {
       const existingTag = tags.get(id);
-      if (existingTag != null) {
+      if (existingTag !== undefined) {
         editedTags.push({ ...existingTag, order });
       }
     });
@@ -445,7 +445,7 @@ export function applyReorder(orderFor: 'tags' | 'tasks', reorderMap: Map<string,
     const editedTasks: TaskWithChildrenId[] = [];
     Array.from(reorderMap.entries()).forEach(([id, order]) => {
       const existingTask = tasks.get(id);
-      if (existingTask != null) {
+      if (existingTask !== undefined) {
         editedTasks.push({
           ...existingTask,
           order,


### PR DESCRIPTION
### Summary

The drag and drop user experience is far from being perfect.
To make order persistent, we have to save the updated order in the firestore. Although firestore seems to have ['latency compensation'](https://firebase.google.com/docs/firestore/query-data/listen#events-local-changes) that can avoid a roundtrip before updated data is pushed to remote, the listener update is still not **synchronous**, which causes a big trouble in dnd that relies an a synchronous state change.

In the past, we introduced `localTasks` as a cache in focus view to solve the problem. We are able to mostly avoid the dropped task bouncing back to the original position, but there are still some occasional flashes. In future view, such caching mechanism has not been implemented, so the resulting experience is even worse.

Recently, I encountered a similar problem in my side projects, and I found a more principled and easier way to solve it. Surprisingly, this easier way also makes the UX better. An crucial observation is that

> Redux store update is synchronous.

Therefore, instead of `setState` locally in a component, why don't we do similar stuff to the redux store? Then we can avoid creating two versions of truth. It's also easier to implement, since the functions we call to update on firebase already works on change sets, and our redux store updates also work on change set.

After this change, we are able to completely remove those ugly local caches and make the app more responsive!

### Test Plan

Try to drag and drop within focus view, from focus view completed to uncompleted, within a day in future view and between days.
No more flashes!