### PR TITLE
Replace css-transform hack for TaskCreator position with flexbox

### DIFF
--- a/frontend/src/components/TaskCreator/index.module.scss
+++ b/frontend/src/components/TaskCreator/index.module.scss
@@ -1,8 +1,13 @@
+.TaskCreator {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+}
+
 .NewTaskComponent {
   border-top: none;
   border-left: none;
   border-right: none;
-  margin-top: 20px;
   bottom: 10px;
   width: 100%;
   padding: 10px 20px;
@@ -10,6 +15,10 @@
   background: #e3e3e3;
   font-size: 18px;
   font-family: 'Open Sans', sans-serif;
+
+  &.NewTaskComponentOpened {
+    margin-top: 20px;
+  }
 }
 
 .NewTaskComponent::placeholder {
@@ -25,9 +34,7 @@
 
 .NewTaskWrap {
   position: relative;
-  left: 50%;
   text-align: center;
-  transform: translateX(-50%);
   z-index: 5;
   bottom: 20px;
   height: initial;
@@ -300,9 +307,7 @@
 
 .GroupNewTaskWrap {
   position: relative;
-  left: 50%;
   text-align: center;
-  transform: translateX(-50%);
   z-index: 5;
   height: initial;
   max-height: 44px;

--- a/frontend/src/components/TaskCreator/index.tsx
+++ b/frontend/src/components/TaskCreator/index.tsx
@@ -91,14 +91,8 @@ export class TaskCreator extends React.PureComponent<Props, State> {
    * --------------------------------------------------------------------------------
    */
 
-  /**
-   * Open the new task editor.
-   */
   private openNewTask = (): void => this.setState({ opened: true });
 
-  /**
-   * Close (collapse) the new task editor.
-   */
   private closeNewTask = (): void => this.setState({ opened: false });
 
   /**
@@ -125,20 +119,12 @@ export class TaskCreator extends React.PureComponent<Props, State> {
    * --------------------------------------------------------------------------------
    */
 
-  /**
-   * Focus on the task name, if possible.
-   */
   private focusTaskName = (): void => {
     if (this.addTask) {
       this.addTask.focus();
     }
   };
 
-  /**
-   * Handle on potential save.
-   *
-   * @param e the event that signals a potential save action.
-   */
   private handleSave = (e?: SyntheticEvent<HTMLElement>): void => {
     if (e != null) {
       e.preventDefault();
@@ -192,27 +178,12 @@ export class TaskCreator extends React.PureComponent<Props, State> {
    * --------------------------------------------------------------------------------
    */
 
-  /**
-   * Edit the task name.
-   *
-   * @param e the event that contains the new task name.
-   */
   private editTaskName = (e: SyntheticEvent<HTMLInputElement>): void =>
     this.setState({ name: e.currentTarget.value }, this.focusTaskName);
 
-  /**
-   * Edit the tag.
-   *
-   * @param {string} tag the new tag.
-   */
   private editTag = (tag: string): void =>
     this.setState({ tag, tagPickerOpened: false }, this.focusTaskName);
 
-  /**
-   * Edit the member.
-   *
-   * @param {string} member the new member.
-   */
   private editMember = (member?: SamwiseUserProfile): void =>
     this.setState({ member, tagPickerOpened: false }, this.focusTaskName);
 
@@ -249,9 +220,6 @@ export class TaskCreator extends React.PureComponent<Props, State> {
     }
   };
 
-  /**
-   * Reset the date picker
-   */
   private clearDate = (): void => {
     this.setState(
       { date: new Date(), datePickerOpened: false, datePicked: false },
@@ -259,17 +227,8 @@ export class TaskCreator extends React.PureComponent<Props, State> {
     );
   };
 
-  /**
-   * Toggle the pin status.
-   * @param {boolean} inFocus the new in-focus status.
-   */
   private togglePin = (inFocus: boolean): void => this.setState({ inFocus }, this.focusTaskName);
 
-  /**
-   * Add a new subtask.
-   *
-   * @param e the event that contains the new name for new sub-task.
-   */
   private addNewSubTask = (e: SyntheticEvent<HTMLInputElement>): void => {
     const newSubTaskName = e.currentTarget.value;
     if (newSubTaskName === '') {
@@ -290,24 +249,12 @@ export class TaskCreator extends React.PureComponent<Props, State> {
     }));
   };
 
-  /**
-   * Handle a keypress event in a new subtask box.
-   * It can potentially make the form to lose focus to exit.
-   *
-   * @param e the event that contains the key pressed in the new subtask input box.
-   */
   private newSubTaskKeyPress = (e: KeyboardEvent<HTMLInputElement>): void => {
     if (e.key === 'Tab') {
       this.closeNewTask();
     }
   };
 
-  /**
-   * Edit a subtask.
-   *
-   * @param subTaskId id of the subtask to edit.
-   * @return the event handler.
-   */
   private editSubTask = (subTaskId: string) => (e: SyntheticEvent<HTMLInputElement>) => {
     const name = e.currentTarget.value;
     this.setState(({ subTasks }: State) => ({
@@ -315,23 +262,12 @@ export class TaskCreator extends React.PureComponent<Props, State> {
     }));
   };
 
-  /**
-   * Potentially submit a subtask.
-   *
-   * @param e the keyboard event.
-   */
   private submitSubTask = (e: KeyboardEvent<HTMLInputElement>): void => {
     if (e.key === 'Enter') {
       this.handleSave();
     }
   };
 
-  /**
-   * Delete a subtask.
-   *
-   * @param {string} subtaskId id of the subtask to delete.
-   * @return {Function<SyntheticEvent<HTMLInputElement>, void>} the event handler.
-   */
   private deleteSubTask = (subtaskId: string) => (e: SyntheticEvent<HTMLButtonElement>) => {
     e.preventDefault();
     this.setState(({ subTasks }: State) => ({
@@ -339,9 +275,6 @@ export class TaskCreator extends React.PureComponent<Props, State> {
     }));
   };
 
-  /**
-   * Reset the task.
-   */
   private resetTask = (): void => this.setState({ ...initialState() }, this.focusTaskName);
 
   /**
@@ -477,15 +410,15 @@ export class TaskCreator extends React.PureComponent<Props, State> {
 
   public render(): ReactElement {
     const { name, opened } = this.state;
-    const toggleDisplayStyle = opened ? {} : { display: 'none' };
-    const { theme, view } = this.props;
+    const { theme, view, taskCreatorOpened } = this.props;
+    const isOpen = opened || taskCreatorOpened;
     return (
       <div className={styles.TaskCreator} style={theme === 'dark' ? this.darkModeStyle : undefined}>
         <div
           onClick={this.closeNewTask}
           role="presentation"
           className={styles.CloseNewTask}
-          style={toggleDisplayStyle}
+          style={isOpen ? {} : { display: 'none' }}
         />
         <form
           className={view === 'personal' ? styles.NewTaskWrap : styles.GroupNewTaskWrap}
@@ -497,7 +430,11 @@ export class TaskCreator extends React.PureComponent<Props, State> {
             type="text"
             value={name}
             onChange={this.editTaskName}
-            className={styles.NewTaskComponent}
+            className={
+              isOpen
+                ? `${styles.NewTaskComponent} ${styles.NewTaskComponentOpened}`
+                : styles.NewTaskComponent
+            }
             placeholder={opened ? '' : PLACEHOLDER_TEXT}
             ref={(e) => {
               this.addTask = e;


### PR DESCRIPTION
### Summary <!-- Required -->

The existing code use `left: 50%; transformX: -50%` just to center the task creator 🤦 .
This is terrible and it needs to be replaced by flexbox based solutions.

### Test Plan <!-- Required -->

personal view: still correctly centered.
<img width="1792" alt="Screen Shot 2020-10-24 at 17 04 36" src="https://user-images.githubusercontent.com/4290500/97093565-0d6b5c80-161b-11eb-8aa8-fcd539f68ef3.png">

group view: still correctly centered.
<img width="1792" alt="Screen Shot 2020-10-24 at 17 04 39" src="https://user-images.githubusercontent.com/4290500/97093566-0e03f300-161b-11eb-8893-07d4d4aef5de.png">

personal view: opened task creator looks fine.
<img width="1792" alt="Screen Shot 2020-10-24 at 17 04 42" src="https://user-images.githubusercontent.com/4290500/97093567-0e03f300-161b-11eb-8d04-0d3e84391aa3.png">

group view: opened task creator looks fine.
<img width="1792" alt="Screen Shot 2020-10-24 at 17 04 44" src="https://user-images.githubusercontent.com/4290500/97093568-0e03f300-161b-11eb-8d0a-abf9a7e399f6.png">

### Notes

Also deleted a bunch of useless jsdoc while I'm working on that file.