### PR TITLE
Adopt tssa 0.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "devDependencies": {
     "@babel/core": "^7.11.4",
-    "@dev-sam/tssa": "^0.0.9",
+    "@dev-sam/tssa": "^0.0.10",
     "@types/jest": "^26.0.10",
     "@types/node": "^13.7.0",
     "@typescript-eslint/eslint-plugin": "^3.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1302,10 +1302,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@dev-sam/tssa@^0.0.9":
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/@dev-sam/tssa/-/tssa-0.0.9.tgz#5adbb0372c5466f6afe1b0c65a0fa2efc3365ed3"
-  integrity sha512-s7uk5nLNoNS9NRJkClJUid/CJlKjCB5qUom37v9ht5x1Yu/woCcGYQZBsDV7XQi1EMpruVHUF6o65yL2BEJdAQ==
+"@dev-sam/tssa@^0.0.10":
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/@dev-sam/tssa/-/tssa-0.0.10.tgz#7dcfefaad54e71400c36a567779c4744ee938285"
+  integrity sha512-m8OAuKbAIg9N1S8i8pli07FvDVO9LJ7LYBvvdjhjbUzvDfFZEfSZNwA/Lt9D55wWWkeuAslIJ62ttFl3fUDXyg==
   dependencies:
     "@octokit/rest" "^18.0.6"
     "@types/diff" "^4.0.2"


### PR DESCRIPTION
### Summary <!-- Required -->

Adopt new tssa that gets rid of noisy css change report and make change reports more succinct.

It makes the change reports more succinct by only report direct affects if the reference tree is linear. In this case it's safe to only report the direct reference, since this is the only place we need to look into and test.

### Test Plan <!-- Required -->

#### Test 1

Running `git diff 0d12e77b 55e1d3ad | yarn tssa` (change in #608) gives us:

```
Your changes in `frontend/src/components/GroupView/RightView/index.tsx` will directly affect: `frontend/src/components/GroupView/index.tsx`

Your changes in `frontend/src/components/TaskCreator/index.tsx` may directly affect:

> `frontend/src/PersonalView.tsx`
> `frontend/src/components/GroupView/RightView/index.tsx`

Your changes in `frontend/src/firebase/actions.ts` may directly affect:

> `frontend/src/components/TaskCreator/index.tsx`
> `frontend/src/components/Util/TaskEditors/TaskEditor/MainTaskEditor.tsx`
> `frontend/src/components/TaskView/FutureView/FutureViewTask.tsx`
> `frontend/src/components/TaskView/FutureView/index.tsx`
> `frontend/src/components/Util/TaskEditors/TaskEditor/OneSubTaskEditor.tsx`
> `frontend/src/components/TaskView/FutureView/FutureViewSubTask.tsx`
> `frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx`
> `frontend/src/components/TitleBar/Settings/SettingsPage.tsx`
> `frontend/src/components/TitleBar/Onboarding/Onboard.tsx`

Your changes in `frontend/src/firebase/listeners.ts` will directly affect: `frontend/src/components/Util/AppInit/LoginBarrier.tsx`

Your changes in `frontend/src/store/state.ts` will directly affect: `frontend/src/store/store.ts`

Your changes in `functions/src/iCalFunctions.ts` will directly affect: `functions/src/index.ts`
```

You can see that the report list is much shorter.

#### Test 2

Make a random change in `EditorHeader.tsx` and run tssa on this change, we get:

```
Your changes in `frontend/src/components/Util/TaskEditors/TaskEditor/EditorHeader.tsx` may directly affect: `frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx`.

It will also affect the following files. Make sure you fully test those changes!

> `frontend/src/components/Util/TaskEditors/InlineTaskEditor.tsx`
> `frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx`
```

You can see that tssa is doing smart things. Although `InlineTaskEditor` and `FloatingTaskEditor` do not directly use `EditorHeader`, it can still detect this transitive usage and correctly report that `EditorHeader` is potentially used in several places, which reminds us to test the changes in all those places.