### PR TITLE
Update course-info script for FA20 semifinal data

### DIFF
--- a/course-info/src/fetch-exam.ts
+++ b/course-info/src/fetch-exam.ts
@@ -3,7 +3,7 @@ import { JSDOM } from 'jsdom';
 import { ExamInfo } from './types';
 
 const prelimUrl = 'https://registrar.cornell.edu/exams/fall-prelim-exam-schedule';
-const finalUrl = 'https://registrar.cornell.edu/calendars-exams/semifinal-exam-schedule';
+const semiFinalUrl = 'https://registrar.cornell.edu/calendars-exams/semifinal-exam-schedule';
 
 const currentYear = new Date().getFullYear();
 
@@ -33,7 +33,7 @@ function parsePrelimLine(line: string): ExamInfo {
   };
 }
 
-function parseFinalLine(line: string): ExamInfo {
+function parseSemiFinalLine(line: string): ExamInfo {
   // Adapted for FA20 semifinals.
   const segments = line.split(/\s+/);
   const subject = segments[0];
@@ -71,7 +71,7 @@ function parseFinalLine(line: string): ExamInfo {
   };
 }
 
-function getExamInfoList(rawText: string, isFinal: boolean): readonly ExamInfo[] {
+function getExamInfoList(rawText: string, isSemiFinal: boolean): readonly ExamInfo[] {
   const lines = rawText.split('\n');
   const infoList: ExamInfo[] = [];
   for (let i = 0; i < lines.length; i += 1) {
@@ -82,7 +82,7 @@ function getExamInfoList(rawText: string, isFinal: boolean): readonly ExamInfo[]
       !line.startsWith('final exam') &&
       !line.startsWith('Course')
     ) {
-      const info = isFinal ? parseFinalLine(line) : parsePrelimLine(line);
+      const info = isSemiFinal ? parseSemiFinalLine(line) : parsePrelimLine(line);
       infoList.push(info);
     }
   }
@@ -92,5 +92,6 @@ function getExamInfoList(rawText: string, isFinal: boolean): readonly ExamInfo[]
 const createJson = (url: string, isFinal: boolean): Promise<readonly ExamInfo[]> =>
   fetchExamText(url).then((rawText) => getExamInfoList(rawText, isFinal));
 
-export const createFinalJson = (): Promise<readonly ExamInfo[]> => createJson(finalUrl, true);
+export const createSemiFinalJson = (): Promise<readonly ExamInfo[]> =>
+  createJson(semiFinalUrl, true);
 export const createPrelimJson = (): Promise<readonly ExamInfo[]> => createJson(prelimUrl, false);

--- a/course-info/src/merge-json.ts
+++ b/course-info/src/merge-json.ts
@@ -62,7 +62,7 @@ async function main(): Promise<void> {
   const map = new Map<string, Course>();
   processCourseInfoJson(map, JSON.parse(readFileSync('fa20-courses.json', 'utf8')));
   // TODO: re-enable them when Cornell publishes finals (no idea when it will happen)
-  // processExamInfoJson(map, await createFinalJson(), 'final');
+  processExamInfoJson(map, await createFinalJson(), 'final');
   processExamInfoJson(map, await createPrelimJson(), 'prelim');
   const result = Array.from(map.values()).map((course) => course.plainJs);
   writeFileSync('fa20-courses-with-exams-min.json', JSON.stringify(result));

--- a/course-info/src/merge-json.ts
+++ b/course-info/src/merge-json.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync } from 'fs';
 import { CourseInfo, ExamInfo, ExamType, ExamTimeType, FullInfo } from './types';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { createFinalJson, createPrelimJson } from './fetch-exam';
+import { createSemiFinalJson, createPrelimJson } from './fetch-exam';
 
 class Course {
   public readonly examTimes: Map<number, ExamType> = new Map();
@@ -62,7 +62,7 @@ async function main(): Promise<void> {
   const map = new Map<string, Course>();
   processCourseInfoJson(map, JSON.parse(readFileSync('fa20-courses.json', 'utf8')));
   // TODO: re-enable them when Cornell publishes finals (no idea when it will happen)
-  processExamInfoJson(map, await createFinalJson(), 'final');
+  processExamInfoJson(map, await createSemiFinalJson(), 'semifinal');
   processExamInfoJson(map, await createPrelimJson(), 'prelim');
   const result = Array.from(map.values()).map((course) => course.plainJs);
   writeFileSync('fa20-courses-with-exams-min.json', JSON.stringify(result));

--- a/course-info/src/types.ts
+++ b/course-info/src/types.ts
@@ -12,7 +12,7 @@ export type ExamInfo = {
   readonly time: number;
 };
 
-export type ExamType = 'prelim' | 'final';
+export type ExamType = 'prelim' | 'final' | 'semifinal';
 
 export type ExamTimeType = { readonly type: ExamType; readonly time: number };
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This PR implements the final data parser, adjusted for the FA20 semifinal schedule released today [here](https://registrar.cornell.edu/calendars-exams/semifinal-exam-schedule). It has been adapted so that it fits this semester's current layout.

- [x] gets one step closer to getting rid of #510, but COVID sucks

### Test Plan <!-- Required -->

Run the bash script in `/course-info` by running `./run` in the directory. See that no errors occur. You can cross-check the generated .json file to see if the examTimes field for a certain class object is defined. For example, CS 3110 has a semifinal on Nov 18 at 7:30PM, and we can cross-check the Unix time to see it is the same date.

![image](https://user-images.githubusercontent.com/7517829/96205928-c05dfb00-0f35-11eb-8a4f-b02544ef1faf.png)

