### PR TITLE
View and Reject Invitations

### DIFF
--- a/frontend/src/components/TitleBar/GroupInvites/index.module.css
+++ b/frontend/src/components/TitleBar/GroupInvites/index.module.css
@@ -1,0 +1,50 @@
+.Banner {
+  position: fixed;
+  
+  bottom: 0;
+  right: 0;
+  width: 50vw;
+  max-width: 400px;
+  z-index: 20;
+  height: auto;
+  color: white;
+
+  list-style-type: none;
+}
+
+.Banner li {
+  align-items: center;
+  align-content: center;
+  display: flex;
+  background-color: #7fbdff;
+  padding: 1em;
+  margin: 1em;
+}
+
+.Text {
+  flex: auto;
+}
+
+.ButtonWrap {
+  display: block;
+  text-align: center;;
+}
+
+.ButtonWrap button {
+  color: white;
+  background: none;
+  padding: 8px;
+  border: 1px solid white;
+  border-radius: 5px;
+  cursor: pointer;
+  display:block;
+  width: 100%;
+}
+
+.ButtonWrap button:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.ButtonWrap button:active {
+  background: rgba(255, 255, 255, 0.4);
+}

--- a/frontend/src/components/TitleBar/GroupInvites/index.tsx
+++ b/frontend/src/components/TitleBar/GroupInvites/index.tsx
@@ -10,16 +10,16 @@ type Props = {
 };
 
 function SingleInvitation(
-  inviter: string, groupID: string,
+  inviter: string, groupID: string, inviteID: string,
 ): ReactElement {
   return (
     <li key={groupID}>
       <span className={styles.Text}>{inviter} has invited you to join their group project.</span>
       <div className={styles.ButtonWrap}>
-        <button type="button" onClick={() => { console.log('Tried to join group, a currently unsupported operation'); }}>
+        <button type="button" onClick={() => { console.log(`Tried to join group ${groupID}, a currently unsupported operation`); }}>
             Join
         </button>
-        <button type="button" onClick={() => { rejectInvite(groupID); }}>
+        <button type="button" onClick={() => { rejectInvite(inviteID); }}>
             Reject
         </button>
       </div>
@@ -34,6 +34,7 @@ const GroupInvites = ({ pendingInvites }: Props): ReactElement | null => {
       {pendingInvites.valueSeq().map((val) => SingleInvitation(
         val.inviterName,
         val.group,
+        val.id,
       ))}
     </ul>
   );

--- a/frontend/src/components/TitleBar/GroupInvites/index.tsx
+++ b/frontend/src/components/TitleBar/GroupInvites/index.tsx
@@ -16,7 +16,12 @@ function SingleInvitation(
     <li key={groupID}>
       <span className={styles.Text}>{inviter} has invited you to join their group project.</span>
       <div className={styles.ButtonWrap}>
-        <button type="button" onClick={() => { console.log(`Tried to join group ${groupID}, a currently unsupported operation`); }}>
+        <button
+          type="button"
+          onClick={() => {
+            console.log(`Tried to join group ${groupID}, a currently unsupported operation`);
+          }}
+        >
             Join
         </button>
         <button type="button" onClick={() => { rejectInvite(inviteID); }}>

--- a/frontend/src/components/TitleBar/GroupInvites/index.tsx
+++ b/frontend/src/components/TitleBar/GroupInvites/index.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { Map } from 'immutable';
 import { State, PendingGroupInvite } from 'common/lib/types/store-types';
 import styles from './index.module.css';
-import { rejectInvite } from '../../../firebase/actions';
+import { joinGroup, rejectInvite } from '../../../firebase/actions';
 
 type Props = {
   readonly pendingInvites: Map<string, PendingGroupInvite>;
@@ -19,7 +19,7 @@ function SingleInvitation(invite: PendingGroupInvite): ReactElement {
         <button
           type="button"
           onClick={() => {
-            console.log(`Tried to join group ${invite.group}, a currently unsupported operation`);
+            joinGroup(invite.group, invite.id);
           }}
         >
           Join

--- a/frontend/src/components/TitleBar/GroupInvites/index.tsx
+++ b/frontend/src/components/TitleBar/GroupInvites/index.tsx
@@ -16,12 +16,7 @@ function SingleInvitation(invite: PendingGroupInvite): ReactElement {
         {`${invite.inviterName} has invited you to join their group project.`}
       </span>
       <div className={styles.ButtonWrap}>
-        <button
-          type="button"
-          onClick={() => {
-            joinGroup(invite.group, invite.id);
-          }}
-        >
+        <button type="button" onClick={() => { joinGroup(invite.group, invite.id); }}>
           Join
         </button>
         <button type="button" onClick={() => { rejectInvite(invite.id); }}>

--- a/frontend/src/components/TitleBar/GroupInvites/index.tsx
+++ b/frontend/src/components/TitleBar/GroupInvites/index.tsx
@@ -14,7 +14,9 @@ function SingleInvitation(
 ): ReactElement {
   return (
     <li key={groupID}>
-      <span className={styles.Text}>{inviter} has invited you to join their group project.</span>
+      <span className={styles.Text}>
+        {`${inviter} has invited you to join their group project.`}
+      </span>
       <div className={styles.ButtonWrap}>
         <button
           type="button"
@@ -22,7 +24,7 @@ function SingleInvitation(
             console.log(`Tried to join group ${groupID}, a currently unsupported operation`);
           }}
         >
-            Join
+          Join
         </button>
         <button type="button" onClick={() => { rejectInvite(inviteID); }}>
             Reject

--- a/frontend/src/components/TitleBar/GroupInvites/index.tsx
+++ b/frontend/src/components/TitleBar/GroupInvites/index.tsx
@@ -9,9 +9,7 @@ type Props = {
   readonly pendingInvites: Map<string, PendingGroupInvite>;
 };
 
-function SingleInvitation(
-  invite: PendingGroupInvite,
-): ReactElement {
+function SingleInvitation(invite: PendingGroupInvite): ReactElement {
   return (
     <li key={invite.group}>
       <span className={styles.Text}>

--- a/frontend/src/components/TitleBar/GroupInvites/index.tsx
+++ b/frontend/src/components/TitleBar/GroupInvites/index.tsx
@@ -10,23 +10,23 @@ type Props = {
 };
 
 function SingleInvitation(
-  inviter: string, groupID: string, inviteID: string,
+  invite: PendingGroupInvite,
 ): ReactElement {
   return (
-    <li key={groupID}>
+    <li key={invite.group}>
       <span className={styles.Text}>
-        {`${inviter} has invited you to join their group project.`}
+        {`${invite.inviterName} has invited you to join their group project.`}
       </span>
       <div className={styles.ButtonWrap}>
         <button
           type="button"
           onClick={() => {
-            console.log(`Tried to join group ${groupID}, a currently unsupported operation`);
+            console.log(`Tried to join group ${invite.group}, a currently unsupported operation`);
           }}
         >
           Join
         </button>
-        <button type="button" onClick={() => { rejectInvite(inviteID); }}>
+        <button type="button" onClick={() => { rejectInvite(invite.id); }}>
             Reject
         </button>
       </div>
@@ -38,11 +38,7 @@ const GroupInvites = ({ pendingInvites }: Props): ReactElement | null => {
   if (pendingInvites.isEmpty()) { return null; }
   return (
     <ul className={styles.Banner}>
-      {pendingInvites.valueSeq().map((val) => SingleInvitation(
-        val.inviterName,
-        val.group,
-        val.id,
-      ))}
+      {pendingInvites.valueSeq().map((invite) => SingleInvitation(invite))}
     </ul>
   );
 };

--- a/frontend/src/components/TitleBar/GroupInvites/index.tsx
+++ b/frontend/src/components/TitleBar/GroupInvites/index.tsx
@@ -1,0 +1,43 @@
+import React, { ReactElement } from 'react';
+import { connect } from 'react-redux';
+import { Map } from 'immutable';
+import { State, PendingGroupInvite } from 'common/lib/types/store-types';
+import styles from './index.module.css';
+import { rejectInvite } from '../../../firebase/actions';
+
+type Props = {
+  readonly pendingInvites: Map<string, PendingGroupInvite>;
+};
+
+function SingleInvitation(
+  inviter: string, groupID: string,
+): ReactElement {
+  return (
+    <li key={groupID}>
+      <span className={styles.Text}>{inviter} has invited you to join their group project.</span>
+      <div className={styles.ButtonWrap}>
+        <button type="button" onClick={() => { console.log('Tried to join group, a currently unsupported operation'); }}>
+            Join
+        </button>
+        <button type="button" onClick={() => { rejectInvite(groupID); }}>
+            Reject
+        </button>
+      </div>
+    </li>
+  );
+}
+
+const GroupInvites = ({ pendingInvites }: Props): ReactElement | null => {
+  if (pendingInvites.isEmpty()) { return null; }
+  return (
+    <ul className={styles.Banner}>
+      {pendingInvites.valueSeq().map((val) => SingleInvitation(
+        val.inviterName,
+        val.group,
+      ))}
+    </ul>
+  );
+};
+
+const Connected = connect(({ pendingInvites }: State) => ({ pendingInvites }))(GroupInvites);
+export default Connected;

--- a/frontend/src/components/TitleBar/index.tsx
+++ b/frontend/src/components/TitleBar/index.tsx
@@ -4,6 +4,7 @@ import { useTime } from 'hooks/time-hook';
 import { date2FullDateString } from 'common/lib/util/datetime-util';
 import { State, Theme } from 'common/lib/types/store-types';
 import Banner from './Banner';
+import GroupInvites from './GroupInvites';
 import styles from './index.module.css';
 import SettingsButton from './Settings/SettingsButton';
 
@@ -28,6 +29,7 @@ export function TitleBar(props: { theme: Theme }): ReactElement {
   return (
     <header className={styles.Main} style={darkModeStyles}>
       <Banner />
+      <GroupInvites />
       <span title="time" className={styles.Time}>{timeString}</span>
       <span title="date" className={styles.Date}>{dateString}</span>
       <span className={styles.Links}><SettingsButton /></span>

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -403,6 +403,8 @@ export const joinGroup = async (
   }
   await groupDoc.update({ members: [...members, email] });
 
+  // TODO remove this whole function after we get a Cloud Function working;
+  // the following line is a hack
   rejectInvite(inviteID);
 };
 

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -394,7 +394,7 @@ export const joinGroup = async (
     throw new Error('Invalid invitation');
   }
   const members = await groupDoc.get().then(
-    (snapshot) => { console.log(snapshot.data()); return (snapshot.data() as FirestoreGroup)?.members; },
+    (snapshot) => (snapshot.data() as FirestoreGroup)?.members,
   );
   const { email } = getAppUser();
   // Check if user is already in the group


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

Implement basic UI to allow users to see and reject group invitations.

### Test Plan <!-- Required -->

![image](https://user-images.githubusercontent.com/6147405/81463336-ef9e5e00-9186-11ea-827f-3861604e59ab.png)


Can gracefully handle multiple invitations:
![image](https://user-images.githubusercontent.com/6147405/81463241-009a9f80-9186-11ea-8232-733f0b3a23a4.png)

Disappears when all are dismissed:
![image](https://user-images.githubusercontent.com/6147405/81463251-19a35080-9186-11ea-9eec-0ffea4144acf.png)

<!-- Provide screenshots or point out the additional unit tests -->

Rejecting an invitation works.
First, confirm that an invitation exists in Firestore:
![image](https://user-images.githubusercontent.com/6147405/81463192-89fda200-9185-11ea-8cf7-571b39417bbd.png)

Then click reject:
![image](https://user-images.githubusercontent.com/6147405/81463196-941fa080-9185-11ea-8a58-578395525eb2.png)

Observe the invitation is gone:
![image](https://user-images.githubusercontent.com/6147405/81463215-bfa28b00-9185-11ea-8c47-a686384aee11.png)
