### PR TITLE
Render a list of user profiles in the group from firestore

### DIFF
--- a/common/types/store-types.ts
+++ b/common/types/store-types.ts
@@ -104,13 +104,19 @@ export type BannerMessageStatus = {
 /**
  * The type of a group entry.
  */
-
 export type Group = {
   readonly id: string;
   readonly name: string;
   readonly members: readonly string[];
   readonly deadline: Date;
   readonly classCode: string;
+};
+
+/** The user profile of any samwise user. */
+export type SamwiseUserProfile = {
+  readonly email: string;
+  readonly name: string;
+  readonly photoURL: string;
 };
 
 /**

--- a/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarPeopleList.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarPeopleList.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import type { SamwiseUserProfile } from 'common/types/store-types';
 import SamwiseIcon from '../../UI/SamwiseIcon';
 import { promptConfirm, promptTextInput } from '../../Util/Modals';
 import GroupViewMiddleBarMemberRow from './GroupViewMiddleBarMemberRow';
@@ -26,16 +27,14 @@ const promptAddMember = (): void => {
   });
 };
 
-type Props = {
-  groupMemberNames: string[];
-};
+type Props = { readonly groupMemberProfiles: readonly SamwiseUserProfile[] };
 
-const People = ({ groupMemberNames }: Props): ReactElement => (
+const People = ({ groupMemberProfiles }: Props): ReactElement => (
   <div className={styles.People}>
     <h2>People</h2>
     <div className={styles.MemberList}>
-      {groupMemberNames.map((m) => (
-        <GroupViewMiddleBarMemberRow memberName={m} key={m} />
+      {groupMemberProfiles.map((profile) => (
+        <GroupViewMiddleBarMemberRow memberName={profile.name} key={profile.email} />
       ))}
     </div>
     <button

--- a/frontend/src/components/GroupView/MiddleBar/index.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/index.tsx
@@ -1,16 +1,16 @@
 import React, { ReactElement } from 'react';
+import { SamwiseUserProfile } from 'common/types/store-types';
+
 import GroupViewMiddleBarPeopleList from './GroupViewMiddleBarPeopleList';
 import GroupViewMiddleBarTaskQueue from './GroupViewMiddleBarTaskQueue';
 import styles from './index.module.scss';
 
-type Props = {
-  groupMemberNames: string[];
-};
+type Props = { readonly groupMemberProfiles: readonly SamwiseUserProfile[] };
 
-const GroupViewMiddleBar = ({ groupMemberNames }: Props): ReactElement => (
+const GroupViewMiddleBar = ({ groupMemberProfiles }: Props): ReactElement => (
   <div className={styles.MiddleBar}>
     <GroupViewMiddleBarTaskQueue />
-    <GroupViewMiddleBarPeopleList groupMemberNames={groupMemberNames} />
+    <GroupViewMiddleBarPeopleList groupMemberProfiles={groupMemberProfiles} />
   </div>
 );
 

--- a/frontend/src/components/GroupView/RightView/index.tsx
+++ b/frontend/src/components/GroupView/RightView/index.tsx
@@ -1,14 +1,11 @@
 import React, { ReactElement } from 'react';
-import type { Group } from 'common/types/store-types';
+import type { Group, SamwiseUserProfile } from 'common/types/store-types';
 import SamwiseIcon from '../../UI/SamwiseIcon';
 import GroupTaskRow from './GroupTaskRow';
 import styles from './index.module.scss';
 import TaskCreator from '../../TaskCreator';
 
-type Props = {
-  readonly group: Group;
-  groupMemberNames: string[];
-};
+type Props = { readonly group: Group; readonly groupMemberProfiles: readonly SamwiseUserProfile[] };
 
 const EditGroupNameIcon = (): ReactElement => {
   const handler = (): void => {
@@ -17,7 +14,7 @@ const EditGroupNameIcon = (): ReactElement => {
   return <SamwiseIcon iconName="pencil" className={styles.EditGroupNameIcon} onClick={handler} />;
 };
 
-const RightView = ({ group, groupMemberNames }: Props): ReactElement => (
+const RightView = ({ group, groupMemberProfiles }: Props): ReactElement => (
   <div className={styles.RightView}>
     <div className={styles.GroupTaskCreator}>
       <TaskCreator view="group" group={group.name} />
@@ -29,8 +26,8 @@ const RightView = ({ group, groupMemberNames }: Props): ReactElement => (
         <EditGroupNameIcon />
       </div>
       <div className={styles.GroupTaskRowContainer}>
-        {groupMemberNames.map((m) => (
-          <GroupTaskRow memberName={m} key={m} />
+        {groupMemberProfiles.map((samwiseUserProfile) => (
+          <GroupTaskRow memberName={samwiseUserProfile.name} key={samwiseUserProfile.email} />
         ))}
       </div>
     </div>

--- a/frontend/src/components/GroupView/index.tsx
+++ b/frontend/src/components/GroupView/index.tsx
@@ -1,19 +1,57 @@
-import React, { ReactElement } from 'react';
-import type { Group } from 'common/types/store-types';
+import React, { ReactElement, useState, useEffect } from 'react';
+import type { Group, SamwiseUserProfile } from 'common/types/store-types';
+import type { FirestoreUserData } from 'common/types/firestore-types';
 import MiddleBar from './MiddleBar';
 import RightView from './RightView';
 import styles from './index.module.scss';
+import { database } from '../../firebase/db';
 
 type Props = { readonly group: Group };
 
-// TODO: fetch members' name and profile picture from samwise-user collection.
-const members = ['Darien Lopez', 'Sarah Johnson', 'Michelle Parker', 'Samwise Bear'];
+const useGroupMemberProfiles = (
+  groupMemberEmails: readonly string[]
+): readonly SamwiseUserProfile[] => {
+  const [emailProfileMapping, setEmailProfileMapping] = useState<Record<string, FirestoreUserData>>(
+    {}
+  );
 
-const GroupView = ({ group }: Props): ReactElement => (
-  <div className={styles.GroupView}>
-    <MiddleBar groupMemberNames={members} />
-    <RightView group={group} groupMemberNames={members} />
-  </div>
-);
+  useEffect(() => {
+    // When we are reaching this line, it either means that we are running the effect for the first
+    // time, or because the group member list has changed, so we have to invalidate the cache.
+    setEmailProfileMapping({});
+    const unsubscribers = groupMemberEmails.map((groupMemberEmail) =>
+      database
+        .usersCollection()
+        .doc(groupMemberEmail)
+        .onSnapshot((snapshot) => {
+          setEmailProfileMapping((map) => ({
+            ...map,
+            [groupMemberEmail]: snapshot.data() as FirestoreUserData,
+          }));
+        })
+    );
+    return () => unsubscribers.forEach((unsubscriber) => unsubscriber());
+  }, [groupMemberEmails]);
+
+  const profiles = Object.entries(emailProfileMapping).map(([email, namePhoto]) => ({
+    email,
+    ...namePhoto,
+  }));
+  // Only return the profiles when the length of profiles matches length of email list.
+  // There can be a temporarily mismatch when some snapshots have not been resolved yet.
+  // This check ensures that all group members appear together.
+  return profiles.length === groupMemberEmails.length ? profiles : [];
+};
+
+const GroupView = ({ group }: Props): ReactElement => {
+  const groupMemberProfiles = useGroupMemberProfiles(group.members);
+
+  return (
+    <div className={styles.GroupView}>
+      <MiddleBar groupMemberProfiles={groupMemberProfiles} />
+      <RightView group={group} groupMemberProfiles={groupMemberProfiles} />
+    </div>
+  );
+};
 
 export default GroupView;


### PR DESCRIPTION
### Summary <!-- Required -->

This PR changes the member list from a hardcoded names to a list of profiles from firestore. I extract the logic of fetching users into a custom hook since the logic is a bit involved. See the inline comments for its flow.

To allow reading the profile from client side listeners, we do have to loosen the security rules a little bit. I currently loosen the rule to allow read if the user's email ends with @cornell.edu. I think this setup doesn't weaken any security measures. Currently it will only expose name and profile picture, which you can get by typing the email in cornell email composer anyways.

### Test Plan <!-- Required -->

<img width="845" alt="Screen Shot 2020-09-26 at 23 44 22" src="https://user-images.githubusercontent.com/4290500/94355460-3c110a00-0052-11eb-88da-f831219cc3da.png">
