### PR TITLE
Move blanket button styling of settings page to SettingButton css

### DIFF
--- a/frontend/src/components/SideBar/index.module.scss
+++ b/frontend/src/components/SideBar/index.module.scss
@@ -65,11 +65,6 @@
   text-align: center;
 }
 
-.Links button {
-  background: none;
-  cursor: pointer;
-}
-
 .Links {
   position: absolute;
   bottom: 0;

--- a/frontend/src/components/TitleBar/Settings/SettingsButton.module.scss
+++ b/frontend/src/components/TitleBar/Settings/SettingsButton.module.scss
@@ -1,3 +1,12 @@
+.SettingsButtonContainer {
+  display: inline-block;
+
+  & button {
+    background: none;
+    cursor: pointer;
+  }
+}
+
 .CloseButton {
   position: absolute;
   top: 32px;

--- a/frontend/src/components/TitleBar/Settings/SettingsButton.tsx
+++ b/frontend/src/components/TitleBar/Settings/SettingsButton.tsx
@@ -10,7 +10,7 @@ export default function SettingsButton(): ReactElement {
   const closeModal = (): void => setShowSettings(false);
 
   return (
-    <div style={{ display: 'inline-block' }}>
+    <div className={styles.SettingsButtonContainer}>
       <button type="submit" onClick={displayModal} className={styles.SettingsButton}>
         <p style={{ transform: 'scale(2)translateY(-5px)' }} title="Settings Button">
           <SamwiseIcon iconName="settings" />

--- a/frontend/src/components/TitleBar/Settings/__snapshots__/SettingsButton.test.tsx.snap
+++ b/frontend/src/components/TitleBar/Settings/__snapshots__/SettingsButton.test.tsx.snap
@@ -2,11 +2,7 @@
 
 exports[`SettingsButton matches snapshot. 1`] = `
 <div
-  style={
-    Object {
-      "display": "inline-block",
-    }
-  }
+  className="SettingsButtonContainer"
 >
   <button
     className="SettingsButton"

--- a/frontend/src/components/TitleBar/index.module.scss
+++ b/frontend/src/components/TitleBar/index.module.scss
@@ -33,8 +33,3 @@
 .Links {
   float: right;
 }
-
-.Links button {
-  background: none;
-  cursor: pointer;
-}


### PR DESCRIPTION
### Summary <!-- Required -->

We shouldn't do this kind of blanket button styling at all, since it affects too many buttons at once. However, we are already stuck with this for a long time and it's already affecting too many buttons. :(

This diff tries to mitigate the problem by moving two same instances of this blanket button styling into 1SettingButton.module.css`, so that this kind of bad styling practice only appears once, so it will be easier to us to fix them in the future. It also helps to remove another `no-descending-specificity` css warning.

### Test Plan <!-- Required -->

master:
<img width="1792" alt="master" src="https://user-images.githubusercontent.com/4290500/96181977-d0a8b280-0f02-11eb-9224-3ecac2c6d8dd.png">

current:
<img width="1792" alt="this" src="https://user-images.githubusercontent.com/4290500/96181991-d30b0c80-0f02-11eb-9a48-256119e91c39.png">
