### PR TITLE
Changed FocusPicker, TagPicker, and DatePicker to buttons

### DIFF
--- a/frontend/src/components/TaskCreator/DatePicker.tsx
+++ b/frontend/src/components/TaskCreator/DatePicker.tsx
@@ -133,7 +133,6 @@ export default function DatePicker(props: Props): ReactElement {
     );
     return (
       <button
-        // role="presentation"
         onClick={clickPicker}
         onKeyPress={pressedPicker}
         className={`${styles.DateButton} ${styles.Label}`}

--- a/frontend/src/components/TaskCreator/DatePicker.tsx
+++ b/frontend/src/components/TaskCreator/DatePicker.tsx
@@ -132,15 +132,16 @@ export default function DatePicker(props: Props): ReactElement {
       </>
     );
     return (
-      <span
-        role="presentation"
+      <button
+        // role="presentation"
         onClick={clickPicker}
         onKeyPress={pressedPicker}
-        className={styles.Label}
+        className={`${styles.DateButton} ${styles.Label}`}
         style={style}
+        type="button"
       >
         {internal}
-      </span>
+      </button>
     );
   };
 

--- a/frontend/src/components/TaskCreator/FocusPicker.tsx
+++ b/frontend/src/components/TaskCreator/FocusPicker.tsx
@@ -35,5 +35,3 @@ export default function FocusPicker({ pinned, onPinChange }: Props): ReactElemen
     </div>
   );
 }
-// role="presentation"
-//

--- a/frontend/src/components/TaskCreator/FocusPicker.tsx
+++ b/frontend/src/components/TaskCreator/FocusPicker.tsx
@@ -21,14 +21,19 @@ export default function FocusPicker({ pinned, onPinChange }: Props): ReactElemen
   const pinIconName = pinned ? 'pin-dark-filled' : 'pin-dark-outline';
   return (
     <div className={styles.Main}>
-      <span
-        role="presentation"
+      <button
+        type="button"
         onClick={clickPicker}
         onKeyPress={pressedPicker}
-        className={styles.Label}
+        className={`${styles.TestBorder} ${styles.Label}`}
       >
-        <SamwiseIcon iconName={pinIconName} className={styles.CenterIcon} />
-      </span>
+        <SamwiseIcon
+          iconName={pinIconName}
+          className={`${styles.CenterIcon} ${styles.ImageSize}`}
+        />
+      </button>
     </div>
   );
 }
+// role="presentation"
+//

--- a/frontend/src/components/TaskCreator/Picker.module.scss
+++ b/frontend/src/components/TaskCreator/Picker.module.scss
@@ -1,10 +1,10 @@
 .Main {
   display: inline-flex;
   height: 20px;
-  line-height: 20px !important;
-  text-align: center !important;
+  line-height: 20px;
+  text-align: center;
   position: relative;
-  color: white !important;
+  color: white;
   margin-left: 5px;
   transform: translateY(-30px);
   z-index: 2;
@@ -18,32 +18,30 @@
 }
 
 .TestBorder {
-  border-color: transparent !important;
-  color: transparent !important;
-  background-color: transparent !important;
-  padding: 0px;
+  border-color: transparent;
+  color: transparent;
+  background-color: transparent;
+  padding: 0;
 }
 
 .TagButton {
-  background: rgb(150, 150, 150) !important;
-  border-color: transparent !important;
-  color: #ffffff !important;
-  // padding: 0px 2px 0px 10px !important;
-  font: 14px 'Open Sans', sans-serif !important;
-  width: 96.84px !important;
-  height: 20px !important;
-  padding: 0px !important;
+  background: rgb(150, 150, 150);
+  border-color: transparent;
+  color: #fff;
+  font: 14px 'Open Sans', sans-serif;
+  width: 96.84px;
+  height: 20px;
+  padding: 0;
 }
 
 .DateButton {
-  background: rgb(150, 150, 150) !important;
-  border-color: transparent !important;
-  color: #ffffff !important;
-  // padding: 0px 2px 0px 10px !important;
-  font: 14px 'Open Sans', sans-serif !important;
-  width: 94.03px !important;
-  height: 20px !important;
-  padding: 0px !important;
+  background: rgb(150, 150, 150);
+  border-color: transparent;
+  color: #fff;
+  font: 14px 'Open Sans', sans-serif;
+  width: 94.03px;
+  height: 20px;
+  padding: 0;
 }
 
 .Label {
@@ -58,12 +56,11 @@
 .DateDisplay {
   display: inline-flex;
   align-items: center;
-  //padding: 0 5px 0 10px;
   height: 15px;
 }
 
 .TagDisplay {
-  padding: 0 2px 0px 10px !important;
+  padding: 0 2px 0 10px !important;
   height: 15px;
   text-overflow: ellipsis !important;
   overflow: hidden !important;

--- a/frontend/src/components/TaskCreator/Picker.module.scss
+++ b/frontend/src/components/TaskCreator/Picker.module.scss
@@ -1,10 +1,10 @@
 .Main {
   display: inline-flex;
   height: 20px;
-  line-height: 20px;
-  text-align: center;
+  line-height: 20px !important;
+  text-align: center !important;
   position: relative;
-  color: white;
+  color: white !important;
   margin-left: 5px;
   transform: translateY(-30px);
   z-index: 2;
@@ -15,6 +15,35 @@
 .Main > span > span {
   display: inline-flex;
   align-items: center;
+}
+
+.TestBorder {
+  border-color: transparent !important;
+  color: transparent !important;
+  background-color: transparent !important;
+  padding: 0px;
+}
+
+.TagButton {
+  background: rgb(150, 150, 150) !important;
+  border-color: transparent !important;
+  color: #ffffff !important;
+  // padding: 0px 2px 0px 10px !important;
+  font: 14px 'Open Sans', sans-serif !important;
+  width: 96.84px !important;
+  height: 20px !important;
+  padding: 0px !important;
+}
+
+.DateButton {
+  background: rgb(150, 150, 150) !important;
+  border-color: transparent !important;
+  color: #ffffff !important;
+  // padding: 0px 2px 0px 10px !important;
+  font: 14px 'Open Sans', sans-serif !important;
+  width: 94.03px !important;
+  height: 20px !important;
+  padding: 0px !important;
 }
 
 .Label {
@@ -29,14 +58,16 @@
 .DateDisplay {
   display: inline-flex;
   align-items: center;
-  padding: 0 5px 0 10px;
+  //padding: 0 5px 0 10px;
+  height: 15px;
 }
 
 .TagDisplay {
-  padding: 0 2px 0 10px;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
+  padding: 0 2px 0px 10px !important;
+  height: 15px;
+  text-overflow: ellipsis !important;
+  overflow: hidden !important;
+  white-space: nowrap !important;
 
   /* Any narrower and some long class tags will begin to be truncated. */
   max-width: 110px;
@@ -47,6 +78,11 @@
 .TagDisplay > span,
 .DateDisplay > span {
   display: flex;
+}
+
+.ImageSize {
+  width: 1.15em;
+  height: 1.15em;
 }
 
 .CenterIcon {

--- a/frontend/src/components/TaskCreator/Picker.module.scss
+++ b/frontend/src/components/TaskCreator/Picker.module.scss
@@ -60,11 +60,11 @@
 }
 
 .TagDisplay {
-  padding: 0 2px 0 10px !important;
+  padding: 0 2px 0 10px;
   height: 15px;
-  text-overflow: ellipsis !important;
-  overflow: hidden !important;
-  white-space: nowrap !important;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 
   /* Any narrower and some long class tags will begin to be truncated. */
   max-width: 110px;

--- a/frontend/src/components/TaskCreator/TagPicker.tsx
+++ b/frontend/src/components/TaskCreator/TagPicker.tsx
@@ -48,10 +48,8 @@ function TagPicker({ tag, opened, onTagChange, onPickerOpened, getTag }: Props):
     return (
       <button
         type="button"
-        // role="presentation"
         onClick={clickPicker}
         onKeyPress={pressedPicker}
-        // className={styles.Label}
         className={`${styles.TagButton} ${styles.Label}`}
         style={style}
       >

--- a/frontend/src/components/TaskCreator/TagPicker.tsx
+++ b/frontend/src/components/TaskCreator/TagPicker.tsx
@@ -46,15 +46,17 @@ function TagPicker({ tag, opened, onTagChange, onPickerOpened, getTag }: Props):
       </>
     );
     return (
-      <span
-        role="presentation"
+      <button
+        type="button"
+        // role="presentation"
         onClick={clickPicker}
         onKeyPress={pressedPicker}
-        className={styles.Label}
+        // className={styles.Label}
+        className={`${styles.TagButton} ${styles.Label}`}
         style={style}
       >
         {internal}
-      </span>
+      </button>
     );
   };
   return (

--- a/frontend/src/components/TaskCreator/__snapshots__/FocusPicker.test.tsx.snap
+++ b/frontend/src/components/TaskCreator/__snapshots__/FocusPicker.test.tsx.snap
@@ -4,11 +4,11 @@ exports[`Pinned FocusPicker matches snapshot 1`] = `
 <div
   className="Main"
 >
-  <span
-    className="Label"
+  <button
+    className="TestBorder Label"
     onClick={[Function]}
     onKeyPress={[Function]}
-    role="presentation"
+    type="button"
   >
     <span
       onKeyUp={[Function]}
@@ -18,11 +18,11 @@ exports[`Pinned FocusPicker matches snapshot 1`] = `
     >
       <img
         alt="Unpin from Focus"
-        className="SamwiseIconDefaultStyle CenterIcon"
+        className="SamwiseIconDefaultStyle CenterIcon ImageSize"
         src="/svgs/pin-2-dark-filled.svg"
       />
     </span>
-  </span>
+  </button>
 </div>
 `;
 
@@ -30,11 +30,11 @@ exports[`Unpinned FocusPicker matches snapshot 1`] = `
 <div
   className="Main"
 >
-  <span
-    className="Label"
+  <button
+    className="TestBorder Label"
     onClick={[Function]}
     onKeyPress={[Function]}
-    role="presentation"
+    type="button"
   >
     <span
       onKeyUp={[Function]}
@@ -44,10 +44,10 @@ exports[`Unpinned FocusPicker matches snapshot 1`] = `
     >
       <img
         alt="Pin to Focus"
-        className="SamwiseIconDefaultStyle CenterIcon"
+        className="SamwiseIconDefaultStyle CenterIcon ImageSize"
         src="/svgs/pin-2-dark-outline.svg"
       />
     </span>
-  </span>
+  </button>
 </div>
 `;

--- a/frontend/src/components/TaskCreator/__snapshots__/TagPicker.test.tsx.snap
+++ b/frontend/src/components/TaskCreator/__snapshots__/TagPicker.test.tsx.snap
@@ -4,16 +4,16 @@ exports[`TagPicker(THE_GLORIOUS_NONE_TAG, false) matches snapshot 1`] = `
 <div
   className="Main"
 >
-  <span
-    className="Label"
+  <button
+    className="TagButton Label"
     onClick={[Function]}
     onKeyPress={[Function]}
-    role="presentation"
     style={
       Object {
         "background": "#969696",
       }
     }
+    type="button"
   >
     <span
       className="TagDisplay"
@@ -32,7 +32,7 @@ exports[`TagPicker(THE_GLORIOUS_NONE_TAG, false) matches snapshot 1`] = `
       </span>
        add class  
     </span>
-  </span>
+  </button>
 </div>
 `;
 
@@ -40,16 +40,16 @@ exports[`TagPicker(THE_GLORIOUS_NONE_TAG, true) matches snapshot 1`] = `
 <div
   className="Main"
 >
-  <span
-    className="Label"
+  <button
+    className="TagButton Label"
     onClick={[Function]}
     onKeyPress={[Function]}
-    role="presentation"
     style={
       Object {
         "background": "#969696",
       }
     }
+    type="button"
   >
     <span
       className="TagDisplay"
@@ -68,7 +68,7 @@ exports[`TagPicker(THE_GLORIOUS_NONE_TAG, true) matches snapshot 1`] = `
       </span>
        add class  
     </span>
-  </span>
+  </button>
   <div
     className="NewTaskClassPick"
   >
@@ -136,16 +136,16 @@ exports[`TagPicker(bar, false) matches snapshot 1`] = `
 <div
   className="Main"
 >
-  <span
-    className="Label"
+  <button
+    className="TagButton Label"
     onClick={[Function]}
     onKeyPress={[Function]}
-    role="presentation"
     style={
       Object {
         "background": "blue",
       }
     }
+    type="button"
   >
     <span
       className="TagDisplay"
@@ -159,7 +159,7 @@ exports[`TagPicker(bar, false) matches snapshot 1`] = `
     >
       ×
     </button>
-  </span>
+  </button>
 </div>
 `;
 
@@ -167,16 +167,16 @@ exports[`TagPicker(bar, true) matches snapshot 1`] = `
 <div
   className="Main"
 >
-  <span
-    className="Label"
+  <button
+    className="TagButton Label"
     onClick={[Function]}
     onKeyPress={[Function]}
-    role="presentation"
     style={
       Object {
         "background": "blue",
       }
     }
+    type="button"
   >
     <span
       className="TagDisplay"
@@ -190,7 +190,7 @@ exports[`TagPicker(bar, true) matches snapshot 1`] = `
     >
       ×
     </button>
-  </span>
+  </button>
   <div
     className="NewTaskClassPick"
   >
@@ -258,16 +258,16 @@ exports[`TagPicker(baz, false) matches snapshot 1`] = `
 <div
   className="Main"
 >
-  <span
-    className="Label"
+  <button
+    className="TagButton Label"
     onClick={[Function]}
     onKeyPress={[Function]}
-    role="presentation"
     style={
       Object {
         "background": "green",
       }
     }
+    type="button"
   >
     <span
       className="TagDisplay"
@@ -281,7 +281,7 @@ exports[`TagPicker(baz, false) matches snapshot 1`] = `
     >
       ×
     </button>
-  </span>
+  </button>
 </div>
 `;
 
@@ -289,16 +289,16 @@ exports[`TagPicker(baz, true) matches snapshot 1`] = `
 <div
   className="Main"
 >
-  <span
-    className="Label"
+  <button
+    className="TagButton Label"
     onClick={[Function]}
     onKeyPress={[Function]}
-    role="presentation"
     style={
       Object {
         "background": "green",
       }
     }
+    type="button"
   >
     <span
       className="TagDisplay"
@@ -312,7 +312,7 @@ exports[`TagPicker(baz, true) matches snapshot 1`] = `
     >
       ×
     </button>
-  </span>
+  </button>
   <div
     className="NewTaskClassPick"
   >
@@ -380,16 +380,16 @@ exports[`TagPicker(foo, false) matches snapshot 1`] = `
 <div
   className="Main"
 >
-  <span
-    className="Label"
+  <button
+    className="TagButton Label"
     onClick={[Function]}
     onKeyPress={[Function]}
-    role="presentation"
     style={
       Object {
         "background": "red",
       }
     }
+    type="button"
   >
     <span
       className="TagDisplay"
@@ -403,7 +403,7 @@ exports[`TagPicker(foo, false) matches snapshot 1`] = `
     >
       ×
     </button>
-  </span>
+  </button>
 </div>
 `;
 
@@ -411,16 +411,16 @@ exports[`TagPicker(foo, true) matches snapshot 1`] = `
 <div
   className="Main"
 >
-  <span
-    className="Label"
+  <button
+    className="TagButton Label"
     onClick={[Function]}
     onKeyPress={[Function]}
-    role="presentation"
     style={
       Object {
         "background": "red",
       }
     }
+    type="button"
   >
     <span
       className="TagDisplay"
@@ -434,7 +434,7 @@ exports[`TagPicker(foo, true) matches snapshot 1`] = `
     >
       ×
     </button>
-  </span>
+  </button>
   <div
     className="NewTaskClassPick"
   >


### PR DESCRIPTION
### Summary <!-- Required -->
Changed span tags for all the pickers to button tags. Adjusted the corresponding css to maintain the same design by adding more css classes for each picker. Each picker still performs the same as before, but internally each picker is a button now. 

### Fixes
Mostly changed border-color, color, background-color, and padding to get the focus picker to look like before it was changed to a button - made a new class with these attributes
Changed border-color, color, font, width and height to get the tag and date picker to look like before it was changed to a button- made a new class called "TagButton" and DateButton  to integrate these changes

- [x] changed FocusPicker to button
- [x] changed DatePicker to button
- [x] changed TagPicker to button
- [x] fixes https://github.com/cornell-dti/samwise/issues/491#issue-612272465

### Test Plan <!-- Required -->

Compared the original functionality from before making the changes to after making each picker a button. Original functionality/appearance: 
<img width="673" alt="Screen Shot 2020-10-02 at 11 28 38 PM" src="https://user-images.githubusercontent.com/20613939/94982252-129b2700-0507-11eb-838f-9080b766cba1.png">
<img width="433" alt="Screen Shot 2020-10-02 at 11 28 32 PM" src="https://user-images.githubusercontent.com/20613939/94982257-19299e80-0507-11eb-9f90-c1c9a34c75a9.png">
<img width="438" alt="Screen Shot 2020-10-02 at 11 28 22 PM" src="https://user-images.githubusercontent.com/20613939/94982267-26468d80-0507-11eb-8939-78e9a5f086b6.png">

Functionality/appearance after making changes:
<img width="680" alt="Screen Shot 2020-10-02 at 11 30 58 PM" src="https://user-images.githubusercontent.com/20613939/94982396-1b402d00-0508-11eb-9f9a-3f4bcb5bb857.png">
<img width="420" alt="Screen Shot 2020-10-02 at 11 30 53 PM" src="https://user-images.githubusercontent.com/20613939/94982399-1b402d00-0508-11eb-8bf9-1020850dc9e3.png">
<img width="423" alt="Screen Shot 2020-10-02 at 11 30 46 PM" src="https://user-images.githubusercontent.com/20613939/94982400-1b402d00-0508-11eb-9651-c1285c6a94ce.png">

I compared the appearance/functionality after making the changes to the original version to make sure the designs stayed the same and the pickers performed as expected

