### PR TITLE
Update course info check frequency

### DIFF
--- a/.github/workflows/e2e-course-info.yml
+++ b/.github/workflows/e2e-course-info.yml
@@ -1,6 +1,6 @@
 on:
   schedule:
-    - cron: '0 15 * * 6'
+    - cron: '0 19 * * 6'
   pull_request:
     paths:
       - .github/workflows/e2e-course-info.yml

--- a/.github/workflows/e2e-course-info.yml
+++ b/.github/workflows/e2e-course-info.yml
@@ -1,9 +1,6 @@
 on:
   schedule:
-    - cron: '0 0 * * 1/2'
-  push:
-    branches:
-      - master
+    - cron: '0 15 * * 6'
   pull_request:
     paths:
       - .github/workflows/e2e-course-info.yml


### PR DESCRIPTION
### Summary <!-- Required -->

This PR reduces the course info check frequency as suggested in #533. We no longer run course info check on push to master and instead run it every week before/at our meeting (Saturdays 3pm). 

### Test Plan <!-- Required -->

👀 Action should no longer be triggered on push to master but it should run on Saturday 3pm EDT/19:00 UTC (if I got the cron syntax right).

![image](https://user-images.githubusercontent.com/20008134/93552756-599def80-f93f-11ea-9399-a292f15a7fbc.png)

