### PR TITLE
Fix Regressions

### DIFF
--- a/frontend/src/components/GroupView/RightView/index.module.css
+++ b/frontend/src/components/GroupView/RightView/index.module.css
@@ -20,7 +20,7 @@
   overflow-y: auto;
 }
 
-h2 {
+.RightView h2 {
   display: inline-block;
   color: #808080;
   font-size: 26px;

--- a/frontend/src/components/TaskCreator/index.module.css
+++ b/frontend/src/components/TaskCreator/index.module.css
@@ -42,9 +42,6 @@
   .SubmitNewTask, .GroupSubmitNewTask.GroupSubmitNewTask {
     height: 50px;
   }
-  .TaskCreator {
-    height: 5vh;
-  }
   .NewTaskModal {
     width: calc(30vw + 60px);
   }
@@ -65,6 +62,11 @@
   }
 }
 
+@media only screen and (min-width: 800px) and (min-height: 650px) {
+  .TaskCreator {
+    height: 5vh;
+  }
+}
 
 .NewTaskComponent:focus {
   outline: none;


### PR DESCRIPTION
### Summary <!-- Required -->

Fixes #498 which was caused by setting `TaskCreator ` a blanket `height: 5vh` for large screen widths to fix the bottom margin. However, for low screen heights we should just allow `height: auto`. (There may be a shift at height 650px though)

Also fixes greyed out settings page title:
![image](https://user-images.githubusercontent.com/20008134/81484801-9120c080-9216-11ea-8f62-8a42f6cd91d4.png)

### Test Plan <!-- Required -->
👀