### PR TITLE
Eliminate all ONE_TIME check in task editors

### DIFF
--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -168,7 +168,7 @@ function TaskEditor({
   };
 
   const onSaveButtonClicked = (): void => {
-    if (onSave() && type !== 'ONE_TIME') {
+    if (onSave() && type === 'MASTER_TEMPLATE') {
       onSaveClicked();
     }
   };
@@ -221,7 +221,7 @@ function TaskEditor({
 
   useEffect(() => {
     const intervalID = setInterval(() => {
-      if (type === 'ONE_TIME') {
+      if (type !== 'MASTER_TEMPLATE') {
         onSave();
       }
     }, 1000);


### PR DESCRIPTION
### Summary <!-- Required -->

For TaskEditor, one time task and group task's behavior is mostly the same. Instead, only repeating task has some special behavior.

We have some code that was written in the past when there was only one time task and repeating task, so checking whether a task is a ONE_TIME task is as valid as checking whether a task is MASTER_TEMPLATE. However, since the introduction of group task, only checking for ONE_TIME task runs the danger of doing same stuff for both repeating and group task, which is wrong in most cases.

This diff replaces the remaining checks of `=== 'ONE_TIME'` into checks for  `!== 'GROUP'`. 

### Test Plan <!-- Required -->

Creating group task, repeating task and one time tasks still work.