### PR TITLE
Create .stylelintignore

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,8 @@
+build/
+coverage/
+node_modules/
+dist/
+out/
+.next/
+compiled/
+common/lib


### PR DESCRIPTION
### Summary <!-- Required -->

Create `.stylelintignore` to match `.eslintignore` and `.prettierignore`. Otherwise `yarn lint` will emit a lot of errors locally because stylelint tries to lint on css in `dist` folder .

### Test Plan <!-- Required -->

👀 