### PR TITLE
Remove dead css code

### DIFF
--- a/frontend/src/components/SideBar/index.module.scss
+++ b/frontend/src/components/SideBar/index.module.scss
@@ -39,17 +39,6 @@
   margin-left: 0;
 }
 
-.AddGroup > div > p {
-  font-size: 8px;
-  line-height: 10px;
-  font-weight: normal;
-}
-
-.GroupIcons .AddGroup > p {
-  margin: 0;
-  font-size: 8px;
-}
-
 .PlusIcon {
   font-size: 3em;
 }


### PR DESCRIPTION
### Summary <!-- Required -->

It is not used anywhere to style anything.

The only place where `styles.AddGroup` appears is here:

https://github.com/cornell-dti/samwise/blob/54876502d725903f31f4183a016714405b856034/frontend/src/components/SideBar/index.tsx#L42-L49

Which doesn't contain any child `p`.

### Test Plan <!-- Required -->

Affected components still look fine.

<img width="90" alt="Screen Shot 2020-10-14 at 16 24 45" src="https://user-images.githubusercontent.com/4290500/96041455-de463580-0e39-11eb-97d7-482597838ceb.png">
<img width="112" alt="Screen Shot 2020-10-14 at 16 24 48" src="https://user-images.githubusercontent.com/4290500/96041456-de463580-0e39-11eb-92e8-26f58ac4cc2f.png">