### PR TITLE
Remove redundunt map of groupMemberProfiles

### DIFF
--- a/frontend/src/components/GroupView/MiddleBar/index.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/index.tsx
@@ -22,20 +22,13 @@ const GroupViewMiddleBar = ({
   const { email } = getAppUser();
 
   return (
-    <div>
-      {groupMemberProfiles.map(() => {
-        const filteredTasks = tasks.filter(({ owner }) => owner.includes(email));
-        return (
-          <div className={styles.MiddleBar}>
-            <GroupViewMiddleBarTaskQueue tasks={filteredTasks} />
-            <GroupViewMiddleBarPeopleList
-              group={group}
-              groupMemberProfiles={groupMemberProfiles}
-              changeView={changeView}
-            />
-          </div>
-        );
-      })}
+    <div className={styles.MiddleBar}>
+      <GroupViewMiddleBarTaskQueue tasks={tasks.filter(({ owner }) => owner.includes(email))} />
+      <GroupViewMiddleBarPeopleList
+        group={group}
+        groupMemberProfiles={groupMemberProfiles}
+        changeView={changeView}
+      />
     </div>
   );
 };


### PR DESCRIPTION
### Summary <!-- Required -->

Not sure what the map is doing, but the logic looks very wrong. Remove this map to avoid duplicate elements.

### Test Plan <!-- Required -->

Middle bar still works:

<img width="1680" alt="Screen Shot 2020-11-01 at 17 46 27" src="https://user-images.githubusercontent.com/4290500/97817404-44202300-1c6a-11eb-934e-1a5d40294a82.png">


### Notes <!-- Optional -->

@IshikaJain do you know what's going on with the map? Looking at the git blame looks like you introduced this change.