### PR TITLE
GroupTasks pulling real data from Firestore

### DIFF
--- a/frontend/src/components/GroupView/RightView/GroupTask.tsx
+++ b/frontend/src/components/GroupView/RightView/GroupTask.tsx
@@ -1,45 +1,21 @@
+import { Task } from 'common/types/store-types';
 import React, { ReactElement } from 'react';
-import { connect } from 'react-redux';
-import { error } from 'common/util/general-util';
-import { State, Task } from 'common/types/store-types';
-import {
-  getFilteredNotCompletedInFocusTask,
-  getFilteredCompletedInFocusTask,
-} from 'common/util/task-util';
 import InlineTaskEditor from '../../Util/TaskEditors/InlineTaskEditor';
 import styles from './GroupTask.module.scss';
 
-type OwnProps = {
-  readonly id: string;
-  readonly order: number;
-  // Needed for react-redux. See the connect function at the bottom.
-  // eslint-disable-next-line react/no-unused-prop-types
-  readonly filterCompleted: boolean;
-};
-type Props = OwnProps & {
+type Props = {
   readonly original: Task;
-  readonly filtered: Task | null;
 };
 
-function GroupTask({ id, order, original, filtered }: Props): ReactElement {
-  if (filtered === null) {
-    throw new Error(`The filtered task should not be null! id: ${id}, order: ${order}`);
-  }
+function GroupTask({ original }: Props): ReactElement {
   return (
     <InlineTaskEditor
       className={styles.GroupTask}
       calendarPosition="bottom"
       original={original}
-      filtered={filtered}
+      filtered={original}
     />
   );
 }
 
-const Connected = connect(({ tasks }: State, { id, filterCompleted }: OwnProps) => {
-  const original = tasks.get(id) ?? error();
-  const filtered = filterCompleted
-    ? getFilteredCompletedInFocusTask(original)
-    : getFilteredNotCompletedInFocusTask(original);
-  return { original, filtered };
-})(GroupTask);
-export default Connected;
+export default GroupTask;

--- a/frontend/src/components/GroupView/RightView/GroupTaskRow.tsx
+++ b/frontend/src/components/GroupView/RightView/GroupTaskRow.tsx
@@ -7,7 +7,7 @@ import styles from './GroupTaskRow.module.scss';
 
 type Props = {
   memberName: string;
-  readonly tasks: Task[];
+  readonly tasks: readonly Task[];
 };
 
 const clickAddGroupTask = (e: SyntheticEvent<HTMLElement>): void => {

--- a/frontend/src/components/GroupView/RightView/GroupTaskRow.tsx
+++ b/frontend/src/components/GroupView/RightView/GroupTaskRow.tsx
@@ -1,11 +1,13 @@
 import React, { ReactElement, SyntheticEvent, KeyboardEvent } from 'react';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Task } from 'common/types/store-types';
 import GroupTasksContainer from './GroupTasksContainer';
 import styles from './GroupTaskRow.module.scss';
 
 type Props = {
   memberName: string;
+  readonly tasks: Task[];
 };
 
 const clickAddGroupTask = (e: SyntheticEvent<HTMLElement>): void => {
@@ -19,7 +21,7 @@ const pressedAddGroupTask = (e: KeyboardEvent): void => {
   }
 };
 
-const GroupTaskRow = ({ memberName }: Props): ReactElement => {
+const GroupTaskRow = ({ tasks, memberName }: Props): ReactElement => {
   const initials = `${memberName.split(' ')[0].charAt(0)}${memberName.split(' ')[1].charAt(0)}`;
 
   return (
@@ -38,7 +40,7 @@ const GroupTaskRow = ({ memberName }: Props): ReactElement => {
         </div>
       </button>
 
-      <GroupTasksContainer />
+      <GroupTasksContainer tasks={tasks} />
     </div>
   );
 };

--- a/frontend/src/components/GroupView/RightView/GroupTasksContainer.tsx
+++ b/frontend/src/components/GroupView/RightView/GroupTasksContainer.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState, ReactNode } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import { Task } from 'common/types/store-types';
 import styles from './GroupTasksContainer.module.scss';
 import GroupTask from './GroupTask';
@@ -12,31 +12,12 @@ type IdOrder = {
   readonly order: number;
 };
 
-function renderTaskList(list: IdOrder[], filterCompleted: boolean): ReactNode {
-  return list.map(({ id }, index) => (
-    <GroupTask key={id} id={id} order={index} filterCompleted={filterCompleted} />
-  ));
+function renderTaskList(list: Task[]): ReactNode {
+  return list.map((item) => <GroupTask key={item.id} original={item} />);
 }
 
 function GroupTasksContainer({ tasks }: Props): ReactElement {
-  const [localTasks, setLocalTasks] = useState<Task[]>(tasks);
-  if (localTasks !== tasks) {
-    setLocalTasks(tasks);
-  }
-  const localCompletedList: IdOrder[] = [];
-  const localUncompletedList: IdOrder[] = [];
-  localTasks.forEach(({ id, order, complete }: Task) => {
-    const idOrder = { id, order };
-    if (complete) {
-      localCompletedList.push(idOrder);
-    } else {
-      localUncompletedList.push(idOrder);
-    }
-  });
-
-  return (
-    <div className={styles.GroupTasksContainer}>{renderTaskList(localUncompletedList, false)}</div>
-  );
+  return <div className={styles.GroupTasksContainer}>{renderTaskList(tasks)}</div>;
 }
 
 export default GroupTasksContainer;

--- a/frontend/src/components/GroupView/RightView/GroupTasksContainer.tsx
+++ b/frontend/src/components/GroupView/RightView/GroupTasksContainer.tsx
@@ -4,7 +4,7 @@ import styles from './GroupTasksContainer.module.scss';
 import GroupTask from './GroupTask';
 
 type Props = {
-  readonly tasks: Task[];
+  readonly tasks: readonly Task[];
 };
 
 type IdOrder = {
@@ -12,7 +12,7 @@ type IdOrder = {
   readonly order: number;
 };
 
-function renderTaskList(list: Task[]): ReactNode {
+function renderTaskList(list: readonly Task[]): ReactNode {
   return list.map((item) => <GroupTask key={item.id} original={item} />);
 }
 

--- a/frontend/src/components/GroupView/RightView/GroupTasksContainer.tsx
+++ b/frontend/src/components/GroupView/RightView/GroupTasksContainer.tsx
@@ -1,10 +1,16 @@
 import React, { ReactElement, useState, ReactNode } from 'react';
-import { connect } from 'react-redux';
+import { Task } from 'common/types/store-types';
 import styles from './GroupTasksContainer.module.scss';
 import GroupTask from './GroupTask';
-import { getFocusViewProps, FocusViewTaskMetaData, FocusViewProps } from '../../../store/selectors';
 
-type IdOrder = { readonly id: string; readonly order: number };
+type Props = {
+  readonly tasks: Task[];
+};
+
+type IdOrder = {
+  readonly id: string;
+  readonly order: number;
+};
 
 function renderTaskList(list: IdOrder[], filterCompleted: boolean): ReactNode {
   return list.map(({ id }, index) => (
@@ -12,19 +18,16 @@ function renderTaskList(list: IdOrder[], filterCompleted: boolean): ReactNode {
   ));
 }
 
-function GroupTasksContainer({ tasks }: FocusViewProps): ReactElement {
-  const [localTasks, setLocalTasks] = useState<FocusViewTaskMetaData[]>(tasks);
+function GroupTasksContainer({ tasks }: Props): ReactElement {
+  const [localTasks, setLocalTasks] = useState<Task[]>(tasks);
   if (localTasks !== tasks) {
     setLocalTasks(tasks);
   }
   const localCompletedList: IdOrder[] = [];
   const localUncompletedList: IdOrder[] = [];
-  localTasks.forEach(({ id, order, inFocusView, inCompleteFocusView }: FocusViewTaskMetaData) => {
-    if (!inFocusView) {
-      return;
-    }
+  localTasks.forEach(({ id, order, complete }: Task) => {
     const idOrder = { id, order };
-    if (inCompleteFocusView) {
+    if (complete) {
       localCompletedList.push(idOrder);
     } else {
       localUncompletedList.push(idOrder);
@@ -36,5 +39,4 @@ function GroupTasksContainer({ tasks }: FocusViewProps): ReactElement {
   );
 }
 
-const Connected = connect(getFocusViewProps)(GroupTasksContainer);
-export default Connected;
+export default GroupTasksContainer;

--- a/frontend/src/components/GroupView/RightView/index.tsx
+++ b/frontend/src/components/GroupView/RightView/index.tsx
@@ -8,7 +8,7 @@ import TaskCreator from '../../TaskCreator';
 type Props = {
   readonly group: Group;
   readonly groupMemberProfiles: readonly SamwiseUserProfile[];
-  readonly tasks: Task[];
+  readonly tasks: readonly Task[];
 };
 
 const EditGroupNameIcon = (): ReactElement => {

--- a/frontend/src/components/GroupView/RightView/index.tsx
+++ b/frontend/src/components/GroupView/RightView/index.tsx
@@ -1,11 +1,15 @@
 import React, { ReactElement } from 'react';
-import type { Group, SamwiseUserProfile } from 'common/types/store-types';
+import type { Group, SamwiseUserProfile, Task } from 'common/types/store-types';
 import SamwiseIcon from '../../UI/SamwiseIcon';
 import GroupTaskRow from './GroupTaskRow';
 import styles from './index.module.scss';
 import TaskCreator from '../../TaskCreator';
 
-type Props = { readonly group: Group; readonly groupMemberProfiles: readonly SamwiseUserProfile[] };
+type Props = {
+  readonly group: Group;
+  readonly groupMemberProfiles: readonly SamwiseUserProfile[];
+  readonly tasks: Task[];
+};
 
 const EditGroupNameIcon = (): ReactElement => {
   const handler = (): void => {
@@ -14,24 +18,33 @@ const EditGroupNameIcon = (): ReactElement => {
   return <SamwiseIcon iconName="pencil" className={styles.EditGroupNameIcon} onClick={handler} />;
 };
 
-const RightView = ({ group, groupMemberProfiles }: Props): ReactElement => (
-  <div className={styles.RightView}>
-    <div className={styles.GroupTaskCreator}>
-      <TaskCreator view="group" group={group.name} />
-    </div>
-
+const RightView = ({ group, groupMemberProfiles, tasks }: Props): ReactElement => {
+  return (
     <div className={styles.RightView}>
-      <div>
-        <h2>{group.name}</h2>
-        <EditGroupNameIcon />
+      <div className={styles.GroupTaskCreator}>
+        <TaskCreator view="group" group={group.name} />
       </div>
-      <div className={styles.GroupTaskRowContainer}>
-        {groupMemberProfiles.map((samwiseUserProfile) => (
-          <GroupTaskRow memberName={samwiseUserProfile.name} key={samwiseUserProfile.email} />
-        ))}
+
+      <div className={styles.RightView}>
+        <div>
+          <h2>{group.name}</h2>
+          <EditGroupNameIcon />
+        </div>
+        <div className={styles.GroupTaskRowContainer}>
+          {groupMemberProfiles.map((samwiseUserProfile) => {
+            const filteredTasks = tasks.filter((t) => t.owner === samwiseUserProfile.email);
+            return (
+              <GroupTaskRow
+                tasks={filteredTasks}
+                memberName={samwiseUserProfile.name}
+                key={samwiseUserProfile.email}
+              />
+            );
+          })}
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default RightView;

--- a/frontend/src/components/GroupView/index.tsx
+++ b/frontend/src/components/GroupView/index.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState, useEffect } from 'react';
-import type { Group, SamwiseUserProfile } from 'common/types/store-types';
+import type { Group, SamwiseUserProfile, Task } from 'common/types/store-types';
 import type { FirestoreUserData } from 'common/types/firestore-types';
 import MiddleBar from './MiddleBar';
 import RightView from './RightView';
@@ -44,12 +44,27 @@ const useGroupMemberProfiles = (
 };
 
 const GroupView = ({ group }: Props): ReactElement => {
+  const [groupTaskArray, setGroupTaskArray] = useState<Task[]>([]);
+  useEffect(() => {
+    database
+      .tasksCollection()
+      .where('type', '==', 'GROUP')
+      .where('group', '==', group.id)
+      .onSnapshot((s) =>
+        s.forEach((it) => {
+          const task = { ...it.data(), id: it.id } as Task;
+          // get rid of groupTaskArray from dependency array
+          setGroupTaskArray((ary) => [...ary, task]);
+        })
+      );
+  }, [group]);
+
   const groupMemberProfiles = useGroupMemberProfiles(group.members);
 
   return (
     <div className={styles.GroupView}>
       <MiddleBar groupMemberProfiles={groupMemberProfiles} />
-      <RightView group={group} groupMemberProfiles={groupMemberProfiles} />
+      <RightView group={group} groupMemberProfiles={groupMemberProfiles} tasks={groupTaskArray} />
     </div>
   );
 };

--- a/frontend/src/components/GroupView/index.tsx
+++ b/frontend/src/components/GroupView/index.tsx
@@ -59,12 +59,16 @@ const GroupView = ({ group }: Props): ReactElement => {
       .onSnapshot((s) => {
         setGroupTaskArray([]);
         // this is problematic because it does not account for subtasks yet
-        s.forEach((it) => {
-          const d = it.data();
+        s.forEach((docSnapshot) => {
+          const docData = docSnapshot.data();
           const task = {
-            ...d,
-            id: it.id,
-            metadata: { type: 'GROUP', date: d.date.toDate(), group: d.group } as GroupTaskMetadata,
+            ...docData,
+            id: docSnapshot.id,
+            metadata: {
+              type: 'GROUP',
+              date: docData.date.toDate(),
+              group: docData.group,
+            } as GroupTaskMetadata,
             children: [] as readonly SubTask[],
           } as Task;
           // get rid of groupTaskArray from dependency array

--- a/frontend/src/components/GroupView/index.tsx
+++ b/frontend/src/components/GroupView/index.tsx
@@ -1,5 +1,11 @@
 import React, { ReactElement, useState, useEffect } from 'react';
-import type { Group, SamwiseUserProfile, Task } from 'common/types/store-types';
+import type {
+  Group,
+  SamwiseUserProfile,
+  Task,
+  GroupTaskMetadata,
+  SubTask,
+} from 'common/types/store-types';
 import type { FirestoreUserData } from 'common/types/firestore-types';
 import MiddleBar from './MiddleBar';
 import RightView from './RightView';
@@ -50,13 +56,21 @@ const GroupView = ({ group }: Props): ReactElement => {
       .tasksCollection()
       .where('type', '==', 'GROUP')
       .where('group', '==', group.id)
-      .onSnapshot((s) =>
+      .onSnapshot((s) => {
+        setGroupTaskArray([]);
+        // this is problematic because it does not account for subtasks yet
         s.forEach((it) => {
-          const task = { ...it.data(), id: it.id } as Task;
+          const d = it.data();
+          const task = {
+            ...d,
+            id: it.id,
+            metadata: { type: 'GROUP', date: d.date.toDate(), group: d.group } as GroupTaskMetadata,
+            children: [] as readonly SubTask[],
+          } as Task;
           // get rid of groupTaskArray from dependency array
           setGroupTaskArray((ary) => [...ary, task]);
-        })
-      );
+        });
+      });
   }, [group]);
 
   const groupMemberProfiles = useGroupMemberProfiles(group.members);


### PR DESCRIPTION
### Summary <!-- Required -->

Replace temporary data pulled from focus view with actual data from Firestore according to the group and user.

resolves #560 

### Test Plan <!-- Required -->

Play with it on staging. 
Note: the add tasks is actually broken because it adds based on group name rather than the group id and only assigns the task to yourself. See: #567

The way I have been adding tasks is just using the add task feature at the top and editing fields manually in Firestore.
![image](https://user-images.githubusercontent.com/33106747/95371882-c9512b80-08a8-11eb-96e6-fbb12b1f7c21.png)


### Notes <!-- Optional -->

Subtasks are not yet rendered/supported until there is some util for converting the string[] from Firestore type to the Store type SubTask[]

