### PR TITLE
Allow cornell.edu check to be by passed during dev

### DIFF
--- a/frontend/src/components/Util/AppInit/LoginBarrier.tsx
+++ b/frontend/src/components/Util/AppInit/LoginBarrier.tsx
@@ -22,6 +22,7 @@ import {
   logoHeart,
   logoLink,
 } from '../../../assets/assets-constants';
+import mode from '../../../util/mode-util';
 
 const uiConfig = {
   signInFlow: 'popup',
@@ -62,7 +63,9 @@ export default function LoginBarrier({ appRenderer }: Props): ReactElement {
           return;
         }
         const { email, displayName, photoURL } = currentUserFromFirebase;
-        if (email.endsWith('@cornell.edu')) {
+        // By pass @cornell.edu check locally to allow ourselves
+        // to test inter-user interactions using two google accounts.
+        if (mode === 'DEV' || email.endsWith('@cornell.edu')) {
           addUserInfo(email, displayName, photoURL);
           setGAUser(currentUserFromFirebase);
           cacheAppUser(currentUserFromFirebase);


### PR DESCRIPTION
### Summary

Group task requires us to test interactions between users. Therefore, it's better to have two accounts using samwise at the same time. Right now we have a client only check on cornell.edu account. Since you usually don't have two cornell emails, it adds friction to testing since you need to manually enter data in the db to mock another user.

Let's remove the check for dev to unblock play-testing group tasks.

### Test Plan

:eyes: