### PR TITLE
Support editing group name

### DIFF
--- a/frontend/src/ViewSwitcher.tsx
+++ b/frontend/src/ViewSwitcher.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import type { Group, State } from 'common/types/store-types';
+import type { State } from 'common/types/store-types';
 import { useSelector } from 'react-redux';
 import SideBar from './components/SideBar';
 import PersonalView from './PersonalView';
@@ -10,20 +10,17 @@ import styles from './App.module.scss';
 const ViewSwitcher = (): React.ReactElement => {
   const groups = useSelector((state: State) => Array.from(state.groups.values()));
 
-  const [group, setGroup] = useState<Group | undefined>();
-
-  const changeView = (selectedGroupID?: string | undefined): void => {
-    setGroup(groups.find((oneGroup) => oneGroup.id === selectedGroupID));
-  };
+  const [selectedGroupID, setSelectedGroupID] = useState<string | undefined>();
+  const selectedGroup = groups.find((oneGroup) => oneGroup.id === selectedGroupID);
 
   return (
     <div className={styles.GroupScreen}>
-      <SideBar groups={groups} changeView={changeView} />
+      <SideBar groups={groups} changeView={setSelectedGroupID} />
       <div className={styles.GroupScreenContent}>
-        {group === undefined ? (
+        {selectedGroup === undefined ? (
           <PersonalView />
         ) : (
-          <GroupView group={group} changeView={changeView} />
+          <GroupView group={selectedGroup} changeView={setSelectedGroupID} />
         )}
       </div>
     </div>

--- a/frontend/src/components/GroupView/RightView/index.module.scss
+++ b/frontend/src/components/GroupView/RightView/index.module.scss
@@ -10,8 +10,9 @@
   clear: both;
 }
 
-.EditGroupNameIcon :hover {
+.EditGroupNameIcon:hover {
   cursor: pointer;
+  opacity: 0.8;
 }
 
 .GroupTaskRowContainer {

--- a/frontend/src/components/GroupView/RightView/index.tsx
+++ b/frontend/src/components/GroupView/RightView/index.tsx
@@ -4,6 +4,8 @@ import SamwiseIcon from '../../UI/SamwiseIcon';
 import GroupTaskRow from './GroupTaskRow';
 import styles from './index.module.scss';
 import TaskCreator from '../../TaskCreator';
+import { promptTextInput } from '../../Util/Modals';
+import { updateGroup } from '../../../firebase/actions';
 
 type Props = {
   readonly group: Group;
@@ -11,24 +13,26 @@ type Props = {
   readonly tasks: readonly Task[];
 };
 
-const EditGroupNameIcon = (): ReactElement => {
-  const handler = (): void => {
-    console.log('edit group');
-  };
-  return <SamwiseIcon iconName="pencil" className={styles.EditGroupNameIcon} onClick={handler} />;
-};
-
 const RightView = ({ group, groupMemberProfiles, tasks }: Props): ReactElement => {
+  const onEditGroupNameClicked = (): void => {
+    promptTextInput('Edit your group name', '', 'New Group Name', 'Submit', 'text').then((name) =>
+      updateGroup({ ...group, name })
+    );
+  };
+
   return (
     <div className={styles.RightView}>
       <div className={styles.GroupTaskCreator}>
         <TaskCreator view="group" group={group.name} />
       </div>
-
       <div className={styles.RightView}>
         <div>
           <h2>{group.name}</h2>
-          <EditGroupNameIcon />
+          <SamwiseIcon
+            iconName="pencil"
+            className={styles.EditGroupNameIcon}
+            onClick={onEditGroupNameClicked}
+          />
         </div>
         <div className={styles.GroupTaskRowContainer}>
           {groupMemberProfiles.map(({ name, photoURL, email }) => {

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -11,6 +11,7 @@ import {
   TaskMetadata,
   RepeatingTaskMetadata,
   OneTimeTaskMetadata,
+  Group,
 } from 'common/types/store-types';
 import { error, ignore } from 'common/util/general-util';
 import {
@@ -455,6 +456,10 @@ export const leaveGroup = async (groupID: string): Promise<void> => {
   } else {
     await groupDoc.update({ members: newMembers });
   }
+};
+
+export const updateGroup = async ({ id, ...groupInformation }: Group): Promise<void> => {
+  await database.groupsCollection().doc(id).update(groupInformation);
 };
 
 /**


### PR DESCRIPTION
### Summary <!-- Required -->

This diff added the support for editing group name. The [design](https://www.figma.com/file/MoF3jQ5hQ9dT76iZ57i9VN/Group-Work?node-id=878%3A820) doesn't seem to tell us how it should look, so I decided to go with the prompt modal first. We already have a prompt framework setup, so even if we don't end up using prompt for name edit, we still don't waste too many time on the UI code.

It turns out that the code for ViewSelector also needs some revision. Right now we store the entire group object in the state. This is bad because when the group from firestore changes, we will end up storing an stale value. Thus, I changed it to store selected group id instead, so that when content of the group updates (e.g. name), it will correctly trigger an rerender.

### Test Plan <!-- Required -->

![edit](https://user-images.githubusercontent.com/4290500/96184479-89bcbc00-0f06-11eb-8950-03eaadf2870a.gif)

### Note

You can easily see that there is a flash in the test plan. This is not caused by this diff but instead by some bad setup that caused react to fail to cache the data between rerenders. An interest problem to solve for next week if anyone wants to take the challenge.