### PR TITLE
Unbreak group task creation

### DIFF
--- a/frontend/src/components/GroupView/RightView/index.tsx
+++ b/frontend/src/components/GroupView/RightView/index.tsx
@@ -45,7 +45,7 @@ const RightView = ({ group, groupMemberProfiles, tasks }: Props): ReactElement =
       <div className={styles.GroupTaskCreator}>
         <TaskCreator
           view="group"
-          group={group.name}
+          group={group.id}
           groupMemberProfiles={groupMemberProfiles}
           taskCreatorOpened={taskCreatorOpened}
           assignedMember={assignedMember}


### PR DESCRIPTION
### Summary <!-- Required -->

We currently have a bug that let's you create a group task, but the group task just won't appear in your group view.
It's because we give an incorrect value for the `group` field in metatada. `group` should store group id instead of group name.

This diff fixes this issue.

### Test Plan <!-- Required -->

Add a group task in group view and it should appear in your group view.