### PR TITLE
Fix autosave functionality for group task

### DIFF
--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -157,7 +157,7 @@ function TaskEditor({
   }, [date, diff, id, reset, taskAppearedDate, type]);
 
   const onMouseLeave = (): void => {
-    if (type === 'ONE_TIME') {
+    if (type !== 'MASTER_TEMPLATE') {
       onSave();
     }
     if (onBlur) {


### PR DESCRIPTION
### Summary <!-- Required -->

#574 only removed the save button for group task but it didn't fix the logic for autosave. This diff fixes that.

### Test Plan <!-- Required -->

Broken on master:
![broken](https://user-images.githubusercontent.com/4290500/96069038-6264e100-0e6b-11eb-88ab-598e6a4660dd.gif)

Fixed in this diff:
![fixed](https://user-images.githubusercontent.com/4290500/96069043-6690fe80-0e6b-11eb-918b-eed40fd91342.gif)
