### PR TITLE
Make class tags center aligned in TagPicker

### DIFF
--- a/frontend/src/components/Util/TagListPicker/TagListPicker.module.scss
+++ b/frontend/src/components/Util/TagListPicker/TagListPicker.module.scss
@@ -15,7 +15,7 @@
 
 .NewTaskClass li {
   position: relative;
-  text-align: left;
+  text-align: center;
   padding: 1px 7px;
   margin-bottom: 3px;
   border: none;


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is a 1 line fix that just makes new task class tags under tag picker have center alignment, fixing the issue pointed out by @meganyin13 in #562.

### Test Plan <!-- Required -->

![image](https://user-images.githubusercontent.com/7517829/95278432-28b62980-081e-11eb-9bbe-fccbea4faf2b.png)

play with tagpicker :eyes: 


