### PR TITLE
Do not share code between isOpen and !isOpen for TaskCreator

### DIFF
--- a/frontend/src/components/TaskCreator/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/TaskCreator/__snapshots__/index.test.tsx.snap
@@ -4,16 +4,6 @@ exports[`TaskCreator matches snapshot 1`] = `
 <div
   className="TaskCreator"
 >
-  <div
-    className="CloseNewTask"
-    onClick={[Function]}
-    role="presentation"
-    style={
-      Object {
-        "display": "none",
-      }
-    }
-  />
   <form
     className="NewTaskWrap"
     onFocus={[Function]}

--- a/frontend/src/components/TaskCreator/index.tsx
+++ b/frontend/src/components/TaskCreator/index.tsx
@@ -75,19 +75,14 @@ export class TaskCreator extends React.PureComponent<Props, State> {
 
   private addTask: HTMLInputElement | null | undefined;
 
-  private darkModeStyle: CSSProperties;
-
-  constructor(props: Props) {
-    super(props);
-    this.darkModeStyle = {
-      background: 'black',
-      color: 'white',
-    };
-  }
-
   private get isOpen(): boolean {
     // eslint-disable-next-line react/destructuring-assignment
     return this.state.opened || this.props.taskCreatorOpened || false;
+  }
+
+  private get darkModeStyle(): CSSProperties | undefined {
+    const { theme } = this.props;
+    return theme === 'dark' ? { background: 'black', color: 'white' } : undefined;
   }
 
   /*
@@ -287,11 +282,8 @@ export class TaskCreator extends React.PureComponent<Props, State> {
    *
    * @return the rendered other info editor.
    */
-  private renderOtherInfoEditor(): ReactElement | null {
+  private renderOtherInfoEditor(): ReactElement {
     const { view, groupMemberProfiles, assignedMember, clearAssignedMember } = this.props;
-    if (!this.isOpen) {
-      return null;
-    }
     const {
       tag,
       member,
@@ -303,7 +295,6 @@ export class TaskCreator extends React.PureComponent<Props, State> {
       datePicked,
       needToSwitchFocus,
     } = this.state;
-    const { theme } = this.props;
     const existingSubTaskEditor = (
       { id, name }: SubTask,
       i: number,
@@ -326,7 +317,7 @@ export class TaskCreator extends React.PureComponent<Props, State> {
             value={name}
             onChange={this.editSubTask(id)}
             onKeyDown={this.submitSubTask}
-            style={theme === 'dark' ? this.darkModeStyle : undefined}
+            style={this.darkModeStyle}
           />
         </li>
       );
@@ -344,10 +335,7 @@ export class TaskCreator extends React.PureComponent<Props, State> {
           <div className={styles.DescText}>
             <p>Add optional subtasks to break down your tasks into more manageable pieces.</p>
           </div>
-          <div
-            className={styles.NewTaskModal}
-            style={theme === 'dark' ? this.darkModeStyle : undefined}
-          >
+          <div className={styles.NewTaskModal} style={this.darkModeStyle}>
             <div className={styles.SubtasksContainer}>
               <ul className={styles.SubtasksList}>{subTasks.map(existingSubTaskEditor)}</ul>
               <SamwiseIcon iconName="edit" className={styles.EditIcon} tabIndex={-1} />
@@ -358,7 +346,7 @@ export class TaskCreator extends React.PureComponent<Props, State> {
                 value=""
                 onChange={this.addNewSubTask}
                 onKeyDown={this.newSubTaskKeyPress}
-                style={theme === 'dark' ? this.darkModeStyle : undefined}
+                style={this.darkModeStyle}
               />
             </div>
             <button type="button" className={styles.ResetButton} onClick={this.resetTask}>
@@ -397,7 +385,7 @@ export class TaskCreator extends React.PureComponent<Props, State> {
           <button
             type="submit"
             className={view === 'personal' ? styles.SubmitNewTask : styles.GroupSubmitNewTask}
-            style={theme === 'dark' ? this.darkModeStyle : undefined}
+            style={this.darkModeStyle}
           >
             <SamwiseIcon iconName="add-task" />
           </button>
@@ -408,35 +396,40 @@ export class TaskCreator extends React.PureComponent<Props, State> {
 
   public render(): ReactElement {
     const { name } = this.state;
-    const { theme, view } = this.props;
+    const { view } = this.props;
+    const formClassname = view === 'personal' ? styles.NewTaskWrap : styles.GroupNewTaskWrap;
+    if (!this.isOpen) {
+      return (
+        <div className={styles.TaskCreator} style={this.darkModeStyle}>
+          <form className={formClassname} onSubmit={this.handleSave} onFocus={this.openNewTask}>
+            <input
+              required
+              type="text"
+              value={name}
+              onChange={this.editTaskName}
+              className={styles.NewTaskComponent}
+              placeholder={PLACEHOLDER_TEXT}
+              style={this.darkModeStyle}
+            />
+          </form>
+        </div>
+      );
+    }
+
     return (
-      <div className={styles.TaskCreator} style={theme === 'dark' ? this.darkModeStyle : undefined}>
-        <div
-          onClick={this.closeNewTask}
-          role="presentation"
-          className={styles.CloseNewTask}
-          style={this.isOpen ? {} : { display: 'none' }}
-        />
-        <form
-          className={view === 'personal' ? styles.NewTaskWrap : styles.GroupNewTaskWrap}
-          onSubmit={this.handleSave}
-          onFocus={this.openNewTask}
-        >
+      <div className={styles.TaskCreator} style={this.darkModeStyle}>
+        <div onClick={this.closeNewTask} role="presentation" className={styles.CloseNewTask} />
+        <form className={formClassname} onSubmit={this.handleSave} onFocus={this.openNewTask}>
           <input
             required
             type="text"
             value={name}
             onChange={this.editTaskName}
-            className={
-              this.isOpen
-                ? `${styles.NewTaskComponent} ${styles.NewTaskComponentOpened}`
-                : styles.NewTaskComponent
-            }
-            placeholder={this.isOpen ? '' : PLACEHOLDER_TEXT}
+            className={`${styles.NewTaskComponent} ${styles.NewTaskComponentOpened}`}
             ref={(e) => {
               this.addTask = e;
             }}
-            style={theme === 'dark' ? this.darkModeStyle : undefined}
+            style={this.darkModeStyle}
           />
           {this.renderOtherInfoEditor()}
         </form>


### PR DESCRIPTION
### Summary <!-- Required -->

Trying to share code between the open state and close state of the TaskCreator is the root source of evil that caused the unnecessary `position: absolute` hack mentioned in #618. In the end, we did manage to share a few lines of code, but at the cost of completely unnecessary `position: absolute` hack.

This diff starts to reverse that decision. In particular, it deals with the `!isOpen` case in one place, and then make the rest of the code only worry about the `isOpen` case. It will make the flow easier to understand, and help us untangle the unnecessary dependency between these two, so that we can eventually remove the `position: absolute` hack without worrying about the `!isOpen` case.

### Test Plan <!-- Required -->

Closed state still works:
<img width="1680" alt="Screen Shot 2020-10-31 at 20 10 36" src="https://user-images.githubusercontent.com/4290500/97792479-32307880-1bb5-11eb-86db-ef5b131aab55.png">

Open state still works:
<img width="1680" alt="Screen Shot 2020-10-31 at 20 09 11" src="https://user-images.githubusercontent.com/4290500/97792475-2f358800-1bb5-11eb-8d9a-662e7be6cde0.png">
