### PR TITLE
Implement group task sidebar icon colors from course IDs

### DIFF
--- a/frontend/src/components/SideBar/GroupIcon.module.scss
+++ b/frontend/src/components/SideBar/GroupIcon.module.scss
@@ -1,7 +1,6 @@
 @import '../../colors.scss';
 
 .GroupIcon {
-  background: $aqua;
   line-height: 44px;
   text-align: center;
   font-size: 32px;

--- a/frontend/src/components/SideBar/GroupIcon.tsx
+++ b/frontend/src/components/SideBar/GroupIcon.tsx
@@ -1,21 +1,41 @@
 import React, { ReactElement } from 'react';
+import { connect } from 'react-redux';
+import { State, Tag } from 'common/types/store-types';
+import { NONE_TAG } from 'common/util/tag-util';
 import { Views } from './types';
 import styles from './GroupIcon.module.scss';
+import { getOrderedTags } from '../../store/selectors';
 
-type Props = {
+type OwnProps = {
   classCode: string;
   handleClick: (selectedView: Views, selectedGroup: string | undefined, e?: KeyboardEvent) => void;
   selected: boolean;
 };
 
-const GroupIcon = ({ classCode, handleClick, selected }: Props): ReactElement => (
-  <button
-    type="button"
-    onClick={() => handleClick('group', classCode)}
-    className={styles.GroupIcon + (selected ? ` ${styles.Active}` : '')}
-  >
-    {classCode.charAt(0)}
-  </button>
-);
+type Props = OwnProps & { readonly tags: Tag[] };
 
-export default GroupIcon;
+const GroupIcon = ({ classCode, handleClick, selected, tags }: Props): ReactElement => {
+  const currentClassTag =
+    tags.find(({ classId }) => {
+      const segments = classId !== null ? classId.split(/\s+/) : null;
+      if (segments === null) {
+        return false;
+      }
+      const classIdWithoutNumerical = `${segments[1]} ${segments[2]}`;
+      return classIdWithoutNumerical === classCode;
+    }) ?? NONE_TAG;
+  const { color } = currentClassTag;
+  return (
+    <button
+      type="button"
+      onClick={() => handleClick('group', classCode)}
+      className={styles.GroupIcon + (selected ? ` ${styles.Active}` : '')}
+      style={{ background: color }}
+    >
+      {classCode.charAt(0)}
+    </button>
+  );
+};
+
+const Connected = connect((state: State) => ({ tags: getOrderedTags(state) }))(GroupIcon);
+export default Connected;


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request implements group task sidebar icon colors as in the Figma design [here](https://www.figma.com/file/MoF3jQ5hQ9dT76iZ57i9VN/Group-Work?node-id=878%3A3099). Previously, groups all had the same color, but this can help users disambiguate different classes with the same subject. This required a refactor of GroupIcon to get the specific tag from the course ID from the Redux store and extract the color of the tag for it. Course IDs for Tag objects are in the form `{some number} {subject} {class number}`, but the `classCode` given to the `GroupIcon` is only `{subject} {class number}`. We split the string to compare only the subject and class number to try and match the tag to a course, and update the group icon background color accordingly.

- [x] implemented colors for group icons based on corresponding class tag colors from the user

### Test Plan <!-- Required -->

![image](https://user-images.githubusercontent.com/7517829/96078792-508e3880-0e81-11eb-9131-e4e44997d06d.png)

Enable group tasks in the GateKeeper. Then create some groups for your classes, and see that the group icons match the colors of the tags in personal view for the same classes.
