### PR TITLE
Auto update username when the user record already exists

### DIFF
--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -487,6 +487,7 @@ export const addUserInfo = async (
 
     if (snapshot.exists) {
       const userInfoPartial: Partial<FirestoreUserData> = {
+        name: fullName,
         photoURL: photoURL || 'Default Photo',
       };
       transaction.update(userDoc, userInfoPartial);


### PR DESCRIPTION
### Summary

Looks like a bug when we only update photo but not username. @ptwu 

### Test Plan

Edit your name in firestore manually in db. Refresh the page, and check firestore record updates to your google username again.