### PR TITLE
Render GroupView and SideBar using groups from firestore

### DIFF
--- a/common/types/firestore-types.ts
+++ b/common/types/firestore-types.ts
@@ -57,9 +57,9 @@ export type FirestoreGroupTask = FirestoreCommonTask & {
 
 export type FirestoreGroup = {
   readonly name: string;
-  readonly members: string[];
+  readonly members: readonly string[];
   readonly deadline: Date;
-  readonly classCode?: string;
+  readonly classCode: string;
 };
 
 export type FirestorePendingGroupInvite = {

--- a/common/types/store-types.ts
+++ b/common/types/store-types.ts
@@ -110,7 +110,7 @@ export type Group = {
   readonly name: string;
   readonly members: readonly string[];
   readonly deadline: Date;
-  readonly classCode?: string;
+  readonly classCode: string;
 };
 
 /**

--- a/frontend/src/ViewSwitcher.tsx
+++ b/frontend/src/ViewSwitcher.tsx
@@ -1,30 +1,26 @@
 import React, { useState } from 'react';
+import type { Group, State } from 'common/types/store-types';
+import { useSelector } from 'react-redux';
 import SideBar from './components/SideBar';
 import PersonalView from './PersonalView';
 import GroupView from './components/GroupView';
 import styles from './App.module.scss';
 
-type Views = 'personal' | 'group';
-
 /** Handles switching the view from Personal to Group */
 const ViewSwitcher = (): React.ReactElement => {
-  const groups = ['CS 2110', 'CS 3110', 'INFO 3450'];
+  const groups = useSelector((state: State) => Array.from(state.groups.values()));
 
-  const [view, setView] = useState<Views>('personal');
-  const [group, setGroup] = useState('');
+  const [group, setGroup] = useState<Group | undefined>();
 
-  const changeView = (selectedView: Views, selectedGroup?: string | undefined): void => {
-    setView(selectedView);
-    if (selectedGroup !== undefined) {
-      setGroup(selectedGroup);
-    }
+  const changeView = (selectedGroupID?: string | undefined): void => {
+    setGroup(groups.find((oneGroup) => oneGroup.id === selectedGroupID));
   };
 
   return (
     <div className={styles.GroupScreen}>
       <SideBar groups={groups} changeView={changeView} />
       <div className={styles.GroupScreenContent}>
-        {view === 'personal' ? <PersonalView /> : <GroupView groupName={group} />}
+        {group === undefined ? <PersonalView /> : <GroupView group={group} />}
       </div>
     </div>
   );

--- a/frontend/src/components/GroupView/RightView/index.tsx
+++ b/frontend/src/components/GroupView/RightView/index.tsx
@@ -1,11 +1,12 @@
 import React, { ReactElement } from 'react';
+import type { Group } from 'common/types/store-types';
 import SamwiseIcon from '../../UI/SamwiseIcon';
 import GroupTaskRow from './GroupTaskRow';
 import styles from './index.module.scss';
 import TaskCreator from '../../TaskCreator';
 
 type Props = {
-  groupName: string;
+  readonly group: Group;
   groupMemberNames: string[];
 };
 
@@ -16,15 +17,15 @@ const EditGroupNameIcon = (): ReactElement => {
   return <SamwiseIcon iconName="pencil" className={styles.EditGroupNameIcon} onClick={handler} />;
 };
 
-const RightView = ({ groupName, groupMemberNames }: Props): ReactElement => (
+const RightView = ({ group, groupMemberNames }: Props): ReactElement => (
   <div className={styles.RightView}>
     <div className={styles.GroupTaskCreator}>
-      <TaskCreator view="group" group={groupName} />
+      <TaskCreator view="group" group={group.name} />
     </div>
 
     <div className={styles.RightView}>
       <div>
-        <h2>{groupName}</h2>
+        <h2>{group.name}</h2>
         <EditGroupNameIcon />
       </div>
       <div className={styles.GroupTaskRowContainer}>

--- a/frontend/src/components/GroupView/index.tsx
+++ b/frontend/src/components/GroupView/index.tsx
@@ -1,18 +1,18 @@
 import React, { ReactElement } from 'react';
+import type { Group } from 'common/types/store-types';
 import MiddleBar from './MiddleBar';
 import RightView from './RightView';
 import styles from './index.module.scss';
 
-type Props = {
-  groupName: string;
-};
+type Props = { readonly group: Group };
 
+// TODO: fetch members' name and profile picture from samwise-user collection.
 const members = ['Darien Lopez', 'Sarah Johnson', 'Michelle Parker', 'Samwise Bear'];
 
-const GroupView = ({ groupName }: Props): ReactElement => (
+const GroupView = ({ group }: Props): ReactElement => (
   <div className={styles.GroupView}>
     <MiddleBar groupMemberNames={members} />
-    <RightView groupName={groupName} groupMemberNames={members} />
+    <RightView group={group} groupMemberNames={members} />
   </div>
 );
 

--- a/frontend/src/components/SideBar/index.tsx
+++ b/frontend/src/components/SideBar/index.tsx
@@ -1,44 +1,41 @@
 import React, { ReactElement, useState } from 'react';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import type { Group } from 'common/types/store-types';
 import SamwiseIcon from '../UI/SamwiseIcon';
 import SettingsButton from '../TitleBar/Settings/SettingsButton';
 import GroupIcon from './GroupIcon';
 import styles from './index.module.scss';
 import AddGroupTags from './AddGroupTags';
-import { Views } from './types';
 
 type Props = {
-  groups: string[];
-  changeView: (selectedView: Views, selectedGroup: string | undefined) => void;
+  readonly groups: readonly Group[];
+  /** When selectedGroup is undefined, it means that we selected personal view */
+  readonly changeView: (selectedGroup: string | undefined) => void;
 };
 
 const SideBar = ({ groups, changeView }: Props): ReactElement => {
   const [showDropdown, setShowDropdown] = useState(false);
   const [selected, setSelected] = useState('personal');
 
-  const handleIconClick = (view: Views, group?: string): void => {
-    changeView(view, group);
-    setSelected(group !== undefined ? group : view);
+  const handleIconClick = (groupID?: string): void => {
+    setSelected(groupID ?? 'personal');
+    changeView(groupID);
   };
 
   return (
     <div className={styles.SideBar}>
-      <button
-        type="button"
-        onClick={() => handleIconClick('personal')}
-        className={styles.PersonalViewButton}
-      >
+      <button type="button" onClick={() => handleIconClick()} className={styles.PersonalViewButton}>
         <SamwiseIcon iconName="personal-view" className={styles.PersonalViewButtonIcon} />
       </button>
       <div className={styles.GroupIcons}>
         <p>My Groups</p>
         {groups.map((g) => (
           <GroupIcon
-            classCode={g}
-            handleClick={() => handleIconClick('group', g)}
-            selected={selected === g}
-            key={g}
+            key={g.id}
+            classCode={g.classCode}
+            handleClick={() => handleIconClick(g.id)}
+            selected={selected === g.id}
           />
         ))}
         <span>


### PR DESCRIPTION
### Summary <!-- Required -->

We already have redux store connected to the firestore collection. Let's read from redux store to replace hardcoded data.

### Test Plan <!-- Required -->

It is correctly rendering my test group with these info:
<img width="581" alt="Screen Shot 2020-09-26 at 16 49 35" src="https://user-images.githubusercontent.com/4290500/94350042-50d0ac00-0018-11eb-982e-c58681ec3d99.png">

<img width="1680" alt="Screen Shot 2020-09-26 at 16 49 18" src="https://user-images.githubusercontent.com/4290500/94350041-50381580-0018-11eb-8b41-36e2ee921da0.png">

