### PR TITLE
Unbreak course-info semifinal exam script for CS 2800

### DIFF
--- a/course-info/src/fetch-exam.ts
+++ b/course-info/src/fetch-exam.ts
@@ -39,7 +39,14 @@ function parseSemiFinalLine(line: string): ExamInfo {
   const subject = segments[0];
   const courseNumber = segments[1];
   const sectionNumber = segments[2];
-
+  if (subject === 'CS' && courseNumber === '2800') {
+    return {
+      subject,
+      courseNumber,
+      sectionNumber,
+      time: new Date(2020, 10, 17, 19, 30).getTime(),
+    };
+  }
   const dateFormat = segments[3];
   const dateData = dateFormat.split('-');
   let dateTimeString = '';


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This PR unbreaks the course exam script which was erroring on one line: CS 2800. This is because [the registrar](https://registrar.cornell.edu/calendars-exams/semifinal-exam-schedule) seems to have manually inputted this line without a hyphen in the date of the exam, which is different from the original format of each line. We hardcode the exam data for CS 2800 to avoid an error on that line.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
![image](https://user-images.githubusercontent.com/7517829/97092045-887a4600-160e-11eb-9262-2483931c3c5e.png)


### Notes <!-- Optional -->

lol
