### PR TITLE
Firestore Support for Sending Group Invitations

### DIFF
--- a/common/src/firebase/database.ts
+++ b/common/src/firebase/database.ts
@@ -125,4 +125,6 @@ export default class Database {
   tasksCollection = (): Collection => this.db().collection('samwise-tasks');
 
   subTasksCollection = (): Collection => this.db().collection('samwise-subtasks');
+
+  pendingInvitesCollection = (): Collection => this.db().collection('samwise-group-pending-invites');
 }

--- a/common/src/types/action-types.ts
+++ b/common/src/types/action-types.ts
@@ -51,7 +51,8 @@ export type PatchCourses = {
 
 export type PatchPendingInvite = {
   readonly type: 'PATCH_PENDING_GROUP_INVITE';
-  readonly change: PendingGroupInvite[];
+  readonly created: PendingGroupInvite[];
+  readonly deleted: string[];
 };
 
 export type Action =

--- a/common/src/types/action-types.ts
+++ b/common/src/types/action-types.ts
@@ -6,6 +6,7 @@ import {
   Task,
   Tag,
   BannerMessageStatus,
+  PendingGroupInvite,
 } from './store-types';
 
 export type PatchTags = {
@@ -48,10 +49,16 @@ export type PatchCourses = {
   readonly courses: Map<string, Course[]>;
 };
 
+export type PatchPendingInvite = {
+  readonly type: 'PATCH_PENDING_GROUP_INVITE';
+  readonly change: PendingGroupInvite[];
+};
+
 export type Action =
   | PatchTags
   | PatchTasks
   | PatchSubTasks
   | PatchSettings
   | PatchBannerMessageStatus
-  | PatchCourses;
+  | PatchCourses
+  | PatchPendingInvite;

--- a/common/src/types/firestore-types.ts
+++ b/common/src/types/firestore-types.ts
@@ -61,6 +61,13 @@ export type FirestoreGroup = {
   readonly deadline: Date;
 }
 
+export type FirestorePendingGroupInvite = {
+  readonly group: string;
+  readonly groupName: string; // Name of the group
+  readonly inviterName: string; // Name of person who sent invite
+  readonly invitee: string; // Email of person receiving invitation
+}
+
 // all these tasks stay in 'samwise-tasks'
 // FirestoreLegacyTask should eventually be converted to FirestoreOneTimeTask.
 export type FirestoreTask =

--- a/common/src/types/firestore-types.ts
+++ b/common/src/types/firestore-types.ts
@@ -63,7 +63,6 @@ export type FirestoreGroup = {
 
 export type FirestorePendingGroupInvite = {
   readonly group: string;
-  readonly groupName: string; // Name of the group
   readonly inviterName: string; // Name of person who sent invite
   readonly invitee: string; // Email of person receiving invitation
 }

--- a/common/src/types/store-types.ts
+++ b/common/src/types/store-types.ts
@@ -112,6 +112,15 @@ export type Course = {
 };
 
 /**
+ * The type for a pending group invite
+ */
+export type PendingGroupInvite = {
+  readonly group: string;
+  readonly groupName: string; // Name of the group
+  readonly inviterName: string; // Name of person who sent invite
+}
+
+/**
  * The type of the entire redux state.
  */
 export type State = {
@@ -130,4 +139,6 @@ export type State = {
   readonly settings: Settings;
   readonly bannerMessageStatus: BannerMessageStatus;
   readonly courses: Map<string, Course[]>;
+  // Set of all pending invites; ordered because only one will be shown at a time.
+  readonly pendingInvites: PendingGroupInvite[];
 };

--- a/common/src/types/store-types.ts
+++ b/common/src/types/store-types.ts
@@ -115,6 +115,7 @@ export type Course = {
  * The type for a pending group invite
  */
 export type PendingGroupInvite = {
+  readonly id: string;
   readonly group: string;
   readonly groupName: string; // Name of the group
   readonly inviterName: string; // Name of person who sent invite
@@ -139,6 +140,5 @@ export type State = {
   readonly settings: Settings;
   readonly bannerMessageStatus: BannerMessageStatus;
   readonly courses: Map<string, Course[]>;
-  // Set of all pending invites; ordered because only one will be shown at a time.
-  readonly pendingInvites: PendingGroupInvite[];
+  readonly pendingInvites: Map<string, PendingGroupInvite>;
 };

--- a/common/src/types/store-types.ts
+++ b/common/src/types/store-types.ts
@@ -117,7 +117,6 @@ export type Course = {
 export type PendingGroupInvite = {
   readonly id: string;
   readonly group: string;
-  readonly groupName: string; // Name of the group
   readonly inviterName: string; // Name of person who sent invite
 }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -35,7 +35,7 @@ service cloud.firestore {
     	allow read, write, delete: if request.auth.token.email == resource.data.author
     }
     match /samwise-group-pending-invites/{pendingInvite} {
-      allow create: if request.auth.token.email in get(/databases/$(database)/documents/samwise-groups/$(request.resource.group)).data.members 
+      allow create: if request.auth.token.email in get(/databases/$(database)/documents/samwise-groups/$(request.resource.data.group)).data.members 
       allow read, delete: if request.auth.token.email == resource.data.invitee
     }
   }

--- a/firestore.rules
+++ b/firestore.rules
@@ -35,6 +35,7 @@ service cloud.firestore {
     	allow read, write, delete: if request.auth.token.email == resource.data.author
     }
     match /samwise-group-pending-invites/{pendingInvite} {
+      allow create: if request.auth.token.email in get(/databases/$(database)/documents/samwise-groups/$(request.resource.group)).data.members 
       allow read, delete: if request.auth.token.email == resource.data.invitee
     }
   }

--- a/firestore.rules
+++ b/firestore.rules
@@ -34,5 +34,8 @@ service cloud.firestore {
     	allow create: if request.auth.uid != null
     	allow read, write, delete: if request.auth.token.email == resource.data.author
     }
+    match /samwise-group-pending-invites/{pendingInvite} {
+      allow read, delete: if request.auth.token.email == resource.data.invitee
+    }
   }
 }

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -368,7 +368,18 @@ export const removeSubTask = (
 
 /*
  * --------------------------------------------------------------------------------
- * Section 3: Other Compound Actions
+ * Section 3: Groups Actions
+ * --------------------------------------------------------------------------------
+ */
+
+export const rejectInvite = async (inviteID: string): Promise<void> => {
+  const invitations = await database.pendingInvitesCollection().doc(inviteID);
+  invitations.delete();
+};
+
+/*
+ * --------------------------------------------------------------------------------
+ * Section 4: Other Compound Actions
  * --------------------------------------------------------------------------------
  */
 

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -388,7 +388,7 @@ export const sendInvite = async (
     inviterName: userName,
     invitee,
   };
-  database.pendingInvitesCollection().doc().set(newInvitation);
+  database.pendingInvitesCollection().add(newInvitation);
 };
 
 export const rejectInvite = async (inviteID: string): Promise<void> => {

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -388,7 +388,7 @@ export const sendInvite = async (
     inviterName: userName,
     invitee,
   };
-  database.pendingInvitesCollection().add(newInvitation);
+  await database.pendingInvitesCollection().add(newInvitation);
 };
 
 export const rejectInvite = async (inviteID: string): Promise<void> => {

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -17,6 +17,7 @@ import {
   FirestoreCommon,
   FirestoreTask,
   FirestoreSubTask,
+  FirestorePendingGroupInvite,
 } from 'common/lib/types/firestore-types';
 import { WriteBatch } from 'common/lib/firebase/database';
 import Actions from 'common/lib/firebase/common-actions';
@@ -371,6 +372,24 @@ export const removeSubTask = (
  * Section 3: Groups Actions
  * --------------------------------------------------------------------------------
  */
+
+/**
+ * Send an invitation to a user to join a group.
+ * @param groupID Document ID of the group's Firestore document. The user calling this function must
+ *                be a member of this group.
+ * @param userName The name of the user sending the invitation (in English)
+ * @param invitee The full Cornell email of the user receiving the invitation (all lowercase)
+ */
+export const sendInvite = async (
+  groupID: string, userName: string, invitee: string,
+): Promise<void> => {
+  const newInvitation: FirestorePendingGroupInvite = {
+    group: groupID,
+    inviterName: userName,
+    invitee,
+  };
+  database.pendingInvitesCollection().doc().set(newInvitation);
+};
 
 export const rejectInvite = async (inviteID: string): Promise<void> => {
   const invitations = await database.pendingInvitesCollection().doc(inviteID);

--- a/frontend/src/firebase/listeners.ts
+++ b/frontend/src/firebase/listeners.ts
@@ -253,8 +253,8 @@ export default (onFirstFetched: () => void): (() => void) => {
         if (data === undefined) {
           return;
         }
-        const { group, groupName, inviterName } = data as FirestorePendingGroupInvite;
-        const newInvite: PendingGroupInvite = { id, group, groupName, inviterName };
+        const { group, inviterName } = data as FirestorePendingGroupInvite;
+        const newInvite: PendingGroupInvite = { id, group, inviterName };
         newPendingInvites.push(newInvite);
       }
     });

--- a/frontend/src/store/actions.ts
+++ b/frontend/src/store/actions.ts
@@ -7,6 +7,7 @@ import {
   PatchSettings,
   PatchBannerMessageStatus,
   TaskWithChildrenId,
+  PatchPendingInvite,
 } from 'common/lib/types/action-types';
 import {
   Course,
@@ -14,6 +15,7 @@ import {
   SubTask,
   Settings,
   BannerMessageStatus,
+  PendingGroupInvite,
 } from 'common/lib/types/store-types';
 
 export const patchTags = (created: Tag[], edited: Tag[], deleted: string[]): PatchTags => ({
@@ -46,4 +48,10 @@ export const patchBannerMessageStatus = (
 
 export const patchCourses = (courses: Map<string, Course[]>): PatchCourses => ({
   type: 'PATCH_COURSES', courses,
+});
+
+export const patchPendingInvite = (
+  created: PendingGroupInvite[], deleted: string[],
+): PatchPendingInvite => ({
+  type: 'PATCH_PENDING_GROUP_INVITE', created, deleted,
 });

--- a/frontend/src/store/reducers.ts
+++ b/frontend/src/store/reducers.ts
@@ -253,8 +253,12 @@ function patchCourses(state: State, { courses }: PatchCourses): State {
   return { ...state, courses };
 }
 
-function patchPendingInvite(state: State, { change }: PatchPendingInvite): State {
-  return { ...state, pendingInvites: change };
+function patchPendingInvite(state: State, { created, deleted }: PatchPendingInvite): State {
+  const newInvites = state.pendingInvites.withMutations((invites) => {
+    created.forEach((t) => invites.set(t.id, t));
+    deleted.forEach((id) => invites.delete(id));
+  });
+  return { ...state, pendingInvites: newInvites };
 }
 
 export default function rootReducer(state: State = initialState, action: Action): State {

--- a/frontend/src/store/reducers.ts
+++ b/frontend/src/store/reducers.ts
@@ -7,6 +7,7 @@ import {
   PatchSubTasks,
   PatchSettings,
   PatchBannerMessageStatus,
+  PatchPendingInvite,
 } from 'common/lib/types/action-types';
 import { State, SubTask, Task } from 'common/lib/types/store-types';
 import { error } from 'common/lib/util/general-util';
@@ -252,6 +253,10 @@ function patchCourses(state: State, { courses }: PatchCourses): State {
   return { ...state, courses };
 }
 
+function patchPendingInvite(state: State, { change }: PatchPendingInvite): State {
+  return { ...state, pendingInvites: change };
+}
+
 export default function rootReducer(state: State = initialState, action: Action): State {
   switch (action.type) {
     case 'PATCH_TAGS':
@@ -266,6 +271,8 @@ export default function rootReducer(state: State = initialState, action: Action)
       return patchBannerMessageStatus(state, action);
     case 'PATCH_COURSES':
       return patchCourses(state, action);
+    case 'PATCH_PENDING_GROUP_INVITE':
+      return patchPendingInvite(state, action);
     default:
       return state;
   }

--- a/frontend/src/store/state.ts
+++ b/frontend/src/store/state.ts
@@ -17,7 +17,7 @@ export const initialState: State = {
   settings: { canvasCalendar: null, completedOnboarding: true, theme: 'light' },
   bannerMessageStatus: {},
   courses: Map(),
-  pendingInvites: [],
+  pendingInvites: Map(),
 };
 
 /**
@@ -97,5 +97,5 @@ export const initialStateForTesting: State = {
       },
     ],
   }),
-  pendingInvites: [],
+  pendingInvites: Map(),
 };

--- a/frontend/src/store/state.ts
+++ b/frontend/src/store/state.ts
@@ -17,6 +17,7 @@ export const initialState: State = {
   settings: { canvasCalendar: null, completedOnboarding: true, theme: 'light' },
   bannerMessageStatus: {},
   courses: Map(),
+  pendingInvites: [],
 };
 
 /**
@@ -96,4 +97,5 @@ export const initialStateForTesting: State = {
       },
     ],
   }),
+  pendingInvites: [],
 };


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

Create firebase functions and add support in the Redux Store for the `samwise-group-pending-invites` collection, used to store invitations for people to join a group. 
There is now a function called `sendInvite()` that can be called to invite a user to a group.
Invitations are pulled down to the redux store of the receiving user.
Also changed Firestore security rules to match.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Manually added a document to Firestore, and then added some test code to print out `JSON.stringify(pendingInvites)` from the Redux store, and it shows up correctly:
![image](https://user-images.githubusercontent.com/6147405/81460631-a1805f00-9174-11ea-95a9-37a20d718650.png)

Likewise, manually calling the function to send an invite works.
![image](https://user-images.githubusercontent.com/6147405/81461723-bb717000-917b-11ea-820f-05c04b43c01b.png)
As does manually calling the function to reject an invite, though I'm not sure how to screenshot that.