### PR TITLE
Label semifinals correctly in the frontend

### DIFF
--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -648,7 +648,20 @@ export const importCourseExams = (): void => {
     }
     allCoursesWithId.forEach((course: Course) => {
       course.examTimes.forEach(({ type, time }) => {
-        const courseType = type === 'final' ? 'Final' : 'Prelim';
+        let courseType: string;
+        switch (type) {
+          case 'final':
+            courseType = 'Final';
+            break;
+          case 'prelim':
+            courseType = 'Prelim';
+            break;
+          case 'semifinal':
+            courseType = 'Semifinal';
+            break;
+          default:
+            throw new Error('Undefined course exam type');
+        }
         const examName = `${course.subject} ${course.courseNumber} ${courseType}`;
         const t = new Date(time);
         const filter = (task: Task): boolean => {


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This PR fixes error pointed out in this week's release #602 where semifinals were incorrectly labeled in the frontend.

### Test Plan <!-- Required -->

Check for semifinals to show up instead of "Prelim" when importing course exams.