### PR TITLE
Give all default exports a name for fast refresh

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,6 +26,7 @@
     "react/state-in-constructor": "off",
     "import/extensions": "off",
     "indent": "off",
+    "import/no-anonymous-default-export": "error",
     "@typescript-eslint/ban-ts-comment": ["error", { "ts-expect-error": "allow-with-description" }],
     "@typescript-eslint/indent": "off",
     "@typescript-eslint/prefer-interface": "off",

--- a/frontend/src/PersonalView.tsx
+++ b/frontend/src/PersonalView.tsx
@@ -9,7 +9,7 @@ import TitleBar from './components/TitleBar';
 /**
  * The top level Personal Samwise view component.
  */
-export default (): ReactElement => (
+const PersonalView = (): ReactElement => (
   <>
     <Onboard />
     <TitleBar />
@@ -18,3 +18,5 @@ export default (): ReactElement => (
     <AllComplete />
   </>
 );
+
+export default PersonalView;

--- a/frontend/src/ViewSwitcher.tsx
+++ b/frontend/src/ViewSwitcher.tsx
@@ -5,10 +5,8 @@ import GroupView from 'components/GroupView';
 import styles from 'App.module.css';
 
 type Views = 'personal' | 'group';
-/**
- * Handles switching the view from Personal to Group
- */
-export default (): React.ReactElement => {
+
+const ViewSwitcher = (): React.ReactElement => {
   const groups = ['CS 2110', 'CS 3110', 'INFO 3450'];
 
   const [view, setView] = useState<Views>('personal');
@@ -28,3 +26,8 @@ export default (): React.ReactElement => {
     </div>
   );
 };
+
+/**
+ * Handles switching the view from Personal to Group
+ */
+export default ViewSwitcher;

--- a/frontend/src/components/GroupView/MiddleBar/People/Member.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/People/Member.tsx
@@ -8,7 +8,7 @@ type Props = {
   memberName: string;
 };
 
-export default ({ memberName }: Props): ReactElement => {
+const Member = ({ memberName }: Props): ReactElement => {
   const initials = `${memberName.split(' ')[0].charAt(0)}${memberName.split(' ')[1].charAt(0)}`;
   return (
     <div className={styles.Member}>
@@ -22,3 +22,5 @@ export default ({ memberName }: Props): ReactElement => {
     </div>
   );
 };
+
+export default Member;

--- a/frontend/src/components/GroupView/MiddleBar/People/index.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/People/index.tsx
@@ -30,7 +30,7 @@ type Props = {
   groupMemberNames: string[];
 };
 
-export default ({ groupMemberNames }: Props): ReactElement => (
+const People = ({ groupMemberNames }: Props): ReactElement => (
   <div className={styles.People}>
     <h2>People</h2>
     <div className={styles.MemberList}>
@@ -55,3 +55,5 @@ export default ({ groupMemberNames }: Props): ReactElement => (
     </button>
   </div>
 );
+
+export default People;

--- a/frontend/src/components/GroupView/MiddleBar/TaskQueue/index.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/TaskQueue/index.tsx
@@ -8,9 +8,11 @@ const EmptyTaskQueue = (): React.ReactElement => (
   </div>
 );
 
-export default (): React.ReactElement => (
+const TaskQueue = (): React.ReactElement => (
   <div className={styles.TaskQueue}>
     <h2>Task Queue</h2>
     <EmptyTaskQueue />
   </div>
 );
+
+export default TaskQueue;

--- a/frontend/src/components/GroupView/MiddleBar/index.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/index.tsx
@@ -7,9 +7,11 @@ type Props = {
   groupMemberNames: string[];
 };
 
-export default ({ groupMemberNames }: Props): ReactElement => (
+const MiddleBar = ({ groupMemberNames }: Props): ReactElement => (
   <div className={styles.MiddleBar}>
     <TaskQueue />
     <People groupMemberNames={groupMemberNames} />
   </div>
 );
+
+export default MiddleBar;

--- a/frontend/src/components/GroupView/RightView/GroupTaskRow/index.tsx
+++ b/frontend/src/components/GroupView/RightView/GroupTaskRow/index.tsx
@@ -19,7 +19,7 @@ const pressedAddGroupTask = (e: KeyboardEvent): void => {
   }
 };
 
-export default ({ memberName }: Props): ReactElement => {
+const GroupTaskRow = ({ memberName }: Props): ReactElement => {
   const initials = `${memberName.split(' ')[0].charAt(0)}${memberName.split(' ')[1].charAt(0)}`;
 
   return (
@@ -42,3 +42,5 @@ export default ({ memberName }: Props): ReactElement => {
     </div>
   );
 };
+
+export default GroupTaskRow;

--- a/frontend/src/components/GroupView/RightView/index.tsx
+++ b/frontend/src/components/GroupView/RightView/index.tsx
@@ -16,7 +16,7 @@ const EditGroupNameIcon = (): ReactElement => {
   return <SamwiseIcon iconName="pencil" className={styles.EditGroupNameIcon} onClick={handler} />;
 };
 
-export default ({ groupName, groupMemberNames }: Props): ReactElement => (
+const RightView = ({ groupName, groupMemberNames }: Props): ReactElement => (
   <div className={styles.RightView}>
     <div className={styles.GroupTaskCreator}>
       <TaskCreator view="group" group={groupName} />
@@ -35,3 +35,5 @@ export default ({ groupName, groupMemberNames }: Props): ReactElement => (
     </div>
   </div>
 );
+
+export default RightView;

--- a/frontend/src/components/GroupView/index.tsx
+++ b/frontend/src/components/GroupView/index.tsx
@@ -9,9 +9,11 @@ type Props = {
 
 const members = ['Darien Lopez', 'Sarah Johnson', 'Michelle Parker', 'Samwise Bear'];
 
-export default ({ groupName }: Props): ReactElement => (
+const GroupView = ({ groupName }: Props): ReactElement => (
   <div className={styles.GroupView}>
     <MiddleBar groupMemberNames={members} />
     <RightView groupName={groupName} groupMemberNames={members} />
   </div>
 );
+
+export default GroupView;

--- a/frontend/src/components/SideBar/GroupIcon.tsx
+++ b/frontend/src/components/SideBar/GroupIcon.tsx
@@ -8,7 +8,7 @@ type Props = {
   selected: boolean;
 };
 
-export default ({ classCode, handleClick, selected }: Props): ReactElement => (
+const GroupIcon = ({ classCode, handleClick, selected }: Props): ReactElement => (
   <button
     type="button"
     onClick={() => handleClick('group', classCode)}
@@ -17,3 +17,5 @@ export default ({ classCode, handleClick, selected }: Props): ReactElement => (
     {classCode.charAt(0)}
   </button>
 );
+
+export default GroupIcon;

--- a/frontend/src/components/SideBar/index.tsx
+++ b/frontend/src/components/SideBar/index.tsx
@@ -13,7 +13,7 @@ type Props = {
   changeView: (selectedView: Views, selectedGroup: string | undefined) => void;
 };
 
-export default ({ groups, changeView }: Props): ReactElement => {
+const SideBar = ({ groups, changeView }: Props): ReactElement => {
   const [showDropdown, setShowDropdown] = useState(false);
   const [selected, setSelected] = useState('personal');
 
@@ -60,3 +60,5 @@ export default ({ groups, changeView }: Props): ReactElement => {
     </div>
   );
 };
+
+export default SideBar;

--- a/frontend/src/components/TaskView/FocusView/CompletedSeparator.tsx
+++ b/frontend/src/components/TaskView/FocusView/CompletedSeparator.tsx
@@ -11,7 +11,7 @@ type Props = {
 const getIconClassName = (notInverted: boolean): string =>
   notInverted ? styles.Icon : `${styles.Icon} ${styles.Inverted}`;
 
-export default ({
+const CompletedSeparator = ({
   count,
   doesShowCompletedTasks,
   onDoesShowCompletedTasksChange,
@@ -26,3 +26,5 @@ export default ({
     <div className={styles.Line} />
   </div>
 );
+
+export default CompletedSeparator;

--- a/frontend/src/components/TaskView/FutureView/FutureViewSevenColumns.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewSevenColumns.tsx
@@ -5,10 +5,7 @@ import { SimpleDate } from './future-view-types';
 
 type Props = { readonly days: readonly SimpleDate[]; readonly doesShowCompletedTasks: boolean };
 
-/**
- * The component used to contain all the backlog days in 7 columns.
- */
-export default ({ days, doesShowCompletedTasks }: Props): ReactElement => {
+const FutureViewSevenColumns = ({ days, doesShowCompletedTasks }: Props): ReactElement => {
   const interval = days.length === 14 ? '2W' : 'Monthly';
   // Start building items
   const items = days.map((date: SimpleDate, i: number) => (
@@ -36,3 +33,8 @@ export default ({ days, doesShowCompletedTasks }: Props): ReactElement => {
     </div>
   );
 };
+
+/**
+ * The component used to contain all the backlog days in 7 columns.
+ */
+export default FutureViewSevenColumns;

--- a/frontend/src/components/TaskView/ProgressTracker/Bear.tsx
+++ b/frontend/src/components/TaskView/ProgressTracker/Bear.tsx
@@ -5,10 +5,7 @@ import { HappyBear, RegularBear } from '../../../assets/assets-constants';
 
 type Props = TasksProgressProps & { readonly inMobileView: boolean };
 
-/**
- * The bear as a progress checker.
- */
-export default ({ completedTasksCount, allTasksCount, inMobileView }: Props): ReactElement => {
+const Bear = ({ completedTasksCount, allTasksCount, inMobileView }: Props): ReactElement => {
   const allCompleted = completedTasksCount === allTasksCount;
   let style: CSSProperties = { backgroundImage: `url(${allCompleted ? HappyBear : RegularBear})` };
   if (!inMobileView) {
@@ -16,3 +13,8 @@ export default ({ completedTasksCount, allTasksCount, inMobileView }: Props): Re
   }
   return <div className={styles.Bear} style={style} />;
 };
+
+/**
+ * The bear as a progress checker.
+ */
+export default Bear;

--- a/frontend/src/components/UI/Loading.tsx
+++ b/frontend/src/components/UI/Loading.tsx
@@ -1,8 +1,10 @@
 import React, { ReactElement } from 'react';
 import styles from './Loading.module.css';
 
-export default (): ReactElement => (
+const Loading = (): ReactElement => (
   <div className={styles.LoadingTextWrapper}>
     <div className={styles.LoadingText}>Loading...</div>
   </div>
 );
+
+export default Loading;

--- a/frontend/src/components/UI/ModeIndicator.tsx
+++ b/frontend/src/components/UI/ModeIndicator.tsx
@@ -14,4 +14,6 @@ export const ConfigurableModeIndicator = ({ mode }: Props): ReactElement | null 
   return <div className={styles.Indicator}>{mode}</div>;
 };
 
-export default (): ReactElement | null => <ConfigurableModeIndicator mode={systemMode} />;
+const ModeIndicator = (): ReactElement | null => <ConfigurableModeIndicator mode={systemMode} />;
+
+export default ModeIndicator;

--- a/frontend/src/components/Util/Modals/TextInputModal.tsx
+++ b/frontend/src/components/Util/Modals/TextInputModal.tsx
@@ -43,7 +43,7 @@ export type TextInputModalProps = {
   readonly onCancel: () => void;
 };
 
-export default ({
+const TextInputModal = ({
   open,
   title,
   subText,
@@ -96,3 +96,5 @@ export default ({
     </Modal>
   );
 };
+
+export default TextInputModal;

--- a/frontend/src/components/Util/SearchBox/DropdownItem.tsx
+++ b/frontend/src/components/Util/SearchBox/DropdownItem.tsx
@@ -7,7 +7,11 @@ type Props<T extends FuseItem> = {
   readonly onSelect: (selected: T) => void;
 };
 
-export default <T extends FuseItem>({ item, className, onSelect }: Props<T>): ReactElement => (
+const DropdownItem = <T extends FuseItem>({
+  item,
+  className,
+  onSelect,
+}: Props<T>): ReactElement => (
   <button
     type="button"
     className={className}
@@ -18,3 +22,5 @@ export default <T extends FuseItem>({ item, className, onSelect }: Props<T>): Re
     {item.value}
   </button>
 );
+
+export default DropdownItem;

--- a/frontend/src/components/Util/SearchBox/index.tsx
+++ b/frontend/src/components/Util/SearchBox/index.tsx
@@ -13,7 +13,7 @@ type Props<T extends FuseItem> = {
 
 type State<T> = { readonly searchInput: string; readonly searchResults: readonly T[] };
 
-export default <T extends FuseItem>({
+const SearchBox = <T extends FuseItem>({
   placeholder,
   fuse,
   inputClassname,
@@ -62,3 +62,5 @@ export default <T extends FuseItem>({
     </div>
   );
 };
+
+export default SearchBox;

--- a/frontend/src/firebase/listeners.ts
+++ b/frontend/src/firebase/listeners.ts
@@ -77,7 +77,7 @@ const transformDate = (dateOrTimestamp: Date | Timestamp): Date =>
 /**
  * Initialize listeners bind to firestore.
  */
-export default (onFirstFetched: () => void): (() => void) => {
+const initializeFirebaseListeners = (onFirstFetched: () => void): (() => void) => {
   let firstTagsFetched = false;
   let firstTasksFetched = false;
   let firstSubTasksFetched = false;
@@ -312,3 +312,5 @@ export default (onFirstFetched: () => void): (() => void) => {
     unmountPendingInviteListener();
   };
 };
+
+export default initializeFirebaseListeners;

--- a/functions/src/focus-today-task.ts
+++ b/functions/src/focus-today-task.ts
@@ -1,6 +1,6 @@
 import database from './db';
 
-export default async (): Promise<void> => {
+const focusTasksThatAreDueToday = async (): Promise<void> => {
   const todayAtZero = new Date();
   todayAtZero.setHours(0, 0, 0, 0);
   const todayAt235959 = new Date();
@@ -17,3 +17,5 @@ export default async (): Promise<void> => {
   });
   batch.commit();
 };
+
+export default focusTasksThatAreDueToday;

--- a/functions/src/remove-old-tasks.ts
+++ b/functions/src/remove-old-tasks.ts
@@ -29,7 +29,7 @@ export const partition = (
   return partitioned;
 };
 
-export default async (): Promise<void> => {
+const removeOldTasks = async (): Promise<void> => {
   const cutoff = nDaysBeforeNow(N);
   const snapshot = await database.tasksCollection().where('date', '<', cutoff).get();
   const idListToDelete: string[] = [];
@@ -52,3 +52,5 @@ export default async (): Promise<void> => {
     await batch.commit();
   }
 };
+
+export default removeOldTasks;


### PR DESCRIPTION
### Summary <!-- Required -->

Motivation:

<img width="606" alt="Screen Shot 2020-09-05 at 15 38 27" src="https://user-images.githubusercontent.com/4290500/92312516-52660180-ef8f-11ea-865c-60ff5f44de78.png">

Generated by `cd frontend && npx @next/codemod name-default-component`, and manually rename components that are named `Index` to be named after their parent folder.

Added a linter rule to enforce that we don't regress.

### Test Plan <!-- Required -->

👀 