### PR TITLE
Fix the value for active prop passed into TaskEditor and one of its usage

### DIFF
--- a/frontend/src/components/Util/TaskEditors/InlineTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/InlineTaskEditor.tsx
@@ -47,7 +47,7 @@ export default function InlineTaskEditor({
       displayGrabber
       calendarPosition={calendarPosition}
       newSubTaskAutoFocused={!original.inFocus}
-      active={disabled}
+      active={!disabled}
       onFocus={onFocus}
       onBlur={onBlur}
       memberName={memberName}

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -282,7 +282,7 @@ function TaskEditor({
             memberName={memberName}
           />
         ))}
-        <div className={styles.SubtaskHide} style={active === true ? { maxHeight: 0 } : undefined}>
+        <div className={styles.SubtaskHide} style={active === false ? { maxHeight: 0 } : undefined}>
           <NewSubTaskEditor
             onFirstType={handleCreatedNewSubtask}
             onPressEnter={onSaveButtonClicked}


### PR DESCRIPTION
### Summary <!-- Required -->

Looking at the English, it should be very obvious that `active` should be true when disabled is `false`. This diff fixes this mistake first. Then it turns out that one of the usage of `active` is also flipped, so this diff fixes it as well.

### Test Plan <!-- Required -->

Auto-expanding subtask creator when hover over inline editor still works.

Not hovered:
<img width="399" alt="Screen Shot 2020-11-01 at 18 05 56" src="https://user-images.githubusercontent.com/4290500/97817842-ee994580-1c6c-11eb-9c70-8845e33c1fa1.png">
Hovered:
<img width="380" alt="Screen Shot 2020-11-01 at 18 06 01" src="https://user-images.githubusercontent.com/4290500/97817843-ee994580-1c6c-11eb-8032-38c7bdd24bc5.png">