### PR TITLE
Store user data in Firestore upon login

### DIFF
--- a/common/firebase/database.ts
+++ b/common/firebase/database.ts
@@ -129,6 +129,8 @@ export default class Database {
 
   groupsCollection = (): Collection => this.db().collection('samwise-groups');
 
+  usersCollection = (): Collection => this.db().collection('samwise-users');
+
   pendingInvitesCollection = (): Collection =>
     this.db().collection('samwise-group-pending-invites');
 }

--- a/common/types/firestore-types.ts
+++ b/common/types/firestore-types.ts
@@ -68,6 +68,10 @@ export type FirestorePendingGroupInvite = {
   readonly invitee: string; // Email of person receiving invitation
 };
 
+export type FirestoreUserData = {
+  readonly name: string;
+};
+
 // all these tasks stay in 'samwise-tasks'
 // FirestoreLegacyTask should eventually be converted to FirestoreOneTimeTask.
 export type FirestoreTask = FirestoreMasterTask | FirestoreOneTimeTask | FirestoreGroupTask;

--- a/common/types/firestore-types.ts
+++ b/common/types/firestore-types.ts
@@ -70,6 +70,7 @@ export type FirestorePendingGroupInvite = {
 
 export type FirestoreUserData = {
   readonly name: string;
+  readonly photoURL: string;
 };
 
 // all these tasks stay in 'samwise-tasks'

--- a/frontend/src/components/Util/AppInit/LoginBarrier.tsx
+++ b/frontend/src/components/Util/AppInit/LoginBarrier.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import firebase from 'firebase/app';
 import StyledFirebaseAuth from 'react-firebaseui/StyledFirebaseAuth';
+import { addUserInfo } from 'firebase/actions';
 import { setGAUser } from '../../../util/ga-util';
 import styles from './Login.module.scss';
 import { cacheAppUser, toAppUser } from '../../../firebase/auth-util';
@@ -60,8 +61,9 @@ export default function LoginBarrier({ appRenderer }: Props): ReactElement {
           setLoaded(false);
           return;
         }
-        const { email } = currentUserFromFirebase;
+        const { email, displayName } = currentUserFromFirebase;
         if (email.endsWith('@cornell.edu')) {
+          addUserInfo(email, displayName);
           setGAUser(currentUserFromFirebase);
           cacheAppUser(currentUserFromFirebase);
           setLoginStatus(true);

--- a/frontend/src/components/Util/AppInit/LoginBarrier.tsx
+++ b/frontend/src/components/Util/AppInit/LoginBarrier.tsx
@@ -61,9 +61,9 @@ export default function LoginBarrier({ appRenderer }: Props): ReactElement {
           setLoaded(false);
           return;
         }
-        const { email, displayName } = currentUserFromFirebase;
+        const { email, displayName, photoURL } = currentUserFromFirebase;
         if (email.endsWith('@cornell.edu')) {
-          addUserInfo(email, displayName);
+          addUserInfo(email, displayName, photoURL);
           setGAUser(currentUserFromFirebase);
           cacheAppUser(currentUserFromFirebase);
           setLoginStatus(true);

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -19,6 +19,7 @@ import {
   FirestoreSubTask,
   FirestoreGroup,
   FirestorePendingGroupInvite,
+  FirestoreUserData,
 } from 'common/types/firestore-types';
 import { WriteBatch } from 'common/firebase/database';
 import Actions from 'common/firebase/common-actions';
@@ -475,6 +476,17 @@ export const sendInvite = async (
   await database.pendingInvitesCollection().add(newInvitation);
 };
 
+export const addUserInfo = async (email: string, fullName: string): Promise<void> => {
+  const userInfo: FirestoreUserData = {
+    name: fullName,
+  };
+  const userDoc = await database.usersCollection().doc(email);
+  const snapshot = await userDoc.get();
+  // since user info is only a name, we don't update if the user's current info already exists
+  if (!snapshot.exists) {
+    await userDoc.set(userInfo);
+  }
+};
 /*
  * --------------------------------------------------------------------------------
  * Section 4: Other Compound Actions

--- a/frontend/src/firebase/auth-util.test.ts
+++ b/frontend/src/firebase/auth-util.test.ts
@@ -1,7 +1,7 @@
 import { cacheAppUser, getAppUser } from './auth-util';
 
 it('Can cache and get app user', () => {
-  const appUser = { uid: '', displayName: '', email: '', token: '' };
+  const appUser = { uid: '', displayName: '', email: '', token: '', photoURL: '' };
   cacheAppUser(appUser);
   expect(getAppUser()).toBe(appUser);
 });

--- a/frontend/src/firebase/auth-util.ts
+++ b/frontend/src/firebase/auth-util.ts
@@ -7,6 +7,7 @@ export type AppUser = {
   readonly displayName: string;
   readonly email: string;
   readonly token: string;
+  readonly photoURL: string | null;
 };
 
 /**
@@ -19,12 +20,12 @@ export async function toAppUser(firebaseUser: firebase.User | null): Promise<App
   if (firebaseUser == null) {
     return null;
   }
-  const { uid, displayName, email } = firebaseUser;
+  const { uid, displayName, email, photoURL } = firebaseUser;
   if (typeof displayName !== 'string' || typeof email !== 'string') {
     throw new Error('Bad user!');
   }
   const token: string = await firebaseUser.getIdToken(true);
-  return { uid, displayName, email, token };
+  return { uid, displayName, email, token, photoURL };
 }
 
 let appUser: AppUser | null = null;


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request allows for population of the `samwise-users` collection in the Firestore. Every time a user logs in, the `useEffect` hook in `LoginBarrier` calls a newly created Firebase action that adds a new document to `samwise-users` with `name` and `photoURL` fields (this can be scaled to include more fields in the future, should we want to store more about a user). This will allow for searching names along with corresponding profile photos of group members associated with emails in Group View.

If the user's name is already stored in `samwise-users`, we don't make any change to the name, but update the profile photo.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
![dqv4hpR](https://user-images.githubusercontent.com/7517829/93548351-07f06780-f935-11ea-9bea-d39d2aee0c9c.gif)

