### PR TITLE
Adjust prelim and final URLs and fix parser for FA20

### DIFF
--- a/course-info/run
+++ b/course-info/run
@@ -6,7 +6,7 @@ set -x # Turn this on to debug
 ### - JDK 11+
 ### - Node.js 10+
 
-# Outcome: produce a JSON file sp20-courses.json with all the courses in SP20.
+# Outcome: produce a JSON file fa20-courses.json with all the courses in FA20.
 function createCourseInfoJson() {
     git clone https://github.com/cornell-dti/cornell-api-libs.git
     cd cornell-api-libs

--- a/course-info/src/fetch-exam.ts
+++ b/course-info/src/fetch-exam.ts
@@ -16,7 +16,7 @@ async function fetchExamText(url: string): Promise<string> {
 }
 
 function parsePrelimLine(line: string): ExamInfo {
-  const segments = line.split(' ');
+  const segments = line.split(/\s+/);
   const subject = segments[0];
   const courseNumber = segments[1];
   const dateTimeString = `${segments[3]} ${segments[4]} ${currentYear}`;

--- a/course-info/src/fetch-exam.ts
+++ b/course-info/src/fetch-exam.ts
@@ -20,9 +20,11 @@ function parsePrelimLine(line: string): ExamInfo {
   const subject = segments[0];
   const courseNumber = segments[1];
   const dateTimeString = `${segments[3]} ${segments[4]} ${currentYear}`;
+  const dateHours = parseInt(segments[5].substring(0, 2), 10);
+  const dateMinutes = parseInt(segments[5].substring(3, 5), 10);
   const date = new Date(dateTimeString);
   date.setFullYear(currentYear);
-  date.setHours(19, 30); // 7:30 prelim time
+  date.setHours(segments[6] === 'PM' ? dateHours + 12 : dateHours, dateMinutes);
   return {
     subject,
     courseNumber,

--- a/course-info/src/fetch-exam.ts
+++ b/course-info/src/fetch-exam.ts
@@ -2,8 +2,8 @@ import fetch from 'node-fetch';
 import { JSDOM } from 'jsdom';
 import { ExamInfo } from './types';
 
-const prelimUrl = 'https://registrar.cornell.edu/exams/spring-prelim-schedule';
-const finalUrl = 'https://registrar.cornell.edu/exams/spring-final-exam-schedule';
+const prelimUrl = 'https://registrar.cornell.edu/exams/fall-prelim-exam-schedule';
+const finalUrl = 'https://registrar.cornell.edu/exams/fall-final-exam-schedule';
 
 const currentYear = new Date().getFullYear();
 
@@ -19,15 +19,8 @@ function parsePrelimLine(line: string): ExamInfo {
   const segments = line.split(' ');
   const subject = segments[0];
   const courseNumber = segments[1];
-  let datetimeString = '';
-  for (let i = 2; i < segments.length; i += 1) {
-    const s = segments[i];
-    if (s !== '') {
-      datetimeString = s;
-      break;
-    }
-  }
-  const date = new Date(datetimeString);
+  const dateTimeString = `${segments[3]} ${segments[4]} ${currentYear}`;
+  const date = new Date(dateTimeString);
   date.setFullYear(currentYear);
   date.setHours(19, 30); // 7:30 prelim time
   return {
@@ -69,7 +62,7 @@ function getExamInfoList(rawText: string, isFinal: boolean): readonly ExamInfo[]
   const infoList: ExamInfo[] = [];
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i].trim();
-    if (line !== '' && !line.startsWith('Class') && !line.startsWith('final exam')) {
+    if (line !== '' && !line.startsWith('Course') && !line.startsWith('final exam')) {
       const info = isFinal ? parseFinalLine(line) : parsePrelimLine(line);
       infoList.push(info);
     }

--- a/course-info/src/merge-json.ts
+++ b/course-info/src/merge-json.ts
@@ -61,9 +61,9 @@ function processExamInfoJson(
 async function main(): Promise<void> {
   const map = new Map<string, Course>();
   processCourseInfoJson(map, JSON.parse(readFileSync('fa20-courses.json', 'utf8')));
-  // TODO: re-enable them when Cornell published exams (no idea when it will happen)
+  // TODO: re-enable them when Cornell publishes finals (no idea when it will happen)
   // processExamInfoJson(map, await createFinalJson(), 'final');
-  // processExamInfoJson(map, await createPrelimJson(), 'prelim');
+  processExamInfoJson(map, await createPrelimJson(), 'prelim');
   const result = Array.from(map.values()).map((course) => course.plainJs);
   writeFileSync('fa20-courses-with-exams-min.json', JSON.stringify(result));
 }


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request uncomments the prelim parsing code, as the prelim schedule has been posted on the registrar [here
](https://registrar.cornell.edu/exams/fall-prelim-exam-schedule). The format of the exam listings has also changed, and the HTML parser has been updated accordingly as explained below.

We can't add finals, as the registrar doesn't have this data yet.

- [x] fixes #510  (at least partially since we're uncertain if the registrar will provide finals data at all) 

While the spring prelim schedule from SP20 is no longer accessible, I used archive.org to find a cached version of the page. Previously, dates were in the format `MM/DD/YYYY` for each class, but now they are in the format `DAY_OF_WEEK DD MONTH_NAME`. The HTML parser has been updated accordingly to create a Date object that corresponds to the new date format.

SP20
![image](https://user-images.githubusercontent.com/7517829/94773507-e8702a80-0389-11eb-9f7f-d59ffc3cc55b.png)

FA20
![image](https://user-images.githubusercontent.com/7517829/94773520-f02fcf00-0389-11eb-8517-9c2173fcc703.png)


### Test Plan <!-- Required -->

Run the bash script in `/course-info` by running `./run` in the directory. See that no errors occur. You can cross-check the generated `.json` file to see if the `examTimes` field for a certain class object is defined. For example, CS 3110 has a prelim this coming Sunday, and its exam time has been populated.

![image](https://user-images.githubusercontent.com/7517829/94774700-6df4da00-038c-11eb-83d8-9f7ba7cc6d81.png)

