### PR TITLE
Fix overdue alert style so it appears on task card

### DIFF
--- a/frontend/src/components/UI/OverdueAlert.module.scss
+++ b/frontend/src/components/UI/OverdueAlert.module.scss
@@ -1,7 +1,7 @@
 .OverdueAlertInTaskCard {
-  position: absolute;
+  position: relative;
   top: -5px;
-  right: -5px;
+  left: calc(100% - 20px);
   width: 2em;
   height: 2em;
   background-color: #d0021b;


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This PR fixes the overdue task `!` badge to place it in the top right again. This bug is currently in prod, so we should maybe consider releasing soon.

- [x] fixes #604

### Test Plan <!-- Required -->

Make a task and make it overdue. See that the warning symbol is now at the top right of the card. Check both group and personal view and see it works.
Before
![image](https://user-images.githubusercontent.com/7517829/96353566-40ea3c00-109b-11eb-8b4a-2659c71f2306.png)

After
![image](https://user-images.githubusercontent.com/7517829/96353569-46478680-109b-11eb-9ecc-0c9112426abb.png)
![image](https://user-images.githubusercontent.com/7517829/96353576-4fd0ee80-109b-11eb-8429-94fcbffe31da.png)

