### PR TITLE
Fix group tasks icon in personal view

### DIFF
--- a/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
@@ -133,9 +133,11 @@ function FutureViewTask({
   const RepeatingIcon = (): ReactElement => (
     <SamwiseIcon iconName="repeat-light" className={styles.TaskIconNoHover} />
   );
-  let Icon = (): ReactElement => <RepeatingIcon />;
-  if (compoundTask.original.metadata.type === 'ONE_TIME') {
-    Icon = isCanvasTask ? Placeholder : DragIcon;
+  let Icon = Placeholder;
+  if (compoundTask.original.metadata.type === 'MASTER_TEMPLATE') {
+    Icon = RepeatingIcon;
+  } else if (compoundTask.original.metadata.type === 'ONE_TIME' && !isCanvasTask) {
+    Icon = DragIcon;
   }
   const renderMainTaskInfo = (simplified = false): ReactElement => {
     if (simplified && isInMainList) {


### PR DESCRIPTION
### Summary

Originally, we have the default icon next to the task title be the repeating icon, so now when we add a new type `GROUP`, it will default to the repeating icon. Let's make the Placeholder (empty) the default and if it is `ONE_TIME` and not a canvas task, we can show the `DragIcon`. All other cases, leave the icon blank.

### Test Plan

Make group, one time, and repeating tasks and check the icons. 

![icons](https://user-images.githubusercontent.com/20008134/95001548-ff389c00-0598-11eb-8633-55a283ddfe42.png)

