### PR TITLE
Tasks now show up in task queue in group view

### DIFF
--- a/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarTaskQueue.module.scss
+++ b/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarTaskQueue.module.scss
@@ -1,5 +1,5 @@
 .TaskQueue {
-  height: 60% !important;
+  height: 60%;
 }
 
 .TaskQueue h2 {

--- a/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarTaskQueue.module.scss
+++ b/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarTaskQueue.module.scss
@@ -3,8 +3,8 @@
 }
 
 .TaskQueue h2 {
-  font-weight: bold !important;
-  color: #818181 !important;
+  font-weight: bold;
+  color: #818181;
 }
 
 .EmptyTaskQueue {

--- a/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarTaskQueue.module.scss
+++ b/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarTaskQueue.module.scss
@@ -1,10 +1,10 @@
 .TaskQueue {
-  height: 60%;
+  height: 60% !important;
 }
 
 .TaskQueue h2 {
-  font-weight: bold;
-  color: #818181;
+  font-weight: bold !important;
+  color: #818181 !important;
 }
 
 .EmptyTaskQueue {
@@ -29,4 +29,7 @@
 .EmptyTaskQueue button:hover {
   cursor: pointer;
   opacity: 0.7;
+}
+.Container {
+  overflow-y: scroll;
 }

--- a/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarTaskQueue.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarTaskQueue.tsx
@@ -1,5 +1,12 @@
-import React from 'react';
+import React, { ReactNode, ReactElement } from 'react';
+
+import { Task } from 'common/types/store-types';
 import styles from './GroupViewMiddleBarTaskQueue.module.scss';
+import GroupTask from '../RightView/GroupTask';
+
+type Props = {
+  readonly tasks: readonly Task[];
+};
 
 const EmptyTaskQueue = (): React.ReactElement => (
   <div className={styles.EmptyTaskQueue}>
@@ -7,11 +14,22 @@ const EmptyTaskQueue = (): React.ReactElement => (
     <button type="button">Add task</button>
   </div>
 );
-
-const TaskQueue = (): React.ReactElement => (
-  <div className={styles.TaskQueue}>
-    <h2>Task Queue</h2>
-    <EmptyTaskQueue />
+function renderTaskList(tasks: readonly Task[]): ReactNode {
+  return tasks.map((task) => <GroupTask key={task.id} original={task} memberName="" />);
+}
+const TaskQueue = ({ tasks }: Props): React.ReactElement => (
+  <div>
+    {tasks.length > 0 ? (
+      <div className={styles.Container}>
+        <h2>Task Queue</h2>
+        {renderTaskList(tasks)}
+      </div>
+    ) : (
+      <div className={styles.TaskQueue}>
+        <h2>Task Queue</h2>
+        <EmptyTaskQueue />
+      </div>
+    )}
   </div>
 );
 

--- a/frontend/src/components/GroupView/MiddleBar/index.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/index.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
 import { Group, SamwiseUserProfile, Task } from 'common/types/store-types';
+import { getAppUser } from '../../../firebase/auth-util';
 
 import GroupViewMiddleBarPeopleList from './GroupViewMiddleBarPeopleList';
 import GroupViewMiddleBarTaskQueue from './GroupViewMiddleBarTaskQueue';
@@ -7,7 +8,7 @@ import styles from './index.module.scss';
 
 type Props = {
   readonly group: Group;
-  readonly groupMemberProfiles: SamwiseUserProfile[];
+  readonly groupMemberProfiles: readonly SamwiseUserProfile[];
   readonly changeView: (selectedGroup: string | undefined) => void;
   readonly tasks: readonly Task[];
 };
@@ -18,9 +19,8 @@ const GroupViewMiddleBar = ({
   changeView,
   tasks,
 }: Props): ReactElement => {
-  const allInfo: any = localStorage.getItem('firebaseui::rememberedAccounts');
-  const allInfoJSON = JSON.parse(allInfo);
-  const { email } = allInfoJSON[0];
+  const { email } = getAppUser();
+
   return (
     <div>
       {groupMemberProfiles.map(() => {

--- a/frontend/src/components/GroupView/MiddleBar/index.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/index.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Group, SamwiseUserProfile } from 'common/types/store-types';
+import { Group, SamwiseUserProfile, Task } from 'common/types/store-types';
 
 import GroupViewMiddleBarPeopleList from './GroupViewMiddleBarPeopleList';
 import GroupViewMiddleBarTaskQueue from './GroupViewMiddleBarTaskQueue';
@@ -7,19 +7,37 @@ import styles from './index.module.scss';
 
 type Props = {
   readonly group: Group;
-  readonly groupMemberProfiles: readonly SamwiseUserProfile[];
+  readonly groupMemberProfiles: SamwiseUserProfile[];
   readonly changeView: (selectedGroup: string | undefined) => void;
+  readonly tasks: readonly Task[];
 };
 
-const GroupViewMiddleBar = ({ groupMemberProfiles, group, changeView }: Props): ReactElement => (
-  <div className={styles.MiddleBar}>
-    <GroupViewMiddleBarTaskQueue />
-    <GroupViewMiddleBarPeopleList
-      group={group}
-      groupMemberProfiles={groupMemberProfiles}
-      changeView={changeView}
-    />
-  </div>
-);
+const GroupViewMiddleBar = ({
+  groupMemberProfiles,
+  group,
+  changeView,
+  tasks,
+}: Props): ReactElement => {
+  const allInfo: any = localStorage.getItem('firebaseui::rememberedAccounts');
+  const allInfoJSON = JSON.parse(allInfo);
+  const { email } = allInfoJSON[0];
+  return (
+    <div>
+      {groupMemberProfiles.map(() => {
+        const filteredTasks = tasks.filter(({ owner }) => owner.includes(email));
+        return (
+          <div className={styles.MiddleBar}>
+            <GroupViewMiddleBarTaskQueue tasks={filteredTasks} />
+            <GroupViewMiddleBarPeopleList
+              group={group}
+              groupMemberProfiles={groupMemberProfiles}
+              changeView={changeView}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+};
 
 export default GroupViewMiddleBar;

--- a/frontend/src/components/GroupView/index.tsx
+++ b/frontend/src/components/GroupView/index.tsx
@@ -84,7 +84,12 @@ const GroupView = ({ group, changeView }: Props): ReactElement => {
 
   return (
     <div className={styles.GroupView}>
-      <MiddleBar group={group} groupMemberProfiles={groupMemberProfiles} changeView={changeView} />
+      <MiddleBar
+        group={group}
+        groupMemberProfiles={groupMemberProfiles}
+        changeView={changeView}
+        tasks={groupTaskArray}
+      />
       <RightView group={group} groupMemberProfiles={groupMemberProfiles} tasks={groupTaskArray} />
     </div>
   );


### PR DESCRIPTION
### Summary <!-- Required -->

Tasks now show up in task queue in group view. Only the tasks for the user that is logged in show up in the task queue. 

If task is deleted from task queue, task gets deleted from right side and vice-versa. Additionally, when a new task is created for a user, it automatically gets added to the task queue. 


- [x] tasks show up in task queue


### Test Plan <!-- Required -->
One task assigned to the user logged in: 
<img width="513" alt="Screen Shot 2020-10-30 at 5 53 11 PM" src="https://user-images.githubusercontent.com/20613939/97760118-d1337280-1ad8-11eb-945c-6c4d2a205a17.png">
<img width="281" alt="Screen Shot 2020-10-30 at 5 53 07 PM" src="https://user-images.githubusercontent.com/20613939/97760125-d395cc80-1ad8-11eb-8dae-2fb6a8601fa7.png">

No tasks assigned to logged in user: 
<img width="569" alt="Screen Shot 2020-10-30 at 5 52 53 PM" src="https://user-images.githubusercontent.com/20613939/97760136-d85a8080-1ad8-11eb-96d2-ca265114e765.png">
<img width="278" alt="Screen Shot 2020-10-30 at 5 52 41 PM" src="https://user-images.githubusercontent.com/20613939/97760138-da244400-1ad8-11eb-8495-5cb80cbc262d.png">

Many tasks assigned to user: 
<img width="281" alt="Screen Shot 2020-10-30 at 5 52 18 PM" src="https://user-images.githubusercontent.com/20613939/97760143-dc869e00-1ad8-11eb-9bb7-5cd4304f5b66.png">

<!-- Provide screenshots or point out the additional unit tests -->


