### PR TITLE
Avoid css child selector for Tag and Date Display component

### DIFF
--- a/frontend/src/components/TaskCreator/DatePicker.tsx
+++ b/frontend/src/components/TaskCreator/DatePicker.tsx
@@ -114,7 +114,7 @@ export default function DatePicker(props: Props): ReactElement {
     const internal = isDefault ? (
       <>
         <span className={styles.DateDisplay}>
-          <SamwiseIcon iconName="calendar-light" className={styles.CenterIcon} />
+          <SamwiseIcon iconName="calendar-light" containerClassName={styles.CenterIcon} />
           &nbsp;add date&nbsp;
         </span>
       </>
@@ -122,7 +122,7 @@ export default function DatePicker(props: Props): ReactElement {
       <>
         <span className={styles.DateDisplay}>
           {!(date instanceof Date) && (
-            <SamwiseIcon iconName="repeat" className={dateStyles.RepeatIcon} />
+            <SamwiseIcon iconName="repeat" containerClassName={dateStyles.RepeatIcon} />
           )}
           {date instanceof Date ? date2String(date) : ` ${genNextValidDay(date.pattern.bitSet)}`}
         </span>

--- a/frontend/src/components/TaskCreator/Picker.module.scss
+++ b/frontend/src/components/TaskCreator/Picker.module.scss
@@ -71,8 +71,8 @@
   align-items: center;
 }
 
-.TagDisplay > span,
-.DateDisplay > span {
+.CenterIcon,
+.RepeatIcon {
   display: flex;
 }
 
@@ -82,7 +82,6 @@
 }
 
 .CenterIcon {
-  display: inline;
   color: black;
 }
 

--- a/frontend/src/components/UI/SamwiseIcon.tsx
+++ b/frontend/src/components/UI/SamwiseIcon.tsx
@@ -45,6 +45,7 @@ type Props = {
   readonly iconName: IconName;
   readonly title?: string;
   readonly className?: string;
+  readonly containerClassName?: string;
   readonly style?: CSSProperties;
   readonly tabIndex?: number;
   readonly onClick?: () => void;
@@ -53,6 +54,7 @@ type Props = {
 const SamwiseIcon = ({
   iconName,
   className,
+  containerClassName,
   style,
   tabIndex,
   title,
@@ -205,6 +207,7 @@ const SamwiseIcon = ({
   return (
     <span
       role="button"
+      className={containerClassName}
       title={title ?? altText}
       tabIndex={0}
       onClick={onClick}


### PR DESCRIPTION
### Summary <!-- Required -->

This usage of css child selector is particularly bad. It's actually acting on the `SamwiseIcon`'s `span` container. It's bad because it assumes the implementation detail of its child component, which makes components more tightly coupled.

This diff makes `SamwiseIcon`'s span container css class overridable, so we no longer need this hack.

### Test Plan <!-- Required -->

master:
<img width="506" alt="master" src="https://user-images.githubusercontent.com/4290500/96071025-567b1e00-0e6f-11eb-8f99-fceb0c4ffee2.png">

this diff:
<img width="503" alt="this" src="https://user-images.githubusercontent.com/4290500/96071026-5713b480-0e6f-11eb-8795-1ceeffd86b6b.png">

### Notes <!-- Optional -->

Q: Who created this bad css code?
A: It's me in #518. 😅 
