### PR TITLE
Connect group tasks UI to backend for creating/leaving and profile images

### DIFF
--- a/frontend/src/ViewSwitcher.tsx
+++ b/frontend/src/ViewSwitcher.tsx
@@ -20,7 +20,11 @@ const ViewSwitcher = (): React.ReactElement => {
     <div className={styles.GroupScreen}>
       <SideBar groups={groups} changeView={changeView} />
       <div className={styles.GroupScreenContent}>
-        {group === undefined ? <PersonalView /> : <GroupView group={group} />}
+        {group === undefined ? (
+          <PersonalView />
+        ) : (
+          <GroupView group={group} changeView={changeView} />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarMemberRow.module.scss
+++ b/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarMemberRow.module.scss
@@ -5,17 +5,6 @@
   line-height: 40px;
 }
 
-.Initials {
-  height: 40px;
-  width: 40px;
-  border-radius: 50%;
-  background-color: #d7b6dc;
-  text-align: center;
-  font-size: 16px;
-  line-height: 40px;
-  color: white;
-}
-
 .Member p {
   font-size: 16px;
   color: #3d3d3d;
@@ -23,6 +12,11 @@
   margin: 0 1em;
   overflow-x: hidden;
   overflow-y: hidden;
+}
+
+.MemberProfilePic {
+  width: 40px;
+  height: 40px;
 }
 
 .MemberIcon {

--- a/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarMemberRow.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarMemberRow.tsx
@@ -3,16 +3,21 @@ import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import SamwiseIcon from '../../UI/SamwiseIcon';
 import styles from './GroupViewMiddleBarMemberRow.module.scss';
+import ProfileImage from './ProfileImage';
 
 type Props = {
   memberName: string;
+  profilePicURL: string;
 };
 
-const Member = ({ memberName }: Props): ReactElement => {
-  const initials = `${memberName.split(' ')[0].charAt(0)}${memberName.split(' ')[1].charAt(0)}`;
+const Member = ({ memberName, profilePicURL }: Props): ReactElement => {
   return (
     <div className={styles.Member}>
-      <div className={styles.Initials}>{initials}</div>
+      <ProfileImage
+        className={styles.MemberProfilePic}
+        memberName={memberName}
+        imageURL={profilePicURL}
+      />
       <p>{memberName}</p>
       <div className={styles.Plus}>
         <FontAwesomeIcon icon={faPlus} />

--- a/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarPeopleList.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarPeopleList.tsx
@@ -1,18 +1,20 @@
 import React, { ReactElement } from 'react';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import type { SamwiseUserProfile } from 'common/types/store-types';
+import type { Group, SamwiseUserProfile } from 'common/types/store-types';
 import SamwiseIcon from '../../UI/SamwiseIcon';
 import { promptConfirm, promptTextInput } from '../../Util/Modals';
 import GroupViewMiddleBarMemberRow from './GroupViewMiddleBarMemberRow';
 import styles from './GroupViewMiddleBarPeopleList.module.scss';
+import { leaveGroup } from '../../../firebase/actions';
 
 const leaveGroupPrompt = 'Are you sure you want to leave this group?';
 
-function confirmLeaveGroup(): void {
-  promptConfirm(leaveGroupPrompt).then(() => {
-    console.log('Leave success');
-  });
+async function confirmLeaveGroup(groupID: string): Promise<void> {
+  const confirmed = await promptConfirm(leaveGroupPrompt);
+  if (confirmed) {
+    await leaveGroup(groupID);
+  }
 }
 
 const promptAddMember = (): void => {
@@ -27,9 +29,12 @@ const promptAddMember = (): void => {
   });
 };
 
-type Props = { readonly groupMemberProfiles: readonly SamwiseUserProfile[] };
+type Props = {
+  readonly group: Group;
+  readonly groupMemberProfiles: readonly SamwiseUserProfile[];
+};
 
-const People = ({ groupMemberProfiles }: Props): ReactElement => (
+const People = ({ group, groupMemberProfiles }: Props): ReactElement => (
   <div className={styles.People}>
     <h2>People</h2>
     <div className={styles.MemberList}>
@@ -48,7 +53,7 @@ const People = ({ groupMemberProfiles }: Props): ReactElement => (
       </div>
       Add member
     </button>
-    <button type="button" className={styles.LeaveGroup} onClick={confirmLeaveGroup}>
+    <button type="button" className={styles.LeaveGroup} onClick={() => confirmLeaveGroup(group.id)}>
       <SamwiseIcon iconName="exit" />
       <p>Leave Group</p>
     </button>

--- a/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarPeopleList.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarPeopleList.tsx
@@ -1,19 +1,26 @@
 import React, { ReactElement } from 'react';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import type { Group, SamwiseUserProfile } from 'common/types/store-types';
+import type { Group, SamwiseUserProfile, State } from 'common/types/store-types';
 import SamwiseIcon from '../../UI/SamwiseIcon';
 import { promptConfirm, promptTextInput } from '../../Util/Modals';
 import GroupViewMiddleBarMemberRow from './GroupViewMiddleBarMemberRow';
 import styles from './GroupViewMiddleBarPeopleList.module.scss';
 import { leaveGroup } from '../../../firebase/actions';
+import { useSelector } from 'react-redux';
 
 const leaveGroupPrompt = 'Are you sure you want to leave this group?';
 
-async function confirmLeaveGroup(groupID: string): Promise<void> {
+async function confirmLeaveGroup(
+  groupID: string,
+  changeViewCallback: (selectedGroup: string | undefined) => void,
+  groups: Group[]
+): Promise<void> {
   const confirmed = await promptConfirm(leaveGroupPrompt);
   if (confirmed) {
     await leaveGroup(groupID);
+    const updatedGroups = groups.filter(({ id }) => id !== groupID).map(({ id }) => id);
+    changeViewCallback(updatedGroups[0]);
   }
 }
 
@@ -32,32 +39,40 @@ const promptAddMember = (): void => {
 type Props = {
   readonly group: Group;
   readonly groupMemberProfiles: readonly SamwiseUserProfile[];
+  readonly changeView: (selectedGroup: string | undefined) => void;
 };
 
-const People = ({ group, groupMemberProfiles }: Props): ReactElement => (
-  <div className={styles.People}>
-    <h2>People</h2>
-    <div className={styles.MemberList}>
-      {groupMemberProfiles.map(({ name, email, photoURL }) => (
-        <GroupViewMiddleBarMemberRow memberName={name} key={email} profilePicURL={photoURL} />
-      ))}
-    </div>
-    <button
-      type="button"
-      onClick={promptAddMember}
-      onKeyPress={(e) => (e.key === 'Enter' || e.key === ' ') && promptAddMember()}
-      className={styles.AddMember}
-    >
-      <div>
-        <FontAwesomeIcon icon={faPlus} />
+const People = ({ group, groupMemberProfiles, changeView }: Props): ReactElement => {
+  const groups = useSelector((state: State) => Array.from(state.groups.values()));
+  return (
+    <div className={styles.People}>
+      <h2>People</h2>
+      <div className={styles.MemberList}>
+        {groupMemberProfiles.map(({ name, email, photoURL }) => (
+          <GroupViewMiddleBarMemberRow memberName={name} key={email} profilePicURL={photoURL} />
+        ))}
       </div>
-      Add member
-    </button>
-    <button type="button" className={styles.LeaveGroup} onClick={() => confirmLeaveGroup(group.id)}>
-      <SamwiseIcon iconName="exit" />
-      <p>Leave Group</p>
-    </button>
-  </div>
-);
+      <button
+        type="button"
+        onClick={promptAddMember}
+        onKeyPress={(e) => (e.key === 'Enter' || e.key === ' ') && promptAddMember()}
+        className={styles.AddMember}
+      >
+        <div>
+          <FontAwesomeIcon icon={faPlus} />
+        </div>
+        Add member
+      </button>
+      <button
+        type="button"
+        className={styles.LeaveGroup}
+        onClick={() => confirmLeaveGroup(group.id, changeView, groups)}
+      >
+        <SamwiseIcon iconName="exit" />
+        <p>Leave Group</p>
+      </button>
+    </div>
+  );
+};
 
 export default People;

--- a/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarPeopleList.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarPeopleList.tsx
@@ -33,8 +33,8 @@ const People = ({ groupMemberProfiles }: Props): ReactElement => (
   <div className={styles.People}>
     <h2>People</h2>
     <div className={styles.MemberList}>
-      {groupMemberProfiles.map((profile) => (
-        <GroupViewMiddleBarMemberRow memberName={profile.name} key={profile.email} />
+      {groupMemberProfiles.map(({ name, email, photoURL }) => (
+        <GroupViewMiddleBarMemberRow memberName={name} key={email} profilePicURL={photoURL} />
       ))}
     </div>
     <button

--- a/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarPeopleList.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarPeopleList.tsx
@@ -2,12 +2,12 @@ import React, { ReactElement } from 'react';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { Group, SamwiseUserProfile, State } from 'common/types/store-types';
+import { useSelector } from 'react-redux';
 import SamwiseIcon from '../../UI/SamwiseIcon';
 import { promptConfirm, promptTextInput } from '../../Util/Modals';
 import GroupViewMiddleBarMemberRow from './GroupViewMiddleBarMemberRow';
 import styles from './GroupViewMiddleBarPeopleList.module.scss';
 import { leaveGroup } from '../../../firebase/actions';
-import { useSelector } from 'react-redux';
 
 const leaveGroupPrompt = 'Are you sure you want to leave this group?';
 

--- a/frontend/src/components/GroupView/MiddleBar/ProfileImage.module.scss
+++ b/frontend/src/components/GroupView/MiddleBar/ProfileImage.module.scss
@@ -1,0 +1,3 @@
+.ProfileCircle {
+  border-radius: 50%;
+}

--- a/frontend/src/components/GroupView/MiddleBar/ProfileImage.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/ProfileImage.tsx
@@ -1,0 +1,20 @@
+import React, { ReactElement } from 'react';
+import styles from './ProfileImage.module.scss';
+
+type Props = {
+  readonly memberName: string;
+  readonly imageURL: string;
+  readonly className?: string;
+};
+
+const ProfileImage = ({ memberName, imageURL, className }: Props): ReactElement => {
+  return (
+    <img
+      className={className != null ? `${styles.ProfileCircle} ${className}` : styles.ProfileCircle}
+      src={imageURL}
+      alt={memberName}
+    />
+  );
+};
+
+export default ProfileImage;

--- a/frontend/src/components/GroupView/MiddleBar/index.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/index.tsx
@@ -8,12 +8,17 @@ import styles from './index.module.scss';
 type Props = {
   readonly group: Group;
   readonly groupMemberProfiles: readonly SamwiseUserProfile[];
+  readonly changeView: (selectedGroup: string | undefined) => void;
 };
 
-const GroupViewMiddleBar = ({ groupMemberProfiles, group }: Props): ReactElement => (
+const GroupViewMiddleBar = ({ groupMemberProfiles, group, changeView }: Props): ReactElement => (
   <div className={styles.MiddleBar}>
     <GroupViewMiddleBarTaskQueue />
-    <GroupViewMiddleBarPeopleList group={group} groupMemberProfiles={groupMemberProfiles} />
+    <GroupViewMiddleBarPeopleList
+      group={group}
+      groupMemberProfiles={groupMemberProfiles}
+      changeView={changeView}
+    />
   </div>
 );
 

--- a/frontend/src/components/GroupView/MiddleBar/index.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/index.tsx
@@ -1,16 +1,19 @@
 import React, { ReactElement } from 'react';
-import { SamwiseUserProfile } from 'common/types/store-types';
+import { Group, SamwiseUserProfile } from 'common/types/store-types';
 
 import GroupViewMiddleBarPeopleList from './GroupViewMiddleBarPeopleList';
 import GroupViewMiddleBarTaskQueue from './GroupViewMiddleBarTaskQueue';
 import styles from './index.module.scss';
 
-type Props = { readonly groupMemberProfiles: readonly SamwiseUserProfile[] };
+type Props = {
+  readonly group: Group;
+  readonly groupMemberProfiles: readonly SamwiseUserProfile[];
+};
 
-const GroupViewMiddleBar = ({ groupMemberProfiles }: Props): ReactElement => (
+const GroupViewMiddleBar = ({ groupMemberProfiles, group }: Props): ReactElement => (
   <div className={styles.MiddleBar}>
     <GroupViewMiddleBarTaskQueue />
-    <GroupViewMiddleBarPeopleList groupMemberProfiles={groupMemberProfiles} />
+    <GroupViewMiddleBarPeopleList group={group} groupMemberProfiles={groupMemberProfiles} />
   </div>
 );
 

--- a/frontend/src/components/GroupView/RightView/GroupTaskRow.module.scss
+++ b/frontend/src/components/GroupView/RightView/GroupTaskRow.module.scss
@@ -4,15 +4,10 @@
   margin-bottom: 1em;
 }
 
-.Initials {
+.ProfilePicGroupView {
   height: 56px;
   width: 56px;
-  border-radius: 50%;
-  background-color: #d7b6dc;
   text-align: center;
-  font-size: 22px;
-  line-height: 56px;
-  color: white;
   margin-top: auto;
   margin-bottom: auto;
   margin-right: 26px;

--- a/frontend/src/components/GroupView/RightView/GroupTaskRow.tsx
+++ b/frontend/src/components/GroupView/RightView/GroupTaskRow.tsx
@@ -4,10 +4,12 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Task } from 'common/types/store-types';
 import GroupTasksContainer from './GroupTasksContainer';
 import styles from './GroupTaskRow.module.scss';
+import ProfileImage from '../MiddleBar/ProfileImage';
 
 type Props = {
-  memberName: string;
+  readonly memberName: string;
   readonly tasks: readonly Task[];
+  readonly profilePicURL: string;
 };
 
 const clickAddGroupTask = (e: SyntheticEvent<HTMLElement>): void => {
@@ -21,12 +23,14 @@ const pressedAddGroupTask = (e: KeyboardEvent): void => {
   }
 };
 
-const GroupTaskRow = ({ tasks, memberName }: Props): ReactElement => {
-  const initials = `${memberName.split(' ')[0].charAt(0)}${memberName.split(' ')[1].charAt(0)}`;
-
+const GroupTaskRow = ({ tasks, memberName, profilePicURL }: Props): ReactElement => {
   return (
     <div className={styles.GroupTaskRow}>
-      <div className={styles.Initials}>{initials}</div>
+      <ProfileImage
+        className={styles.ProfilePicGroupView}
+        memberName={memberName}
+        imageURL={profilePicURL}
+      />
 
       <button
         type="button"

--- a/frontend/src/components/GroupView/RightView/index.tsx
+++ b/frontend/src/components/GroupView/RightView/index.tsx
@@ -31,13 +31,14 @@ const RightView = ({ group, groupMemberProfiles, tasks }: Props): ReactElement =
           <EditGroupNameIcon />
         </div>
         <div className={styles.GroupTaskRowContainer}>
-          {groupMemberProfiles.map((samwiseUserProfile) => {
-            const filteredTasks = tasks.filter((t) => t.owner === samwiseUserProfile.email);
+          {groupMemberProfiles.map(({ name, photoURL, email }) => {
+            const filteredTasks = tasks.filter((t) => t.owner === email);
             return (
               <GroupTaskRow
                 tasks={filteredTasks}
-                memberName={samwiseUserProfile.name}
-                key={samwiseUserProfile.email}
+                memberName={name}
+                profilePicURL={photoURL}
+                key={email}
               />
             );
           })}

--- a/frontend/src/components/GroupView/index.tsx
+++ b/frontend/src/components/GroupView/index.tsx
@@ -81,7 +81,7 @@ const GroupView = ({ group }: Props): ReactElement => {
 
   return (
     <div className={styles.GroupView}>
-      <MiddleBar groupMemberProfiles={groupMemberProfiles} />
+      <MiddleBar group={group} groupMemberProfiles={groupMemberProfiles} />
       <RightView group={group} groupMemberProfiles={groupMemberProfiles} tasks={groupTaskArray} />
     </div>
   );

--- a/frontend/src/components/GroupView/index.tsx
+++ b/frontend/src/components/GroupView/index.tsx
@@ -12,7 +12,10 @@ import RightView from './RightView';
 import styles from './index.module.scss';
 import { database } from '../../firebase/db';
 
-type Props = { readonly group: Group };
+type Props = {
+  readonly group: Group;
+  readonly changeView: (selectedGroup: string | undefined) => void;
+};
 
 const useGroupMemberProfiles = (
   groupMemberEmails: readonly string[]
@@ -49,7 +52,7 @@ const useGroupMemberProfiles = (
   return profiles.length === groupMemberEmails.length ? profiles : [];
 };
 
-const GroupView = ({ group }: Props): ReactElement => {
+const GroupView = ({ group, changeView }: Props): ReactElement => {
   const [groupTaskArray, setGroupTaskArray] = useState<Task[]>([]);
   useEffect(() => {
     database
@@ -81,7 +84,7 @@ const GroupView = ({ group }: Props): ReactElement => {
 
   return (
     <div className={styles.GroupView}>
-      <MiddleBar group={group} groupMemberProfiles={groupMemberProfiles} />
+      <MiddleBar group={group} groupMemberProfiles={groupMemberProfiles} changeView={changeView} />
       <RightView group={group} groupMemberProfiles={groupMemberProfiles} tasks={groupTaskArray} />
     </div>
   );

--- a/frontend/src/components/SideBar/AddGroupTags.module.scss
+++ b/frontend/src/components/SideBar/AddGroupTags.module.scss
@@ -7,8 +7,14 @@
 }
 
 .ClassItem {
+  background: none;
+  border-radius: 0 !important;
   display: flex;
-  padding: 0 0.5em;
+  font-size: 100%;
+  height: 34px !important;
+  margin: 0 !important;
+  padding-left: 10px;
+  width: 100% !important;
 }
 
 .ClassItem:first-of-type {
@@ -32,6 +38,7 @@
   border-radius: 50%;
   background-color: skyblue;
   position: relative;
+  margin-right: 8px;
   top: 5px;
 }
 

--- a/frontend/src/components/SideBar/AddGroupTags.tsx
+++ b/frontend/src/components/SideBar/AddGroupTags.tsx
@@ -1,14 +1,19 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 import { Tag } from 'common/types/store-types';
 import { store } from '../../store/store';
 import styles from './AddGroupTags.module.scss';
+import { createGroup } from '../../firebase/actions';
 
 type AddGroupTagsProps = {
   readonly show: boolean;
   readonly setShow: (show: boolean) => void;
 };
 
-export default function AddGroupTags({ show, setShow }: AddGroupTagsProps): React.ReactElement {
+function newGroup(classCode: string): void {
+  createGroup('default group name', new Date(), classCode);
+}
+
+export default function AddGroupTags({ show, setShow }: AddGroupTagsProps): ReactElement {
   const { tags } = store.getState();
   const classes: Tag[] = [];
   tags.forEach((t: Tag) => {
@@ -25,15 +30,19 @@ export default function AddGroupTags({ show, setShow }: AddGroupTagsProps): Reac
           onMouseEnter={() => setShow(true)}
           onMouseLeave={() => setShow(false)}
         >
-          {classes.map((t): React.ReactElement | undefined => (
-            <div key={t.name}>
-              {t.classId !== null && (
-                <div className={styles.ClassItem}>
-                  <div className={styles.Color} style={{ backgroundColor: t.color }}>
+          {classes.map(({ name, classId, color }): ReactElement | undefined => (
+            <div key={name}>
+              {classId !== null && (
+                <button
+                  type="button"
+                  className={styles.ClassItem}
+                  onClick={() => newGroup(name.split(':')[0])}
+                >
+                  <div className={styles.Color} style={{ backgroundColor: color }}>
                     {' '}
                   </div>
-                  <p>{t.name.split(':')[0]}</p>
-                </div>
+                  <p>{name.split(':')[0]}</p>
+                </button>
               )}
             </div>
           ))}

--- a/frontend/src/components/SideBar/AddGroupTags.tsx
+++ b/frontend/src/components/SideBar/AddGroupTags.tsx
@@ -10,7 +10,7 @@ type AddGroupTagsProps = {
 };
 
 function newGroup(classCode: string): void {
-  createGroup('default group name', new Date(), classCode);
+  createGroup('New group', new Date(), classCode);
 }
 
 export default function AddGroupTags({ show, setShow }: AddGroupTagsProps): ReactElement {

--- a/frontend/src/components/SideBar/AddGroupTags.tsx
+++ b/frontend/src/components/SideBar/AddGroupTags.tsx
@@ -10,7 +10,7 @@ type AddGroupTagsProps = {
 };
 
 function newGroup(classCode: string): void {
-  createGroup('New group', new Date(), classCode);
+  createGroup(`New ${classCode} Group`, new Date(), classCode);
 }
 
 export default function AddGroupTags({ show, setShow }: AddGroupTagsProps): ReactElement {
@@ -30,22 +30,25 @@ export default function AddGroupTags({ show, setShow }: AddGroupTagsProps): Reac
           onMouseEnter={() => setShow(true)}
           onMouseLeave={() => setShow(false)}
         >
-          {classes.map(({ name, classId, color }): ReactElement | undefined => (
-            <div key={name}>
-              {classId !== null && (
-                <button
-                  type="button"
-                  className={styles.ClassItem}
-                  onClick={() => newGroup(name.split(':')[0])}
-                >
-                  <div className={styles.Color} style={{ backgroundColor: color }}>
-                    {' '}
-                  </div>
-                  <p>{name.split(':')[0]}</p>
-                </button>
-              )}
-            </div>
-          ))}
+          {classes.map(({ name, classId, color }): ReactElement | undefined => {
+            const classCode = name.split(':')[0];
+            return (
+              <div key={name}>
+                {classId !== null && (
+                  <button
+                    type="button"
+                    className={styles.ClassItem}
+                    onClick={() => newGroup(classCode)}
+                  >
+                    <div className={styles.Color} style={{ backgroundColor: color }}>
+                      {' '}
+                    </div>
+                    <p>{classCode}</p>
+                  </button>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -447,7 +447,7 @@ export const leaveGroup = async (groupID: string): Promise<void> => {
     return;
   }
   const { email } = getAppUser();
-  const newMembers: string[] = members.filter((m: string) => m !== email);
+  const newMembers: string[] = members.filter((m) => m !== email);
   const groupDoc = await database.groupsCollection().doc(groupID);
   if (newMembers.length === 0) {
     await groupDoc.delete();

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -425,8 +425,9 @@ export const joinGroup = async (groupId: string, inviteID: string): Promise<void
 
 /**
  * Create a group.
- * @param groupID Document ID of the group's Firestore document. The user calling this function must
- *                be a member of this group.
+ * @param name The name of the group
+ * @param deadline Deadline for the group project
+ * @param classCode Class code for the class associated with the group
  */
 export const createGroup = (name: string, deadline: Date, classCode: string): void => {
   const { email } = getAppUser();


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request implements group creation, group leaving for a user's groups, and rendering profile pictures for group members in the UI. 

We create a group using the `createGroup` Firebase action in `actions.ts`, which correspond to each of the class ID picker buttons when hovering on the plus button on the left view switcher bar (this has already been implemented, but with no functionality). The default values chosen are a group `name` of `New group`, `deadline` of the current day, and `member` a singleton array of just the user who created it. For group leaving, we use the `leaveGroup` action, which is also fairly straightforward. However, we also want the page to rerender so that the group that we left is no longer displayed on the user's screen, so we need to lift state up by passing the `changeView` callback from `ViewSwitcher` down to the `GroupViewMiddleBarPeopleList`. Lastly, profile pictures are rendered using the data attached to each `SamwiseUserProfile` type, but a custom `ProfileImage` component has been defined so we can reuse it. Currently, the `ProfileImage` component is just a rounded image with no specified dimensions.

- [x] fixes #559 
- [x] implements profile picture rendering with custom component
- [x] implements group leaving and group creation functionality in the UI with respect to backend
- [x] accessibility improvement for class item picker when creating a group

### Test Plan <!-- Required -->

GIF of how you can test the changes in the frontend:

![gif](https://user-images.githubusercontent.com/7517829/95622621-dce3ca00-0a41-11eb-96e1-03d413f7659b.gif)

Correspondingly, you should see the side-effects of these changes in the Firestore.

### Notes <!-- Optional -->

For accessibility, I refactored the class ID picker for creating a group to be a `<button>` tag. This required overriding several default `<button>` styles, which is why I used `!important` in some of the CSS styles for the `ClassItem` class.

