### PR TITLE
Eliminate all absolute imports

### DIFF
--- a/frontend/src/ViewSwitcher.tsx
+++ b/frontend/src/ViewSwitcher.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import SideBar from 'components/SideBar';
-import PersonalView from 'PersonalView';
-import GroupView from 'components/GroupView';
+import SideBar from './components/SideBar';
+import PersonalView from './PersonalView';
+import GroupView from './components/GroupView';
 import styles from './App.module.scss';
 
 type Views = 'personal' | 'group';

--- a/frontend/src/components/GroupView/MiddleBar/People/Member.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/People/Member.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
-import SamwiseIcon from 'components/UI/SamwiseIcon';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import SamwiseIcon from '../../../UI/SamwiseIcon';
 import styles from './Member.module.scss';
 
 type Props = {

--- a/frontend/src/components/GroupView/MiddleBar/People/index.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/People/index.tsx
@@ -1,8 +1,8 @@
 import React, { ReactElement } from 'react';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import SamwiseIcon from 'components/UI/SamwiseIcon';
-import { promptConfirm, promptTextInput } from 'components/Util/Modals';
+import SamwiseIcon from '../../../UI/SamwiseIcon';
+import { promptConfirm, promptTextInput } from '../../../Util/Modals';
 import Member from './Member';
 import styles from './index.module.scss';
 

--- a/frontend/src/components/SideBar/AddGroupTags.tsx
+++ b/frontend/src/components/SideBar/AddGroupTags.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { store } from 'store/store';
 import { Tag } from 'common/types/store-types';
+import { store } from '../../store/store';
 import styles from './AddGroupTags.module.scss';
 
 type AddGroupTagsProps = {

--- a/frontend/src/components/SideBar/index.tsx
+++ b/frontend/src/components/SideBar/index.tsx
@@ -1,8 +1,8 @@
 import React, { ReactElement, useState } from 'react';
-import SamwiseIcon from 'components/UI/SamwiseIcon';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import SettingsButton from 'components/TitleBar/Settings/SettingsButton';
+import SamwiseIcon from '../UI/SamwiseIcon';
+import SettingsButton from '../TitleBar/Settings/SettingsButton';
 import GroupIcon from './GroupIcon';
 import styles from './index.module.scss';
 import AddGroupTags from './AddGroupTags';

--- a/frontend/src/components/TaskView/FutureView/FutureViewControl.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewControl.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
-import { useTodayLastSecondTime } from 'hooks/time-hook';
 import { date2YearMonth } from 'common/util/datetime-util';
+import { useTodayLastSecondTime } from '../../../hooks/time-hook';
 import { FutureViewContainerType, FutureViewDisplayOption } from './future-view-types';
 import SquareTextButton from '../../UI/SquareTextButton';
 import SquareIconToggle from '../../UI/SquareIconToggle';

--- a/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
@@ -1,17 +1,17 @@
 import React, { KeyboardEvent, ReactElement, SyntheticEvent, ReactNode } from 'react';
 import { connect } from 'react-redux';
-import FloatingTaskEditor from 'components/Util/TaskEditors/FloatingTaskEditor';
-import { Settings, State, SubTask, Task } from 'common/types/store-types';
-import CheckBox from 'components/UI/CheckBox';
-import { FloatingPosition, CalendarPosition } from 'components/Util/TaskEditors/editors-types';
-import { getTodayAtZeroAM, getDateWithDateString } from 'common/util/datetime-util';
-import OverdueAlert from 'components/UI/OverdueAlert';
-import { editMainTask } from 'firebase/actions';
-import { useMappedWindowSize } from 'hooks/window-size-hook';
-import { NONE_TAG } from 'common/util/tag-util';
-import SamwiseIcon from 'components/UI/SamwiseIcon';
-import { removeTaskWithPotentialPrompt } from 'util/task-util';
 import { Draggable } from 'react-beautiful-dnd';
+import { Settings, State, SubTask, Task } from 'common/types/store-types';
+import { getTodayAtZeroAM, getDateWithDateString } from 'common/util/datetime-util';
+import { NONE_TAG } from 'common/util/tag-util';
+import FloatingTaskEditor from '../../Util/TaskEditors/FloatingTaskEditor';
+import CheckBox from '../../UI/CheckBox';
+import { FloatingPosition, CalendarPosition } from '../../Util/TaskEditors/editors-types';
+import OverdueAlert from '../../UI/OverdueAlert';
+import { editMainTask } from '../../../firebase/actions';
+import { useMappedWindowSize } from '../../../hooks/window-size-hook';
+import SamwiseIcon from '../../UI/SamwiseIcon';
+import { removeTaskWithPotentialPrompt } from '../../../util/task-util';
 import FutureViewSubTask from './FutureViewSubTask';
 import styles from './FutureViewTask.module.scss';
 

--- a/frontend/src/components/TaskView/FutureView/index.tsx
+++ b/frontend/src/components/TaskView/FutureView/index.tsx
@@ -1,9 +1,9 @@
 import React, { ReactElement } from 'react';
-import { useTodayLastSecondTime } from 'hooks/time-hook';
 import { DragDropContext, DropResult } from 'react-beautiful-dnd';
 import { computeReorderMap } from 'common/util/order-util';
 import { dateMatchRepeats } from 'common/util/task-util';
 import { Task, RepeatingTaskMetadata, OneTimeTaskMetadata } from 'common/types/store-types';
+import { useTodayLastSecondTime } from '../../../hooks/time-hook';
 import FutureViewControl from './FutureViewControl';
 import FutureViewNDays from './FutureViewNDays';
 import FutureViewSevenColumns from './FutureViewSevenColumns';

--- a/frontend/src/components/TitleBar/index.tsx
+++ b/frontend/src/components/TitleBar/index.tsx
@@ -1,8 +1,8 @@
 import React, { ReactElement } from 'react';
 import { connect } from 'react-redux';
-import { useTime } from 'hooks/time-hook';
 import { date2FullDateString } from 'common/util/datetime-util';
 import { State, Theme } from 'common/types/store-types';
+import { useTime } from '../../hooks/time-hook';
 import Banner from './Banner';
 import GroupInvites from './GroupInvites';
 import styles from './index.module.scss';

--- a/frontend/src/components/Util/AppInit/LoginBarrier.tsx
+++ b/frontend/src/components/Util/AppInit/LoginBarrier.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import firebase from 'firebase/app';
 import StyledFirebaseAuth from 'react-firebaseui/StyledFirebaseAuth';
-import { addUserInfo } from 'firebase/actions';
+import { addUserInfo } from '../../../firebase/actions';
 import { setGAUser } from '../../../util/ga-util';
 import styles from './Login.module.scss';
 import { cacheAppUser, toAppUser } from '../../../firebase/auth-util';

--- a/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable no-param-reassign */
 import React, { ReactElement, ReactNode } from 'react';
 import { getDateWithDateString } from 'common/util/datetime-util';
-import { removeTaskWithPotentialPrompt } from 'util/task-util';
 import { Task } from 'common/types/store-types';
-import { useWindowSizeCallback, WindowSize } from 'hooks/window-size-hook';
+import { removeTaskWithPotentialPrompt } from '../../../util/task-util';
+import { useWindowSizeCallback, WindowSize } from '../../../hooks/window-size-hook';
 import { CalendarPosition, FloatingPosition } from './editors-types';
 import TaskEditor from './TaskEditor';
 import styles from './FloatingTaskEditor.module.scss';

--- a/frontend/src/components/Util/TaskEditors/InlineTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/InlineTaskEditor.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useState } from 'react';
-import { removeTaskWithPotentialPrompt } from 'util/task-util';
 import { Task } from 'common/types/store-types';
+import { removeTaskWithPotentialPrompt } from '../../../util/task-util';
 import TaskEditor from './TaskEditor';
 import { CalendarPosition } from './editors-types';
 

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -6,12 +6,15 @@
 import React, { ReactElement, useEffect, useState, useCallback } from 'react';
 import { connect } from 'react-redux';
 import { MainTask, Settings, State, SubTask, Tag } from 'common/types/store-types';
-import OverdueAlert from 'components/UI/OverdueAlert';
 import { NONE_TAG } from 'common/util/tag-util';
 import { ignore } from 'common/util/general-util';
-import { confirmRepeatedTaskEditMaster, promptRepeatedTaskEditChoice } from 'util/task-util';
-import { editTaskWithDiff, forkTaskWithDiff } from 'firebase/actions';
 import { getTodayAtZeroAM, getDateWithDateString } from 'common/util/datetime-util';
+import OverdueAlert from '../../../UI/OverdueAlert';
+import {
+  confirmRepeatedTaskEditMaster,
+  promptRepeatedTaskEditChoice,
+} from '../../../../util/task-util';
+import { editTaskWithDiff, forkTaskWithDiff } from '../../../../firebase/actions';
 import styles from './index.module.scss';
 import RepeatFrequencyHeader from './RepeatFrequencyHeader';
 import EditorHeader from './EditorHeader';

--- a/frontend/src/util/ga-util.ts
+++ b/frontend/src/util/ga-util.ts
@@ -1,6 +1,6 @@
 import firebase from 'firebase/app';
 import 'firebase/analytics';
-import { AppUser } from 'firebase/auth-util';
+import { AppUser } from '../firebase/auth-util';
 
 export const initialize = (): void => {
   firebase.analytics().logEvent('screen-view', { screenName: 'Homepage' });

--- a/frontend/src/util/task-util.ts
+++ b/frontend/src/util/task-util.ts
@@ -1,7 +1,7 @@
-import { promptChoice, promptConfirm } from 'components/Util/Modals';
 import { Task, OneTimeTaskMetadata, RepeatingTaskMetadata } from 'common/types/store-types';
-import { removeTask, removeOneRepeatedTask } from 'firebase/actions';
-import { store } from 'store/store';
+import { promptChoice, promptConfirm } from '../components/Util/Modals';
+import { removeTask, removeOneRepeatedTask } from '../firebase/actions';
+import { store } from '../store/store';
 
 /**
  * This is the utility module for array of tasks and subtasks.

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -7,7 +7,6 @@
       "esnext"
     ],
     "allowJs": true,
-    "baseUrl": "./src",
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
### Summary <!-- Required -->

Absolute imports can be very confusing because the starting folder sometimes shares the same with the library we are using. e.g. We have a top-level folder `firebase` in src and also `firebase` as a dependency. When we import `firebase/xyz`, it's not immediately clear whether we are importing `firebase` from a local util or from `firebase` in node_modules.

This diff removes the `baseUrl` in tsconfig.json, and use that as a guide to remove all remaining absolute imports.

### Test Plan <!-- Required -->

Preview site loads, CI tests pass.
