### PR TITLE
Deploy Firestore rules

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -26,7 +26,7 @@ jobs:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         run: |
           ./node_modules/.bin/firebase use default
-          ./node_modules/.bin/firebase deploy --token=$FIREBASE_TOKEN --non-interactive --only hosting
+          ./node_modules/.bin/firebase deploy --token=$FIREBASE_TOKEN --non-interactive --only hosting,firestore:rules
       - name: Deploy Functions to Firebase Staging Project
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -28,5 +28,5 @@ jobs:
         run: |
           echo $PRODUCTION_FIREBASE_ADMIN_SDK_CONTENTS > functions/src/firebase-adminsdk.json
           ./node_modules/.bin/firebase use production
-          ./node_modules/.bin/firebase deploy --token=$FIREBASE_TOKEN --non-interactive --only hosting
+          ./node_modules/.bin/firebase deploy --token=$FIREBASE_TOKEN --non-interactive --only hosting,firestore:rules
           node ./deploy-functions.js $FIREBASE_TOKEN production

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,6 +1,6 @@
 service cloud.firestore {
   match /databases/{database}/documents {
-    function canCreate() {
+  	function canCreate() {
     	return request.resource.data.owner == request.auth.token.email;
     }
     function canReadWriteDelete() {
@@ -8,6 +8,9 @@ service cloud.firestore {
     }
     function canOperateOnEmailIdDocs(userEmail) {
     	return request.auth.token.email == userEmail;
+    }
+    function getGroupMembers(group){
+    	return get(/databases/$(database)/documents/samwise-groups/$(group)).data.members
     }
     match /samwise-order-manager/{userEmail} {
     	allow create, read, write, delete: if canOperateOnEmailIdDocs(userEmail)
@@ -24,19 +27,26 @@ service cloud.firestore {
     }
   	match /samwise-tasks/{task} {
     	allow create: if canCreate()
-    	allow read, write, delete: if canReadWriteDelete()
+    	allow read, write, delete: if canReadWriteDelete() 
+      	|| request.auth.token.email in getGroupMembers(resource.data.group);
     }
   	match /samwise-subtasks/{task} {
     	allow create: if canCreate()
     	allow read, write, delete: if canReadWriteDelete()
     }
-    match /samwise-groups/{group} {
-      allow create: if true
-      allow read, delete: if true
-    }
     match /samwise-group-pending-invites/{pendingInvite} {
       allow create: if request.auth.token.email in get(/databases/$(database)/documents/samwise-groups/$(request.resource.data.group)).data.members 
       allow read, delete: if request.auth.token.email == resource.data.invitee
+    }
+    match /samwise-groups/{group} {
+      allow create: if request.auth.uid != null
+      allow read, write, delete: if request.auth.uid != null 
+    }
+    match /samwise-users/{user} {
+      allow create: if canOperateOnEmailIdDocs(user);
+      allow get: if canOperateOnEmailIdDocs(user) 
+          || request.auth.token.email.matches('.*@cornell[.]edu');
+      allow write, delete: if canOperateOnEmailIdDocs(user);
     }
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -30,10 +30,6 @@ service cloud.firestore {
     	allow create: if canCreate()
     	allow read, write, delete: if canReadWriteDelete()
     }
-  	match /demo-comment-board/{comment} {
-    	allow create: if request.auth.uid != null
-    	allow read, write, delete: if request.auth.token.email == resource.data.author
-    }
     match /samwise-groups/{group} {
       allow create: if true
       allow read, delete: if true


### PR DESCRIPTION
### Summary
This PR adds deploying firestore rules as part of the CD process when we merge into staging/release. We want the [firestore.rules](https://github.com/cornell-dti/samwise/blob/master/firestore.rules) to be the single source of truth for security rules. Hopefully, this can prevent SEVs.

### Test Plan
I think we have a dummy rule for `demo-comment-board` that I deleted. If this works, on CD it should trigger a new firestore rules deploy which we can see on the dashboard.

### Notes
I got permission to steal this task from @jason-tung 
