### PR TITLE
Better data caching for group view

### DIFF
--- a/frontend/src/components/GroupView/index.tsx
+++ b/frontend/src/components/GroupView/index.tsx
@@ -24,11 +24,13 @@ const useGroupMemberProfiles = (
     {}
   );
 
+  const connectedGroupMemberEmail = groupMemberEmails.join(',');
+
   useEffect(() => {
     // When we are reaching this line, it either means that we are running the effect for the first
     // time, or because the group member list has changed, so we have to invalidate the cache.
     setEmailProfileMapping({});
-    const unsubscribers = groupMemberEmails.map((groupMemberEmail) =>
+    const unsubscribers = connectedGroupMemberEmail.split(',').map((groupMemberEmail) =>
       database
         .usersCollection()
         .doc(groupMemberEmail)
@@ -40,7 +42,7 @@ const useGroupMemberProfiles = (
         })
     );
     return () => unsubscribers.forEach((unsubscriber) => unsubscriber());
-  }, [groupMemberEmails]);
+  }, [connectedGroupMemberEmail]);
 
   const profiles = Object.entries(emailProfileMapping).map(([email, namePhoto]) => ({
     email,
@@ -54,31 +56,31 @@ const useGroupMemberProfiles = (
 
 const GroupView = ({ group, changeView }: Props): ReactElement => {
   const [groupTaskArray, setGroupTaskArray] = useState<Task[]>([]);
+  const groupID = group.id;
   useEffect(() => {
     database
       .tasksCollection()
       .where('type', '==', 'GROUP')
-      .where('group', '==', group.id)
-      .onSnapshot((s) => {
-        setGroupTaskArray([]);
+      .where('group', '==', groupID)
+      .onSnapshot((snapshot) => {
         // this is problematic because it does not account for subtasks yet
-        s.forEach((docSnapshot) => {
-          const docData = docSnapshot.data();
-          const task = {
-            ...docData,
-            id: docSnapshot.id,
-            metadata: {
-              type: 'GROUP',
-              date: docData.date.toDate(),
-              group: docData.group,
-            } as GroupTaskMetadata,
-            children: [] as readonly SubTask[],
-          } as Task;
-          // get rid of groupTaskArray from dependency array
-          setGroupTaskArray((ary) => [...ary, task]);
-        });
+        setGroupTaskArray(
+          snapshot.docs.map((docSnapshot) => {
+            const docData = docSnapshot.data();
+            return {
+              ...docData,
+              id: docSnapshot.id,
+              metadata: {
+                type: 'GROUP',
+                date: docData.date.toDate(),
+                group: docData.group,
+              } as GroupTaskMetadata,
+              children: [] as readonly SubTask[],
+            } as Task;
+          })
+        );
       });
-  }, [group]);
+  }, [groupID]);
 
   const groupMemberProfiles = useGroupMemberProfiles(group.members);
 


### PR DESCRIPTION
### Summary <!-- Required -->

This PR fixes the issue mentioned in #593. The reason for the flash is because we are doing a bad job with caching data.

- For fetching group task, we should directly use group id as the key for `useEffect` instead of the entire object, since we only care about the stable ID, not some irrelevant changes like group name.
- For fetching group members, we need to overcome the issue of member list not changing, but a changed group object created a new member list object with the exact same content. Therefore, I joined the member email list into string to make it usable as a stable key, to prevent unnecessary updates.

### Test Plan <!-- Required -->

no longer flashes

![test](https://user-images.githubusercontent.com/4290500/96208481-9c9db380-0f3b-11eb-80df-01e508d61c3c.gif)

### Notes <!-- Optional -->

@jason-tung since you write the original code for fetching group tasks.

