### PR TITLE
Add search bar to assign group members

### DIFF
--- a/common/types/store-types.ts
+++ b/common/types/store-types.ts
@@ -112,6 +112,14 @@ export type Group = {
   readonly classCode: string;
 };
 
+/**
+ * The type of a group member.
+ */
+export type GroupMember = {
+  readonly netId: string;
+  readonly name: string;
+};
+
 /** The user profile of any samwise user. */
 export type SamwiseUserProfile = {
   readonly email: string;

--- a/common/types/store-types.ts
+++ b/common/types/store-types.ts
@@ -112,14 +112,6 @@ export type Group = {
   readonly classCode: string;
 };
 
-/**
- * The type of a group member.
- */
-export type GroupMember = {
-  readonly netId: string;
-  readonly name: string;
-};
-
 /** The user profile of any samwise user. */
 export type SamwiseUserProfile = {
   readonly email: string;

--- a/frontend/src/components/TaskCreator/GroupMemberPicker.tsx
+++ b/frontend/src/components/TaskCreator/GroupMemberPicker.tsx
@@ -1,10 +1,10 @@
-import React, { ReactElement, KeyboardEvent } from 'react';
-import { connect } from 'react-redux';
-import { NONE_TAG, NONE_TAG_ID } from 'common/util/tag-util';
-import { State, Tag } from 'common/types/store-types';
-import TagListPicker from '../Util/TagListPicker/TagListPicker';
-import styles from './Picker.module.scss';
-import SamwiseIcon from '../UI/SamwiseIcon';
+import React, { ReactElement, KeyboardEvent } from "react";
+import { connect } from "react-redux";
+import { NONE_TAG, NONE_TAG_ID } from "common/util/tag-util";
+import { State, Tag, GroupMember } from "common/types/store-types";
+import SearchGroupMember from "../Util/GroupMemberListPicker/SearchGroupMember";
+import styles from "./Picker.module.scss";
+import SamwiseIcon from "../UI/SamwiseIcon";
 
 type OwnProps = {
   readonly tag: string;
@@ -16,6 +16,14 @@ type Props = OwnProps & {
   // subscribed from redux store.
   readonly getTag: (id: string) => Tag;
 };
+
+// hardcoded member list
+const members: GroupMember[] = [
+  { netId: "dl123", name: "Darien Lopez" },
+  { netId: "sj234", name: "Sarah Johnson" },
+  { netId: "mp678", name: "Michelle Parker" },
+  { netId: "sj99", name: "Sarah Jo" },
+];
 
 function GroupMemberPicker({
   tag,
@@ -29,28 +37,34 @@ function GroupMemberPicker({
     onPickerOpened();
   };
   const pressedPicker = (e: KeyboardEvent): void => {
-    if (e.key === 'Enter' || e.key === ' ') onPickerOpened();
+    if (e.key === "Enter" || e.key === " ") onPickerOpened();
   };
   const reset = (): void => onTagChange(NONE_TAG_ID);
   // Nodes
   const displayedNode = (isDefault: boolean): ReactElement => {
     const { name, color, classId } = getTag(tag);
-    const style = isDefault ? { background: NONE_TAG.color } : { background: color };
-    const internal = isDefault ? (
-      <>
-        <span className={styles.TagDisplay}>
-          <SamwiseIcon iconName="user-plus" className={styles.CenterIcon} />
-          &nbsp;assign to&nbsp;&nbsp;
-        </span>
-      </>
-    ) : (
-      <>
-        <span className={styles.TagDisplay}>{classId != null ? name.split(':')[0] : name}</span>
-        <button type="button" className={styles.ResetButton} onClick={reset}>
-          &times;
-        </button>
-      </>
-    );
+    const style = isDefault
+      ? { background: NONE_TAG.color }
+      : { background: color };
+    const internal = isDefault
+      ? (
+        <>
+          <span className={styles.TagDisplay}>
+            <SamwiseIcon iconName="user-plus" className={styles.CenterIcon} />
+            &nbsp;assign to&nbsp;&nbsp;
+          </span>
+        </>
+      )
+      : (
+        <>
+          <span className={styles.TagDisplay}>
+            {classId != null ? name.split(":")[0] : name}
+          </span>
+          <button type="button" className={styles.ResetButton} onClick={reset}>
+            &times;
+          </button>
+        </>
+      );
     return (
       <span
         role="presentation"
@@ -67,8 +81,9 @@ function GroupMemberPicker({
     <div className={styles.Main}>
       {displayedNode(tag === NONE_TAG_ID)}
       {opened && (
-        <div className={styles.NewTaskClassPick}>
-          <TagListPicker onTagChange={onTagChange} />
+        // <div className={styles.NewTaskClassPick}>
+        <div>
+          <SearchGroupMember members={members} />
         </div>
       )}
     </div>

--- a/frontend/src/components/TaskCreator/GroupMemberPicker.tsx
+++ b/frontend/src/components/TaskCreator/GroupMemberPicker.tsx
@@ -75,7 +75,6 @@ function GroupMemberPicker({
     <div className={styles.Main}>
       {displayedNode(tag === NONE_TAG_ID)}
       {opened && (
-        // <div className={styles.NewTaskClassPick}>
         <div>
           <SearchGroupMember members={members} />
         </div>

--- a/frontend/src/components/TaskCreator/GroupMemberPicker.tsx
+++ b/frontend/src/components/TaskCreator/GroupMemberPicker.tsx
@@ -1,10 +1,10 @@
-import React, { ReactElement, KeyboardEvent } from "react";
-import { connect } from "react-redux";
-import { NONE_TAG, NONE_TAG_ID } from "common/util/tag-util";
-import { State, Tag, GroupMember } from "common/types/store-types";
-import SearchGroupMember from "../Util/GroupMemberListPicker/SearchGroupMember";
-import styles from "./Picker.module.scss";
-import SamwiseIcon from "../UI/SamwiseIcon";
+import React, { ReactElement, KeyboardEvent } from 'react';
+import { connect } from 'react-redux';
+import { NONE_TAG, NONE_TAG_ID } from 'common/util/tag-util';
+import { State, Tag, GroupMember } from 'common/types/store-types';
+import SearchGroupMember from '../Util/GroupMemberListPicker/SearchGroupMember';
+import styles from './Picker.module.scss';
+import SamwiseIcon from '../UI/SamwiseIcon';
 
 type OwnProps = {
   readonly tag: string;
@@ -19,10 +19,10 @@ type Props = OwnProps & {
 
 // hardcoded member list
 const members: GroupMember[] = [
-  { netId: "dl123", name: "Darien Lopez" },
-  { netId: "sj234", name: "Sarah Johnson" },
-  { netId: "mp678", name: "Michelle Parker" },
-  { netId: "sj99", name: "Sarah Jo" },
+  { netId: 'dl123', name: 'Darien Lopez' },
+  { netId: 'sj234', name: 'Sarah Johnson' },
+  { netId: 'mp678', name: 'Michelle Parker' },
+  { netId: 'sj99', name: 'Sarah Jo' },
 ];
 
 function GroupMemberPicker({
@@ -37,34 +37,28 @@ function GroupMemberPicker({
     onPickerOpened();
   };
   const pressedPicker = (e: KeyboardEvent): void => {
-    if (e.key === "Enter" || e.key === " ") onPickerOpened();
+    if (e.key === 'Enter' || e.key === ' ') onPickerOpened();
   };
   const reset = (): void => onTagChange(NONE_TAG_ID);
   // Nodes
   const displayedNode = (isDefault: boolean): ReactElement => {
     const { name, color, classId } = getTag(tag);
-    const style = isDefault
-      ? { background: NONE_TAG.color }
-      : { background: color };
-    const internal = isDefault
-      ? (
-        <>
-          <span className={styles.TagDisplay}>
-            <SamwiseIcon iconName="user-plus" className={styles.CenterIcon} />
-            &nbsp;assign to&nbsp;&nbsp;
-          </span>
-        </>
-      )
-      : (
-        <>
-          <span className={styles.TagDisplay}>
-            {classId != null ? name.split(":")[0] : name}
-          </span>
-          <button type="button" className={styles.ResetButton} onClick={reset}>
-            &times;
-          </button>
-        </>
-      );
+    const style = isDefault ? { background: NONE_TAG.color } : { background: color };
+    const internal = isDefault ? (
+      <>
+        <span className={styles.TagDisplay}>
+          <SamwiseIcon iconName="user-plus" className={styles.CenterIcon} />
+          &nbsp;assign to&nbsp;&nbsp;
+        </span>
+      </>
+    ) : (
+      <>
+        <span className={styles.TagDisplay}>{classId != null ? name.split(':')[0] : name}</span>
+        <button type="button" className={styles.ResetButton} onClick={reset}>
+          &times;
+        </button>
+      </>
+    );
     return (
       <span
         role="presentation"

--- a/frontend/src/components/TaskCreator/GroupMemberPicker.tsx
+++ b/frontend/src/components/TaskCreator/GroupMemberPicker.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, KeyboardEvent } from 'react';
 import { connect } from 'react-redux';
 import { NONE_TAG, NONE_TAG_ID } from 'common/util/tag-util';
-import { State, Tag, GroupMember } from 'common/types/store-types';
+import { State, Tag, SamwiseUserProfile } from 'common/types/store-types';
 import SearchGroupMember from '../Util/GroupMemberListPicker/SearchGroupMember';
 import styles from './Picker.module.scss';
 import SamwiseIcon from '../UI/SamwiseIcon';
@@ -18,11 +18,11 @@ type Props = OwnProps & {
 };
 
 // hardcoded member list
-const members: GroupMember[] = [
-  { netId: 'dl123', name: 'Darien Lopez' },
-  { netId: 'sj234', name: 'Sarah Johnson' },
-  { netId: 'mp678', name: 'Michelle Parker' },
-  { netId: 'sj99', name: 'Sarah Jo' },
+const members: SamwiseUserProfile[] = [
+  { email: 'dl123@cornell.edu', name: 'Darien Lopez', photoURL: '' },
+  { email: 'sj234@cornell.edu', name: 'Sarah Johnson', photoURL: '' },
+  { email: 'mp678@cornell.edu', name: 'Michelle Parker', photoURL: '' },
+  { email: 'sj99@cornell.edu', name: 'Sarah Jo', photoURL: '' },
 ];
 
 function GroupMemberPicker({

--- a/frontend/src/components/Util/GroupMemberListPicker/SearchGroupMember.module.scss
+++ b/frontend/src/components/Util/GroupMemberListPicker/SearchGroupMember.module.scss
@@ -1,0 +1,45 @@
+input.SearchInput {
+  display: block;
+  width: 90%;
+  font-size: 14px;
+  color: black;
+  height: 24px;
+  padding: 4px 4px;
+  margin: auto;
+  margin-bottom: 8px;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  border-bottom: 1px solid white;
+}
+
+.MemberSearchBox {
+  position: absolute;
+  top: 21px;
+  right: 0;
+  min-width: 164px;
+  margin: 0;
+  list-style: none;
+  background: darkgray;
+  box-shadow: 1px 1px 10px 5px rgba(0, 0, 0, 0.15);
+}
+
+.MemberSearchBox li {
+  position: relative;
+  text-align: left;
+  padding: 4px 8px;
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+  color: black;
+  background: rgba(255, 255, 255, 0.8);
+  opacity: 0.8;
+  transition: opacity 0.1s ease-in-out;
+}
+
+.MemberSearchBox li:hover,
+.MemberSearchBox li:active {
+  opacity: 1;
+}

--- a/frontend/src/components/Util/GroupMemberListPicker/SearchGroupMember.tsx
+++ b/frontend/src/components/Util/GroupMemberListPicker/SearchGroupMember.tsx
@@ -1,0 +1,72 @@
+import React, { ReactElement } from "react";
+import Fuse from "fuse.js";
+import { GroupMember } from "common/types/store-types";
+import GroupMemberSearchBox from "../GroupMemberSearchBox/GroupMemberSearchBox";
+import styles from "./SearchGroupMember.module.scss";
+
+type SimpleMember = {
+  readonly key: number;
+  readonly value: string; // name of student
+  readonly id: string; // netId of student
+};
+
+type Props = { readonly members: GroupMember[] };
+
+/**
+ * Returns computed group member options.
+ *
+ * @param {GroupMember[]} group members.
+ * @return {SimpleMember[]} group member options.
+ */
+function getMemberOptions(
+  members: GroupMember[],
+): SimpleMember[] {
+  const memberOptions: SimpleMember[] = [];
+  let i = 0;
+  members.forEach((member: GroupMember) => {
+    const { netId, name } = member;
+    const id = netId;
+    memberOptions.push({
+      key: i,
+      value: name,
+      id,
+    });
+    i += 1;
+  });
+  return memberOptions;
+}
+
+/**
+ * The configs for fuse searcher. Essential for fuzzy search.
+ * You may need to tune this further, but it's usable right now.
+ */
+const fuseConfigs = {
+  keys: [
+    "key",
+    "value",
+    "name",
+    "id",
+  ],
+  location: 0, // since we have customized the stuff to search, we can just start at beginning.
+  threshold: 0.2, // higher the threshold, more stuff will be matched.
+  distance: 100, // how close the match must be to the fuzzy location
+};
+
+export default function SearchGroupMember(
+  { members }: Props,
+): ReactElement | null {
+  if (members === null) {
+    return null;
+  }
+  const fuse = new Fuse(getMemberOptions(members), fuseConfigs);
+
+  return (
+    <div>
+      <GroupMemberSearchBox
+        placeholder="assign to"
+        inputClassname={styles.SearchInput} // {tagStyles.SearchInput}
+        fuse={fuse}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/Util/GroupMemberListPicker/SearchGroupMember.tsx
+++ b/frontend/src/components/Util/GroupMemberListPicker/SearchGroupMember.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import Fuse from 'fuse.js';
-import { GroupMember } from 'common/types/store-types';
+import { SamwiseUserProfile } from 'common/types/store-types';
 import GroupMemberSearchBox from '../GroupMemberSearchBox/GroupMemberSearchBox';
 import styles from './SearchGroupMember.module.scss';
 
@@ -10,7 +10,7 @@ type SimpleMember = {
   readonly id: string; // netId of student
 };
 
-type Props = { readonly members: GroupMember[] };
+type Props = { readonly members: SamwiseUserProfile[] };
 
 /**
  * Returns computed group member options.
@@ -18,18 +18,16 @@ type Props = { readonly members: GroupMember[] };
  * @param {GroupMember[]} group members.
  * @return {SimpleMember[]} group member options.
  */
-function getMemberOptions(members: GroupMember[]): SimpleMember[] {
+function getMemberOptions(members: SamwiseUserProfile[]): SimpleMember[] {
   const memberOptions: SimpleMember[] = [];
-  let i = 0;
-  members.forEach((member: GroupMember) => {
-    const { netId, name } = member;
-    const id = netId;
+  members.forEach((member: SamwiseUserProfile, index: number) => {
+    const { email, name } = member;
+    const id = email.split('@')[0]; // extract netId from user's email
     memberOptions.push({
-      key: i,
+      key: index,
       value: name,
       id,
     });
-    i += 1;
   });
   return memberOptions;
 }

--- a/frontend/src/components/Util/GroupMemberListPicker/SearchGroupMember.tsx
+++ b/frontend/src/components/Util/GroupMemberListPicker/SearchGroupMember.tsx
@@ -55,7 +55,7 @@ export default function SearchGroupMember({ members }: Props): ReactElement | nu
     <div>
       <GroupMemberSearchBox
         placeholder="assign to"
-        inputClassname={styles.SearchInput} // {tagStyles.SearchInput}
+        inputClassname={styles.SearchInput}
         fuse={fuse}
       />
     </div>

--- a/frontend/src/components/Util/GroupMemberListPicker/SearchGroupMember.tsx
+++ b/frontend/src/components/Util/GroupMemberListPicker/SearchGroupMember.tsx
@@ -1,8 +1,8 @@
-import React, { ReactElement } from "react";
-import Fuse from "fuse.js";
-import { GroupMember } from "common/types/store-types";
-import GroupMemberSearchBox from "../GroupMemberSearchBox/GroupMemberSearchBox";
-import styles from "./SearchGroupMember.module.scss";
+import React, { ReactElement } from 'react';
+import Fuse from 'fuse.js';
+import { GroupMember } from 'common/types/store-types';
+import GroupMemberSearchBox from '../GroupMemberSearchBox/GroupMemberSearchBox';
+import styles from './SearchGroupMember.module.scss';
 
 type SimpleMember = {
   readonly key: number;
@@ -18,9 +18,7 @@ type Props = { readonly members: GroupMember[] };
  * @param {GroupMember[]} group members.
  * @return {SimpleMember[]} group member options.
  */
-function getMemberOptions(
-  members: GroupMember[],
-): SimpleMember[] {
+function getMemberOptions(members: GroupMember[]): SimpleMember[] {
   const memberOptions: SimpleMember[] = [];
   let i = 0;
   members.forEach((member: GroupMember) => {
@@ -41,20 +39,13 @@ function getMemberOptions(
  * You may need to tune this further, but it's usable right now.
  */
 const fuseConfigs = {
-  keys: [
-    "key",
-    "value",
-    "name",
-    "id",
-  ],
+  keys: ['key', 'value', 'name', 'id'],
   location: 0, // since we have customized the stuff to search, we can just start at beginning.
   threshold: 0.2, // higher the threshold, more stuff will be matched.
   distance: 100, // how close the match must be to the fuzzy location
 };
 
-export default function SearchGroupMember(
-  { members }: Props,
-): ReactElement | null {
+export default function SearchGroupMember({ members }: Props): ReactElement | null {
   if (members === null) {
     return null;
   }

--- a/frontend/src/components/Util/GroupMemberSearchBox/GroupMemberSearchBox.tsx
+++ b/frontend/src/components/Util/GroupMemberSearchBox/GroupMemberSearchBox.tsx
@@ -1,0 +1,55 @@
+import React, { ReactElement, ChangeEvent, useState } from "react";
+import Fuse from "fuse.js";
+import { FuseItem } from "../SearchBox/types";
+import styles from "../GroupMemberListPicker/SearchGroupMember.module.scss";
+
+type Props<T extends FuseItem> = {
+  readonly fuse: Fuse<T>;
+  readonly placeholder?: string;
+  readonly inputClassname: string;
+};
+
+type State<T> = {
+  readonly searchInput: string;
+  readonly searchResults: readonly T[];
+};
+
+const GroupMemberSearchBox = <T extends FuseItem>({
+  placeholder,
+  fuse,
+  inputClassname,
+}: Props<T>): ReactElement => {
+  const [{ searchInput, searchResults }, setState] = useState<State<T>>({
+    searchInput: "",
+    searchResults: [],
+  });
+
+  const onSearchChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    const input = event.currentTarget.value;
+    if (input.length > 1) {
+      const newResults = fuse.search(input).map((result) => result.item) as T[];
+      setState({ searchInput: input, searchResults: newResults });
+    } else {
+      setState({ searchInput: input, searchResults: [] });
+    }
+  };
+
+  return (
+    <div className={styles.MemberSearchBox}>
+      <input
+        type="text"
+        placeholder={placeholder}
+        className={inputClassname}
+        value={searchInput}
+        onChange={onSearchChange}
+      />
+      <div>
+        {searchResults.map((item) => (
+          <li>{item.value}</li>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default GroupMemberSearchBox;

--- a/frontend/src/components/Util/GroupMemberSearchBox/GroupMemberSearchBox.tsx
+++ b/frontend/src/components/Util/GroupMemberSearchBox/GroupMemberSearchBox.tsx
@@ -1,7 +1,7 @@
-import React, { ReactElement, ChangeEvent, useState } from "react";
-import Fuse from "fuse.js";
-import { FuseItem } from "../SearchBox/types";
-import styles from "../GroupMemberListPicker/SearchGroupMember.module.scss";
+import React, { ReactElement, ChangeEvent, useState } from 'react';
+import Fuse from 'fuse.js';
+import { FuseItem } from '../SearchBox/types';
+import styles from '../GroupMemberListPicker/SearchGroupMember.module.scss';
 
 type Props<T extends FuseItem> = {
   readonly fuse: Fuse<T>;
@@ -20,7 +20,7 @@ const GroupMemberSearchBox = <T extends FuseItem>({
   inputClassname,
 }: Props<T>): ReactElement => {
   const [{ searchInput, searchResults }, setState] = useState<State<T>>({
-    searchInput: "",
+    searchInput: '',
     searchResults: [],
   });
 

--- a/frontend/src/components/Util/GroupMemberSearchBox/GroupMemberSearchBox.tsx
+++ b/frontend/src/components/Util/GroupMemberSearchBox/GroupMemberSearchBox.tsx
@@ -26,12 +26,8 @@ const GroupMemberSearchBox = <T extends FuseItem>({
 
   const onSearchChange = (event: ChangeEvent<HTMLInputElement>): void => {
     const input = event.currentTarget.value;
-    if (input.length > 1) {
-      const newResults = fuse.search(input).map((result) => result.item) as T[];
-      setState({ searchInput: input, searchResults: newResults });
-    } else {
-      setState({ searchInput: input, searchResults: [] });
-    }
+    const newResults = fuse.search(input).map((result) => result.item) as T[];
+    setState({ searchInput: input, searchResults: newResults });
   };
 
   return (


### PR DESCRIPTION
### Summary
Replaces the tag picker in normal view with a group member picker when in group view. Group members can be searched by either their names or their Cornell netIDs.

- [x] replace tag picker with a group member picker

### Test Plan
![group member picker](https://user-images.githubusercontent.com/48143149/95000170-99461780-058c-11eb-9e6b-b142de845285.png)
