### PR TITLE
Fix Task Tag Text Size

### DIFF
--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.module.scss
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.module.scss
@@ -110,7 +110,6 @@ img.TaskEditorIcon:focus,
 
 .TaskEditorTag {
   margin-left: 0.5em;
-  font: 1.3em 'Open Sans', sans-serif;
   padding: 5px;
   border-radius: 2px;
   color: white;


### PR DESCRIPTION
### Summary
We have a regression in some release where the task tag text just got bigger. Looks to be due to [this line](https://github.com/cornell-dti/samwise/blob/68ac210a35dff04d1f89473252ff147320b19a42/frontend/src/components/Util/TaskEditors/TaskEditor/index.module.scss#L113) in TaskEditorTag introduced by #594. Not sure why it was added but removing it doesn't break anything in group/personal view and reverts the task tag to the intended size 🤷🏻‍♀️

### Test Plan

Before:
<img width="400px" alt="prod" src="https://user-images.githubusercontent.com/20008134/97382910-c68f9800-18a2-11eb-837a-012168982105.png">

After:
<img width="400px" alt="dev" src="https://user-images.githubusercontent.com/20008134/97382948-d9a26800-18a2-11eb-8c31-d56a87cd937f.png">
