### PR TITLE
Use default credentials for firebase functions in prod

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -30,7 +30,5 @@ jobs:
       - name: Deploy Functions to Firebase Staging Project
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-          STAGING_FIREBASE_ADMIN_SDK_CONTENTS: ${{ secrets.STAGING_FIREBASE_ADMIN_SDK_CONTENTS }}
         run: |
-          echo $STAGING_FIREBASE_ADMIN_SDK_CONTENTS > functions/src/firebase-adminsdk.json
           node ./deploy-functions.js $FIREBASE_TOKEN default

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -24,9 +24,7 @@ jobs:
       - name: Deploy to Production
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-          PRODUCTION_FIREBASE_ADMIN_SDK_CONTENTS: ${{ secrets.PRODUCTION_FIREBASE_ADMIN_SDK_CONTENTS }}
         run: |
-          echo $PRODUCTION_FIREBASE_ADMIN_SDK_CONTENTS > functions/src/firebase-adminsdk.json
           ./node_modules/.bin/firebase use production
           ./node_modules/.bin/firebase deploy --token=$FIREBASE_TOKEN --non-interactive --only hosting,firestore:rules
           node ./deploy-functions.js $FIREBASE_TOKEN production

--- a/functions/src/db.ts
+++ b/functions/src/db.ts
@@ -1,15 +1,17 @@
 import * as admin from 'firebase-admin';
+import { readFileSync } from 'fs';
 import Database from 'common/firebase/database';
-import serviceAccount from './firebase-adminsdk.json';
 
 if (process.env.TEST_MODE) {
   // eslint-disable-next-line no-console
   console.log('We are in test mode. Skip initializing firebase-admin.');
-} else {
+} else if (process.env.DEV) {
   admin.initializeApp({
-    credential: admin.credential.cert(serviceAccount as admin.ServiceAccount),
+    credential: JSON.parse(readFileSync('./firebase-adminsdk.json').toString()),
     databaseURL: 'https://samwise-dev.firebaseio.com',
   });
+} else {
+  admin.initializeApp();
 }
 
 const database = new Database(() => admin.firestore());


### PR DESCRIPTION
### Summary <!-- Required -->

Just remembered that we don't actually need to store credential in secrets. In the DTI hackathon project, I directly used:

https://github.com/AkashAryal/Flower/blob/98d233e60cba8be653722e99d7a5cb739b43db52/server/src/index.ts#L1-L9

and everything seems to work fine. I still leave the credential reading code so that we can still run stuff locally if we want to.

### Test Plan <!-- Required -->

![notest](https://user-images.githubusercontent.com/4290500/98450129-ff800600-2107-11eb-9620-79b23880fb1e.jpeg)
