### PR TITLE
Fix frontend task owner code to accomodate new owner schema

### DIFF
--- a/common/firebase/common-actions.ts
+++ b/common/firebase/common-actions.ts
@@ -19,7 +19,7 @@ export default class Actions {
     source: T
   ): Promise<T & FirestoreCommon> => {
     const order = await this.orderManager.allocateNewOrder(orderFor);
-    return { ...source, owner: this.getUserEmail(), order };
+    return { ...source, owner: [this.getUserEmail()], order };
   };
 
   /*
@@ -41,7 +41,7 @@ export default class Actions {
   removeTag = async (id: string): Promise<void> => {
     await this.database
       .tasksCollection()
-      .where('owner', '==', this.getUserEmail())
+      .where('owner', 'array-contains', this.getUserEmail())
       .where('tag', '==', id)
       .get()
       .then((s) => {

--- a/common/types/firestore-types.ts
+++ b/common/types/firestore-types.ts
@@ -2,7 +2,7 @@ import { firestore } from 'firebase/app';
 import { RepeatingPattern } from './store-types';
 
 export type FirestoreCommon = {
-  readonly owner: string;
+  readonly owner: string[];
   readonly order: number;
 };
 

--- a/common/types/firestore-types.ts
+++ b/common/types/firestore-types.ts
@@ -2,7 +2,7 @@ import { firestore } from 'firebase/app';
 import { RepeatingPattern } from './store-types';
 
 export type FirestoreCommon = {
-  readonly owner: string[];
+  readonly owner: readonly string[];
   readonly order: number;
 };
 

--- a/common/types/store-types.ts
+++ b/common/types/store-types.ts
@@ -63,7 +63,7 @@ export type TaskMetadata = OneTimeTaskMetadata | RepeatingTaskMetadata | GroupTa
 export type Task<M = TaskMetadata> = {
   readonly id: string;
   readonly order: number;
-  readonly owner: string[];
+  readonly owner: readonly string[];
   readonly name: string; // Example: "Task 1 name"
   readonly tag: string; // ID of the tag
   readonly complete: boolean;
@@ -73,7 +73,7 @@ export type Task<M = TaskMetadata> = {
 };
 
 export type MainTask = {
-  readonly owner: string[];
+  readonly owner: readonly string[];
   readonly name: string;
   readonly tag: string;
   readonly date: Date | RepeatingDate;

--- a/common/types/store-types.ts
+++ b/common/types/store-types.ts
@@ -63,7 +63,7 @@ export type TaskMetadata = OneTimeTaskMetadata | RepeatingTaskMetadata | GroupTa
 export type Task<M = TaskMetadata> = {
   readonly id: string;
   readonly order: number;
-  readonly owner: string;
+  readonly owner: string[];
   readonly name: string; // Example: "Task 1 name"
   readonly tag: string; // ID of the tag
   readonly complete: boolean;
@@ -73,7 +73,7 @@ export type Task<M = TaskMetadata> = {
 };
 
 export type MainTask = {
-  readonly owner: string;
+  readonly owner: string[];
   readonly name: string;
   readonly tag: string;
   readonly date: Date | RepeatingDate;

--- a/common/util/task-util.test.ts
+++ b/common/util/task-util.test.ts
@@ -13,7 +13,7 @@ const name = 'name';
 type MainTaskTestCommon = {
   readonly id: string;
   readonly order: number;
-  readonly owner: string;
+  readonly owner: string[];
   readonly name: string;
   readonly tag: string;
   readonly metadata: {
@@ -25,7 +25,7 @@ type MainTaskTestCommon = {
 const testTaskCommon: MainTaskTestCommon = {
   id: 'random-id',
   order,
-  owner: 'user',
+  owner: ['user'],
   name,
   tag: 'TAG',
   metadata: {

--- a/common/util/task-util.test.ts
+++ b/common/util/task-util.test.ts
@@ -13,7 +13,7 @@ const name = 'name';
 type MainTaskTestCommon = {
   readonly id: string;
   readonly order: number;
-  readonly owner: string[];
+  readonly owner: readonly string[];
   readonly name: string;
   readonly tag: string;
   readonly metadata: {

--- a/frontend/src/components/GroupView/RightView/index.tsx
+++ b/frontend/src/components/GroupView/RightView/index.tsx
@@ -64,7 +64,7 @@ const RightView = ({ group, groupMemberProfiles, tasks }: Props): ReactElement =
         </div>
         <div className={styles.GroupTaskRowContainer}>
           {groupMemberProfiles.map((user) => {
-            const filteredTasks = tasks.filter((t) => t.owner === user.email);
+            const filteredTasks = tasks.filter(({ owner }) => owner.includes(user.email));
             return (
               <GroupTaskRow
                 key={user.email}

--- a/frontend/src/components/TaskCreator/index.tsx
+++ b/frontend/src/components/TaskCreator/index.tsx
@@ -204,6 +204,7 @@ export class TaskCreator extends React.PureComponent<Props, State> {
     }
     this.setState({ owner: [e.currentTarget.value] });
   };
+
   /**
    * Edit the task name.
    *

--- a/frontend/src/components/TaskCreator/index.tsx
+++ b/frontend/src/components/TaskCreator/index.tsx
@@ -22,7 +22,7 @@ import styles from './index.module.scss';
 type SimpleTask = Omit<Task, 'type' | 'order' | 'children' | 'metadata'>;
 
 type State = SimpleTask & {
-  readonly owner: string;
+  readonly owner: string[];
   readonly member?: SamwiseUserProfile;
   readonly date: Date | RepeatingDate;
   readonly subTasks: SubTask[];
@@ -55,7 +55,7 @@ const PLACEHOLDER_TEXT = 'What do you have to do?';
  */
 const initialState = (): State => ({
   id: randomId(),
-  owner: '',
+  owner: [''],
   name: '',
   tag: NONE_TAG_ID, // the id of the None tag.
   member: undefined,
@@ -193,13 +193,17 @@ export class TaskCreator extends React.PureComponent<Props, State> {
    */
 
   /**
-   * Edit the owner.
+   * Edit the owner for a personal task.
    *
    * @param {string} member the new owner.
    */
-  private editOwner = (e: SyntheticEvent<HTMLInputElement>): void =>
-    this.setState({ owner: e.currentTarget.value });
-
+  private editOwner = (e: SyntheticEvent<HTMLInputElement>): void => {
+    const { owner } = this.state;
+    if (owner.length > 1) {
+      throw new Error('editOwner should only be used for personal tasks');
+    }
+    this.setState({ owner: [e.currentTarget.value] });
+  };
   /**
    * Edit the task name.
    *

--- a/frontend/src/components/TaskCreator/index.tsx
+++ b/frontend/src/components/TaskCreator/index.tsx
@@ -22,7 +22,7 @@ import styles from './index.module.scss';
 type SimpleTask = Omit<Task, 'type' | 'order' | 'children' | 'metadata'>;
 
 type State = SimpleTask & {
-  readonly owner: string[];
+  readonly owner: readonly string[];
   readonly member?: SamwiseUserProfile;
   readonly date: Date | RepeatingDate;
   readonly subTasks: SubTask[];

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -50,14 +50,14 @@ const actions = new Actions(() => getAppUser().email, database);
 async function createFirestoreObject<T>(
   orderFor: 'tags' | 'tasks',
   source: T,
-  owner: string
+  owner: string[]
 ): Promise<T & FirestoreCommon> {
   const order = await actions.orderManager.allocateNewOrder(orderFor);
   return { ...source, owner, order };
 }
 
-const mergeWithOwner = <T>(obj: T): T & { readonly owner: string } => ({
-  owner: getAppUser().email,
+const mergeWithOwner = <T>(obj: T): T & { readonly owner: string[] } => ({
+  owner: [getAppUser().email],
   ...obj,
 });
 
@@ -99,7 +99,7 @@ export const removeTag = (id: string): void => {
 
 const asyncAddTask = async (
   newTaskId: string,
-  owner: string,
+  owner: string[],
   task: TaskWithoutIdOrderChildren,
   subTasks: WithoutId<SubTask>[],
   batch: WriteBatch
@@ -120,11 +120,11 @@ const asyncAddTask = async (
 };
 
 export const addTask = (
-  owner: string,
+  owner: string[],
   task: TaskWithoutIdOrderChildren,
   subTasks: WithoutId<SubTask>[]
 ): void => {
-  const taskOwner = owner === '' ? getAppUser().email : owner;
+  const taskOwner = owner === [''] ? [getAppUser().email] : owner;
   const newTaskId = getNewTaskId();
   const batch = db().batch();
   asyncAddTask(newTaskId, taskOwner, task, subTasks, batch).then(({ createdSubTasks }) => {
@@ -259,8 +259,7 @@ export const forkTaskWithDiff = (
   });
   const batch = database.db().batch();
   const forkId = getNewTaskId();
-  // owner = '' for non-group tasks, so owner is set to the logged-in user
-  const owner = getAppUser().email;
+  const owner = [getAppUser().email];
   asyncAddTask(forkId, owner, newMainTask, newSubTasks, batch).then(() => {
     batch.update(database.tasksCollection().doc(id), {
       forks: firestore.FieldValue.arrayUnion({ forkId, replaceDate }),
@@ -683,7 +682,7 @@ export const importCourseExams = (): void => {
         };
         if (!Array.from(tasks.values()).some(filter)) {
           const newTask: TaskWithoutIdOrderChildren<OneTimeTaskMetadata> = {
-            owner: getAppUser().email,
+            owner: [getAppUser().email],
             name: examName,
             tag: tag.id,
             complete: false,

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -50,7 +50,7 @@ const actions = new Actions(() => getAppUser().email, database);
 async function createFirestoreObject<T>(
   orderFor: 'tags' | 'tasks',
   source: T,
-  owner: string[]
+  owner: readonly string[]
 ): Promise<T & FirestoreCommon> {
   const order = await actions.orderManager.allocateNewOrder(orderFor);
   return { ...source, owner, order };
@@ -99,7 +99,7 @@ export const removeTag = (id: string): void => {
 
 const asyncAddTask = async (
   newTaskId: string,
-  owner: string[],
+  owner: readonly string[],
   task: TaskWithoutIdOrderChildren,
   subTasks: WithoutId<SubTask>[],
   batch: WriteBatch
@@ -120,7 +120,7 @@ const asyncAddTask = async (
 };
 
 export const addTask = (
-  owner: string[],
+  owner: readonly string[],
   task: TaskWithoutIdOrderChildren,
   subTasks: WithoutId<SubTask>[]
 ): void => {

--- a/frontend/src/firebase/listeners.ts
+++ b/frontend/src/firebase/listeners.ts
@@ -42,16 +42,18 @@ type UnmountCallback = () => void;
 const listenTagsChange = (
   email: string,
   listener: (snapshot: QuerySnapshot) => void
-): UnmountCallback => database.tagsCollection().where('owner', '==', email).onSnapshot(listener);
+): UnmountCallback =>
+  database.tagsCollection().where('owner', 'array-contains', email).onSnapshot(listener);
 const listenTasksChange = (
   email: string,
   listener: (snapshot: QuerySnapshot) => void
-): UnmountCallback => database.tasksCollection().where('owner', '==', email).onSnapshot(listener);
+): UnmountCallback =>
+  database.tasksCollection().where('owner', 'array-contains', email).onSnapshot(listener);
 const listenSubTasksChange = (
   email: string,
   listener: (snapshot: QuerySnapshot) => void
 ): UnmountCallback =>
-  database.subTasksCollection().where('owner', '==', email).onSnapshot(listener);
+  database.subTasksCollection().where('owner', 'array-contains', email).onSnapshot(listener);
 const listenSettingsChange = (
   email: string,
   listener: (snapshot: DocumentSnapshot) => void

--- a/frontend/src/store/reducers.test.ts
+++ b/frontend/src/store/reducers.test.ts
@@ -10,7 +10,7 @@ it('reducer works: new task creation -> subtask creation', () => {
       {
         id: '1',
         order: 4,
-        owner: 'foo',
+        owner: ['foo'],
         name: 'test',
         tag: 'foo',
         complete: true,
@@ -80,7 +80,7 @@ it('reducer works: subtask creation -> new task creation', () => {
       {
         id: '1',
         order: 4,
-        owner: 'foo',
+        owner: ['foo'],
         name: 'test',
         tag: 'foo',
         complete: true,
@@ -111,7 +111,7 @@ it('reducer works, task edit -> subtask creation', () => {
       {
         id: 'foo',
         order: 1,
-        owner: 'foo',
+        owner: ['foo'],
         name: 'Foo',
         tag: 'foo',
         complete: true,
@@ -161,7 +161,7 @@ it('reducer works, subtask creation -> task edit', () => {
       {
         id: 'foo',
         order: 1,
-        owner: 'foo',
+        owner: ['foo'],
         name: 'Foo',
         tag: 'foo',
         complete: true,

--- a/frontend/src/store/state.ts
+++ b/frontend/src/store/state.ts
@@ -39,7 +39,7 @@ export const initialStateForTesting: State = {
     foo: {
       id: 'foo',
       order: 1,
-      owner: 'foo',
+      owner: ['foo'],
       name: 'Foo',
       tag: 'foo',
       complete: true,
@@ -53,7 +53,7 @@ export const initialStateForTesting: State = {
     bar: {
       id: 'bar',
       order: 2,
-      owner: 'foo',
+      owner: ['foo'],
       name: 'Bar',
       tag: 'bar',
       complete: false,
@@ -67,7 +67,7 @@ export const initialStateForTesting: State = {
     baz: {
       id: 'baz',
       order: 3,
-      owner: 'foo',
+      owner: ['foo'],
       name: 'Baz',
       tag: 'baz',
       complete: true,

--- a/functions/src/iCalFunctions.ts
+++ b/functions/src/iCalFunctions.ts
@@ -35,18 +35,21 @@ export function parseICal(link: string, user: string): void {
             .get()
             .then(async (querySnapshot: QuerySnapshot) => {
               if (querySnapshot.size === 0) {
-                await db.tasksCollection().doc(taskID).set({
-                  children: [],
-                  complete: false,
-                  date: endDate,
-                  inFocus: false,
-                  name: taskName,
-                  order,
-                  owner: user,
-                  tag: 'THE_GLORIOUS_NONE_TAG',
-                  type: 'ONE_TIME',
-                  icalUID: uid,
-                });
+                await db
+                  .tasksCollection()
+                  .doc(taskID)
+                  .set({
+                    children: [],
+                    complete: false,
+                    date: endDate,
+                    inFocus: false,
+                    name: taskName,
+                    order,
+                    owner: [user],
+                    tag: 'THE_GLORIOUS_NONE_TAG',
+                    type: 'ONE_TIME',
+                    icalUID: uid,
+                  });
               } else {
                 querySnapshot.forEach((doc: DocumentSnapshot) => {
                   db.tasksCollection().doc(doc.id).update({


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request fixes relevant code in the frontend and in functions that considers task owners to be strings rather than string arrays. We created the script in #607 to run on all tasks in the db and change the owners to singleton string arrays instead of strings, and this corresponding PR allows for the data from the backend to be displayed correctly.

- [x] second part of fixing #581 

### Test Plan <!-- Required -->
Review this PR carefully and run the script from #607. If the changes happen as expected in the Firestore, we can merge this in after. See that functionality is preserved as it was for personal view and everything.

### Notes
The default value of `owner` for a task used to be the empty string `''`, but is now `['']`.

### Breaking Changes  <!-- Optional -->

This is a breaking change as it changes the default value of owners in tasks, and how owners are handled in the frontend.