### PR TITLE
Remove useless onKeyPress handler in GroupTaskRow

### DIFF
--- a/frontend/src/components/GroupView/RightView/GroupTaskRow.tsx
+++ b/frontend/src/components/GroupView/RightView/GroupTaskRow.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, KeyboardEvent } from 'react';
+import React, { ReactElement } from 'react';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { SamwiseUserProfile, Task } from 'common/types/store-types';
@@ -12,13 +12,6 @@ type Props = {
   readonly onClick: (member: SamwiseUserProfile) => void;
   readonly tasks: readonly Task[];
   readonly profilePicURL: string;
-};
-
-const pressedAddGroupTask = (e: KeyboardEvent): void => {
-  if (e.key === 'Enter' || e.key === ' ') {
-    e.stopPropagation();
-    console.log('pressed add group task');
-  }
 };
 
 const GroupTaskRow = ({
@@ -40,7 +33,6 @@ const GroupTaskRow = ({
         type="button"
         className={styles.AddTaskContainer}
         onClick={() => onClick(userProfile)}
-        onKeyPress={pressedAddGroupTask}
       >
         <div className={styles.AddTask}>
           <FontAwesomeIcon icon={faPlus} />


### PR DESCRIPTION
### Summary <!-- Required -->

This handler is introduced in https://github.com/cornell-dti/samwise/commit/28265c512636eef6c95d838441d91d83a6011b66, when the code is still dummy and uses `div` instead of `button`. Now we switched to button so a11y should automatically work without this extra handler. This diff removes it, with a good side effect to removing another linter warning.

### Test Plan <!-- Required -->

Try to press that button with tabbing and enter key.