### PR TITLE
Eliminate z-index: 0 and z-index: -1

### DIFF
--- a/frontend/src/components/TaskCreator/index.module.scss
+++ b/frontend/src/components/TaskCreator/index.module.scss
@@ -155,7 +155,6 @@
   cursor: pointer;
   margin: 0;
   font-size: 48px;
-  z-index: 0;
 }
 
 /*
@@ -322,5 +321,4 @@
   cursor: pointer;
   margin: 0;
   font-size: 48px;
-  z-index: 0;
 }

--- a/frontend/src/components/Util/AppInit/Login.module.scss
+++ b/frontend/src/components/Util/AppInit/Login.module.scss
@@ -126,7 +126,6 @@
   top: 0;
   width: 35%;
   min-width: 400px;
-  z-index: -1;
 }
 
 .LandingHeroLogin {
@@ -149,7 +148,6 @@
 .LandingBlue {
   position: absolute;
   top: -10vw;
-  z-index: -1;
 }
 
 .LandingLower {
@@ -184,7 +182,6 @@
   position: absolute;
   left: 5vw;
   width: 60vw;
-  z-index: 0;
 }
 
 .LandingFeatures {


### PR DESCRIPTION
### Summary <!-- Required -->

Let's ensure that we only use z-index when we really need them.

### Test Plan <!-- Required -->

Affected components look fine:

<img width="1323" alt="Screen Shot 2020-10-14 at 16 09 35" src="https://user-images.githubusercontent.com/4290500/96040228-f1580600-0e37-11eb-9c5e-8e384cb4c1f3.png">
<img width="1551" alt="Screen Shot 2020-10-14 at 16 09 42" src="https://user-images.githubusercontent.com/4290500/96040230-f1580600-0e37-11eb-97bd-8f0b97ac6036.png">
<img width="543" alt="Screen Shot 2020-10-14 at 16 10 54" src="https://user-images.githubusercontent.com/4290500/96040231-f1580600-0e37-11eb-89ef-0a37e27cce8c.png">
