### PR TITLE
Fix frontend to work as expected after Task owner migration

### DIFF
--- a/common/firebase/common-actions.ts
+++ b/common/firebase/common-actions.ts
@@ -19,7 +19,10 @@ export default class Actions {
     source: T
   ): Promise<T & FirestoreCommon> => {
     const order = await this.orderManager.allocateNewOrder(orderFor);
-    return { ...source, owner: [this.getUserEmail()], order };
+    if (orderFor === 'tasks') {
+      return { ...source, owner: [this.getUserEmail()], order };
+    }
+    return { ...source, owner: this.getUserEmail(), order };
   };
 
   /*

--- a/common/types/firestore-types.ts
+++ b/common/types/firestore-types.ts
@@ -2,7 +2,7 @@ import { firestore } from 'firebase/app';
 import { RepeatingPattern } from './store-types';
 
 export type FirestoreCommon = {
-  readonly owner: readonly string[];
+  readonly owner: string | readonly string[];
   readonly order: number;
 };
 

--- a/common/util/general-util.test.ts
+++ b/common/util/general-util.test.ts
@@ -31,4 +31,6 @@ it('shallowArrayEqualWorks', () => {
   ).toBeTruthy();
   expect(shallowArrayEqual([{ foo: 'bar', bar: 'foo' }], [])).toBeFalsy();
   expect(shallowArrayEqual([{ foo: 'bar', bar: 'foo' }], [{ foo: 'bar' }])).toBeFalsy();
+  expect(shallowArrayEqual([''], [''])).toBeTruthy();
+  expect(shallowArrayEqual([3, 4, 5, 6], [3, 4, 7, 3])).toBeFalsy();
 });

--- a/common/util/general-util.test.ts
+++ b/common/util/general-util.test.ts
@@ -31,6 +31,4 @@ it('shallowArrayEqualWorks', () => {
   ).toBeTruthy();
   expect(shallowArrayEqual([{ foo: 'bar', bar: 'foo' }], [])).toBeFalsy();
   expect(shallowArrayEqual([{ foo: 'bar', bar: 'foo' }], [{ foo: 'bar' }])).toBeFalsy();
-  expect(shallowArrayEqual([''], [''])).toBeTruthy();
-  expect(shallowArrayEqual([3, 4, 5, 6], [3, 4, 7, 3])).toBeFalsy();
 });

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,7 +1,10 @@
 service cloud.firestore {
   match /databases/{database}/documents {
   	function canCreate() {
-    	return request.auth.token.email in request.resource.data.owner || request.auth.token.email == request.resource.data.owner;
+    	return request.resource.data.owner == request.auth.token.email;
+    }
+    function canCreateTask() {
+    	return request.auth.token.email in request.resource.data.owner;
     }
     function canReadWriteDelete() {
     	return request.auth.token.email in resource.data.owner || request.auth.token.email == resource.data.owner;
@@ -26,7 +29,7 @@ service cloud.firestore {
     	allow read, write, delete: if canReadWriteDelete()
     }
   	match /samwise-tasks/{task} {
-    	allow create: if canCreate()
+    	allow create: if canCreateTask()
     	allow read, write, delete: if canReadWriteDelete()
       	|| request.auth.token.email in getGroupMembers(resource.data.group);
     }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,10 +1,10 @@
 service cloud.firestore {
   match /databases/{database}/documents {
   	function canCreate() {
-    	return request.resource.data.owner == request.auth.token.email;
+    	return request.auth.token.email in request.resource.data.owner || request.auth.token.email == request.resource.data.owner;
     }
     function canReadWriteDelete() {
-    	return request.auth.token.email == resource.data.owner;
+    	return request.auth.token.email in resource.data.owner || request.auth.token.email == resource.data.owner;
     }
     function canOperateOnEmailIdDocs(userEmail) {
     	return request.auth.token.email == userEmail;
@@ -27,7 +27,7 @@ service cloud.firestore {
     }
   	match /samwise-tasks/{task} {
     	allow create: if canCreate()
-    	allow read, write, delete: if canReadWriteDelete() 
+    	allow read, write, delete: if canReadWriteDelete()
       	|| request.auth.token.email in getGroupMembers(resource.data.group);
     }
   	match /samwise-subtasks/{task} {
@@ -35,16 +35,16 @@ service cloud.firestore {
     	allow read, write, delete: if canReadWriteDelete()
     }
     match /samwise-group-pending-invites/{pendingInvite} {
-      allow create: if request.auth.token.email in get(/databases/$(database)/documents/samwise-groups/$(request.resource.data.group)).data.members 
+      allow create: if request.auth.token.email in get(/databases/$(database)/documents/samwise-groups/$(request.resource.data.group)).data.members
       allow read, delete: if request.auth.token.email == resource.data.invitee
     }
     match /samwise-groups/{group} {
       allow create: if request.auth.uid != null
-      allow read, write, delete: if request.auth.uid != null 
+      allow read, write, delete: if request.auth.uid != null
     }
     match /samwise-users/{user} {
       allow create: if canOperateOnEmailIdDocs(user);
-      allow get: if canOperateOnEmailIdDocs(user) 
+      allow get: if canOperateOnEmailIdDocs(user)
           || request.auth.token.email.matches('.*@cornell[.]edu');
       allow write, delete: if canOperateOnEmailIdDocs(user);
     }

--- a/frontend/src/components/TaskCreator/index.tsx
+++ b/frontend/src/components/TaskCreator/index.tsx
@@ -18,7 +18,6 @@ import GroupMemberPicker from './GroupMemberPicker';
 import { addTask, TaskWithoutIdOrderChildren } from '../../firebase/actions';
 import SamwiseIcon from '../UI/SamwiseIcon';
 import styles from './index.module.scss';
-import { getAppUser } from '../../firebase/auth-util';
 
 type SimpleTask = Omit<Task, 'type' | 'order' | 'children' | 'metadata'>;
 
@@ -144,9 +143,7 @@ export class TaskCreator extends React.PureComponent<Props, State> {
     if (e != null) {
       e.preventDefault();
     }
-
     const { owner, name, tag, date, complete, inFocus, subTasks } = this.state;
-
     if (name === '') {
       return;
     }

--- a/frontend/src/components/TaskCreator/index.tsx
+++ b/frontend/src/components/TaskCreator/index.tsx
@@ -18,6 +18,7 @@ import GroupMemberPicker from './GroupMemberPicker';
 import { addTask, TaskWithoutIdOrderChildren } from '../../firebase/actions';
 import SamwiseIcon from '../UI/SamwiseIcon';
 import styles from './index.module.scss';
+import { getAppUser } from '../../firebase/auth-util';
 
 type SimpleTask = Omit<Task, 'type' | 'order' | 'children' | 'metadata'>;
 
@@ -143,7 +144,9 @@ export class TaskCreator extends React.PureComponent<Props, State> {
     if (e != null) {
       e.preventDefault();
     }
+
     const { owner, name, tag, date, complete, inFocus, subTasks } = this.state;
+
     if (name === '') {
       return;
     }
@@ -191,19 +194,6 @@ export class TaskCreator extends React.PureComponent<Props, State> {
    * Part 3: Various Editors
    * --------------------------------------------------------------------------------
    */
-
-  /**
-   * Edit the owner for a personal task.
-   *
-   * @param {string} member the new owner.
-   */
-  private editOwner = (e: SyntheticEvent<HTMLInputElement>): void => {
-    const { owner } = this.state;
-    if (owner.length > 1) {
-      throw new Error('editOwner should only be used for personal tasks');
-    }
-    this.setState({ owner: [e.currentTarget.value] });
-  };
 
   /**
    * Edit the task name.

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -50,7 +50,7 @@ const actions = new Actions(() => getAppUser().email, database);
 async function createFirestoreObject<T>(
   orderFor: 'tags' | 'tasks',
   source: T,
-  owner: readonly string[]
+  owner: readonly string[] | string
 ): Promise<T & FirestoreCommon> {
   const order = await actions.orderManager.allocateNewOrder(orderFor);
   return { ...source, owner, order };
@@ -113,7 +113,7 @@ const asyncAddTask = async (
   });
   const subtaskIds = createdSubTasks.map((s) => s.id);
   const { metadata, ...rest } = task;
-  rest.owner = baseTask.owner;
+  rest.owner = baseTask.owner as readonly string[];
   const firestoreTask: FirestoreTask = { ...baseTask, ...rest, ...metadata, children: subtaskIds };
   batch.set(database.tasksCollection().doc(newTaskId), firestoreTask);
   return { firestoreTask, createdSubTasks };

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -56,8 +56,8 @@ async function createFirestoreObject<T>(
   return { ...source, owner, order };
 }
 
-const mergeWithOwner = <T>(obj: T): T & { readonly owner: string[] } => ({
-  owner: [getAppUser().email],
+const mergeWithOwner = <T>(obj: T): T & { readonly owner: string } => ({
+  owner: getAppUser().email,
   ...obj,
 });
 
@@ -124,7 +124,7 @@ export const addTask = (
   task: TaskWithoutIdOrderChildren,
   subTasks: WithoutId<SubTask>[]
 ): void => {
-  const taskOwner = owner === [''] ? [getAppUser().email] : owner;
+  const taskOwner = [''].toString() === owner.toString() ? [getAppUser().email] : owner;
   const newTaskId = getNewTaskId();
   const batch = db().batch();
   asyncAddTask(newTaskId, taskOwner, task, subTasks, batch).then(({ createdSubTasks }) => {


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

Merging in #607 and #608 and applying the Firebase function from #607 results in some issues. namely, the change to the `FirestoreCommon` type, which assumes that every firestore document now has an owner field of type `string[]`. However, this only applies to tasks - other entities will still have singular owners. As a result, subtasks and tags were not being shown.

This PR also introduces new security rules to fit the new `owner` definition for tasks, and fixes the `mergeWithOwner` function for subtasks, since subtasks still have singular owners.

- [x] fixes #581

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

See that frontend on staging should display everything as normally intended: subtasks for tasks with correct tags, group icons have the correct background colors:

![image](https://user-images.githubusercontent.com/7517829/96961027-c7ef4800-14d1-11eb-8619-a58c5777a240.png)

