### PR TITLE
Setup FirestoreDataConverter for samwise-settings collection

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "tsc --noEmit false"
+    "tsc": "tsc --noEmit",
+    "build": "yarn tsc"
   },
   "dependencies": {
     "firebase": "^7.21.0",

--- a/frontend/src/firebase/listeners.ts
+++ b/frontend/src/firebase/listeners.ts
@@ -55,7 +55,7 @@ const listenSubTasksChange = (
   database.subTasksCollection().where('owner', '==', email).onSnapshot(listener);
 const listenSettingsChange = (
   email: string,
-  listener: (snapshot: DocumentSnapshot) => void
+  listener: (snapshot: DocumentSnapshot<Settings>) => void
 ): UnmountCallback => database.settingsCollection().doc(email).onSnapshot(listener);
 const listenBannerMessageChange = (
   email: string,

--- a/functions/src/iCalFunctions.ts
+++ b/functions/src/iCalFunctions.ts
@@ -69,9 +69,10 @@ export default async function getICalLink(): Promise<void> {
     .settingsCollection()
     .where('canvasCalendar', '>', '')
     .get()
-    .then((querySnapshot: QuerySnapshot) => {
-      querySnapshot.forEach((doc: DocumentSnapshot) => {
-        const link: string = doc.data()?.canvasCalendar;
+    .then((querySnapshot) => {
+      querySnapshot.forEach((doc) => {
+        const link = doc.data()?.canvasCalendar;
+        if (link == null) return;
         try {
           parseICal(link, doc.id);
         } catch {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint:fix": "yarn lint:ts --fix",
     "format": "prettier --write '**/*.{ts,js,tsx,jsx,scss,css,html}'",
     "format:check": "prettier --check '**/*.{ts,js,tsx,jsx,scss,css,html}'",
+    "tsc": "yarn workspaces run tsc",
     "test": "env-cmd -f .env.testing jest",
     "tssa": "tssa common frontend functions"
   },


### PR DESCRIPTION
### Summary <!-- Required -->

Setup infra for using [`FirestoreDataConverter`](https://firebase.google.com/docs/reference/js/firebase.firestore.FirestoreDataConverter) to strictify the type enforcement when we are moving between firestore data and app data. Previous, this layer is horribly `any`-typed. This diff is the first step to change that.

To avoid large disruptions, I started with an easy target: `samwise-settings`. The schema for this collection is very simple, and it's not used very often.

### Test Plan <!-- Required -->

Go to staging to check that it still remembers that you finished onboarding tutorial, which shows that settings are not broken.