### PR TITLE
Changed resetButtonPos positioning, resized tag and date picker

### DIFF
--- a/frontend/src/components/TaskCreator/Picker.module.scss
+++ b/frontend/src/components/TaskCreator/Picker.module.scss
@@ -29,9 +29,9 @@
   border-color: transparent;
   color: #fff;
   font: 14px 'Open Sans', sans-serif;
-  width: 96.84px;
+  // width: 96.84px;
   height: 20px;
-  padding: 0;
+  padding: 0 5px;
 }
 
 .DateButton {
@@ -39,9 +39,10 @@
   border-color: transparent;
   color: #fff;
   font: 14px 'Open Sans', sans-serif;
-  width: 94.03px;
+  width: 100%;
+  padding: 0 5px 0 10px;
   height: 20px;
-  padding: 0;
+  // padding: 0;
 }
 
 .Label {
@@ -104,9 +105,11 @@
   border-radius: 10px;
   margin: 0;
   padding: 0;
-  line-height: 21px;
   position: relative;
   bottom: 0;
+  line-height: 16px;
+  margin-right: -7px;
+  margin-top: -1px;
 }
 
 .ResetButton:hover {

--- a/frontend/src/components/TaskCreator/Picker.module.scss
+++ b/frontend/src/components/TaskCreator/Picker.module.scss
@@ -29,7 +29,6 @@
   border-color: transparent;
   color: #fff;
   font: 14px 'Open Sans', sans-serif;
-  // width: 96.84px;
   height: 20px;
   padding: 0 5px;
 }
@@ -42,7 +41,6 @@
   width: 100%;
   padding: 0 5px 0 10px;
   height: 20px;
-  // padding: 0;
 }
 
 .Label {


### PR DESCRIPTION
### Summary <!-- Required -->
Changed resetButton positioning to match that of the original positioning. Also resized the tag and date picker as they were too stretched out. 

### Fixes <!-- Required -->
Added right and top margin to resetButton. Also adjusted the widths of the tag and date picker. 

This pull request is the first step towards implementing feature Foo

- [x] changed positioning of resetButtons 
- [x] changed size of Tag and Date pickers

### Test Plan <!-- Required -->
Compared functionality to original design after making changes. 
<!-- Provide screenshots or point out the additional unit tests -->
Updated: 
<img width="421" alt="Screen Shot 2020-10-03 at 7 48 17 PM" src="https://user-images.githubusercontent.com/20613939/95003842-aaede600-05b1-11eb-820a-d2ab7092b28d.png">
<img width="430" alt="Screen Shot 2020-10-03 at 7 48 06 PM" src="https://user-images.githubusercontent.com/20613939/95003844-aaede600-05b1-11eb-9f04-03b22aabed25.png">

Original: 
<img width="413" alt="Screen Shot 2020-10-03 at 7 50 45 PM" src="https://user-images.githubusercontent.com/20613939/95003854-c9ec7800-05b1-11eb-90bc-b7d145068fb9.png">
<img width="418" alt="Screen Shot 2020-10-03 at 7 50 58 PM" src="https://user-images.githubusercontent.com/20613939/95003857-ce189580-05b1-11eb-94aa-ce86ea74fb72.png">











