### PR TITLE
Add semifinal to exam + time type in frontend 

### DIFF
--- a/common/types/store-types.ts
+++ b/common/types/store-types.ts
@@ -127,7 +127,7 @@ export type Course = {
   readonly subject: string;
   readonly courseNumber: string;
   readonly title: string;
-  readonly examTimes: { readonly type: 'final' | 'prelim'; readonly time: number }[];
+  readonly examTimes: { readonly type: 'final' | 'prelim' | 'semifinal'; readonly time: number }[];
 };
 
 /**


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request adds semifinals as a type of exam paired with its time in the frontend so we can display it as imported exams.

### Test Plan <!-- Required -->

:eyes:
