### PR TITLE
Avoid child selector for date picker save and cancel buttons

### DIFF
--- a/frontend/src/components/TaskCreator/DatePicker.tsx
+++ b/frontend/src/components/TaskCreator/DatePicker.tsx
@@ -435,11 +435,11 @@ export default function DatePicker(props: Props): ReactElement {
             />
           )}
           {internalDate.type !== 'normal' && openedRepeat}
-          <p className={styles.NewTaskDateSave}>
-            <button type="button" onClick={onCancel}>
+          <p className={styles.NewTaskDateCancelSaveButtonsContainer}>
+            <button type="button" className={styles.NewTaskDateCancelButton} onClick={onCancel}>
               Cancel
             </button>
-            <button type="button" onClick={onSubmit}>
+            <button type="button" className={styles.NewTaskDateSaveButton} onClick={onSubmit}>
               Done
             </button>
           </p>

--- a/frontend/src/components/TaskCreator/Picker.module.scss
+++ b/frontend/src/components/TaskCreator/Picker.module.scss
@@ -192,20 +192,22 @@
   color: rgba(150, 0, 0, 1);
 }
 
-.NewTaskDateSave {
+.NewTaskDateCancelSaveButtonsContainer {
   margin-top: 10px;
   margin-bottom: 0;
   text-align: right;
 }
 
-.NewTaskDateSave button {
+.NewTaskDateCancelButton {
   padding: 3px 10px;
   background: none;
   border-radius: 3px;
   border: none;
   cursor: pointer;
 }
-.NewTaskDateSave button:last-child {
+.NewTaskDateSaveButton {
+  @extend .NewTaskDateCancelButton;
+
   border: 1px black solid;
 }
 


### PR DESCRIPTION
### Summary <!-- Required -->

The child selectors can easily cause us to miss some dead css code, like #584. This diff replaces them with a css class for each container and button, so that it's less likely for us to miss dead css. It also helps to removes some css linter warnings :)

### Test Plan <!-- Required -->

Master:
<img width="838" alt="master" src="https://user-images.githubusercontent.com/4290500/96070154-a6f17c00-0e6d-11eb-8925-4ba069246654.png">
This diff:
<img width="850" alt="new" src="https://user-images.githubusercontent.com/4290500/96070148-a527b880-0e6d-11eb-85c1-dcce32fb9f68.png">

