### PR TITLE
Unbreak getDateWithDateString to fix #624

### DIFF
--- a/common/util/datetime-util.test.ts
+++ b/common/util/datetime-util.test.ts
@@ -1,4 +1,10 @@
-import { day2String, isToday, getTodayAtZeroAM, getDateAfterXWeeks } from './datetime-util';
+import {
+  day2String,
+  isToday,
+  getTodayAtZeroAM,
+  getDateWithDateString,
+  getDateAfterXWeeks,
+} from './datetime-util';
 
 it('day2String works', () => {
   expect(day2String(0)).toBe('SUN');
@@ -20,6 +26,13 @@ it('getTodayAtZeroAM works', () => {
   expect(t.getMinutes()).toBe(0);
   expect(t.getSeconds()).toBe(0);
   expect(t.getMilliseconds()).toBe(0);
+});
+
+it('getDateWithDateString works', () => {
+  const date = getDateWithDateString(null, 'Tue Nov 03 2020');
+  expect(date.getFullYear()).toBe(2020);
+  expect(date.getMonth()).toBe(10);
+  expect(date.getDate()).toBe(3);
 });
 
 it('getDateAfterXWeeks works', () => {

--- a/common/util/datetime-util.ts
+++ b/common/util/datetime-util.ts
@@ -87,6 +87,7 @@ export function getDateWithDateString(date: Date | null, dateString: string): Da
   const newDate = date === null ? new Date() : new Date(date);
   const dateInfo = new Date(dateString);
   newDate.setFullYear(dateInfo.getFullYear());
+  newDate.setDate(1);
   newDate.setMonth(dateInfo.getMonth());
   newDate.setDate(dateInfo.getDate());
   if (date === null) {


### PR DESCRIPTION
### Summary <!-- Required -->

It turns out that `getDateWithDateString` has never been correct. It's always slightly wrong in some weird ways. This is what happens:

https://github.com/cornell-dti/samwise/blob/72aeb1ddc75401244758d090f9c0c1f8d400807c/common/util/datetime-util.ts#L86-L97

Today is Oct 31. Assume we want to set date for a time string `'Tue Nov 03 2020'`.
When we call `date.setMonth(10)`, the following things might be happening under the hood:

1. JS figure out that we need to move one month forward.
2. However, after we move one month forward, we landed in Nov. 31, which doesn't make sense.
3. To fix this, JS turns Nov. 31 into Dec 1.

Then when we set the date, we got this epic OFF-BY-ONE-MONTH error 😱 , which is the underlying cause of #624.

This diff tries to `setDate(1)` first to avoid this kind of tricky conversion. In the long term, we should really consider using a datetime library.

### Test Plan <!-- Required -->

`yarn test`. The added test will fail before this change.