### PR TITLE
Fix calendar styles to avoid regression

### DIFF
--- a/frontend/src/components/TitleBar/Tags/TagAdder.module.css
+++ b/frontend/src/components/TitleBar/Tags/TagAdder.module.css
@@ -31,6 +31,7 @@ input.SearchInput:focus {
 }
 
 button.DropdownItem {
+  border: none;
   display: block;
   width: 100%;
   font-size: 14px;

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -62,6 +62,11 @@ input[type='password'] {
   -moz-appearance: none;
 }
 
+.react-calendar {
+  border: 1px solid #a0a096;
+  text-align: center;
+}
+
 .react-calendar__month-view__weekdays__weekday {
   color: $very-dark-grey;
 }
@@ -72,17 +77,28 @@ input[type='password'] {
 
 $calendar-selected-background: #50e3c2;
 
+button.react-calendar__tile {
+  border: none;
+}
+
+button.react-calendar__tile:hover {
+  cursor: pointer;
+}
+
 button.react-calendar__tile--active {
-  background: $calendar-selected-background;
+  background: $calendar-selected-background !important;
   color: white !important;
   font-weight: bold;
   box-shadow: 1px 1px 5px 2px rgba(0, 0, 0, 0.1);
 }
+
 button.react-calendar__tile--active:hover {
   background: $calendar-selected-background;
+  cursor: pointer;
 }
+
 button.react-calendar__month-view__days__day {
-  /*padding:0.5em 2em;*/
+  background: white;
   padding-top: 0.4em;
   padding-bottom: 0.4em;
 }
@@ -92,14 +108,39 @@ button.react-calendar__month-view__days__day {
   font-weight: normal;
 }
 
+.react-calendar {
+  background: white;
+}
+
 .react-calendar__navigation {
   height: 30px;
   margin-bottom: 10px;
 }
 
+.react-calendar__navigation__label {
+  background: white;
+}
+
+.react-calendar__navigation button {
+  background: white;
+  border: none;
+  min-width: 44px;
+}
+
+.react-calendar__navigation button:hover {
+  background: #e6e6e6;
+  cursor: pointer;
+}
+
+.react-calendar__navigation button:disabled {
+  background: #e6e6e6;
+  cursor: not-allowed;
+}
+
 .react-calendar__navigation button:first-child {
   border-top-left-radius: 2px;
 }
+
 .react-calendar__navigation button:last-child {
   border-top-right-radius: 2px;
 }

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -103,6 +103,29 @@ button.react-calendar__month-view__days__day {
   padding-bottom: 0.4em;
 }
 
+button.react-calendar__month-view__days__day:hover {
+  background: #e6e6e6;
+  border: none;
+}
+
+button.react-calendar__month-view__days__day:disabled {
+  background: #e6e6e6;
+  cursor: not-allowed;
+}
+
+.react-calendar__tile {
+  background: white;
+  padding: 2em 0.5em;
+}
+
+.react-calendar__tile:disabled {
+  background: #f0f0f0;
+}
+
+.react-calendar__tile--hasActive {
+  background: #76baff !important;
+}
+
 .NewTaskDatePick div > abbr {
   color: #7f8fa4;
   font-weight: normal;


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This PR fixes some style issues with our calendar date picker powered by `react-calendar`. Since the last prod release, the UI of the calendar picker has become messed up (but the functionality is still there). ~~We haven't bumped the version of `react-calendar` since,~~ (actually we have bumped react-calendar) so this is likely to have been that or due to the accessibility changes earlier in which we changed tags for buttons to `<button>`.

This issue was pointed out by @mt-xing in #516. 

### Test Plan <!-- Required -->
**Before:**
![fVX368D](https://user-images.githubusercontent.com/7517829/92033183-45e86b80-ed39-11ea-976e-764a917908a4.gif)

**After**
![IV3vBXD](https://user-images.githubusercontent.com/7517829/92033101-1f2a3500-ed39-11ea-86d0-429954b650b0.gif)

Play with the calendar / add date feature on staging for this PR and compare to current prod (https://samwise.today/)

### Notes
Only tested so far on my Windows 10 laptop running on Chrome.