### PR TITLE
Inline renderOtherInfoEditor into render in TaskCreator

### DIFF
--- a/frontend/src/components/TaskCreator/index.tsx
+++ b/frontend/src/components/TaskCreator/index.tsx
@@ -274,14 +274,10 @@ export class TaskCreator extends React.PureComponent<Props, State> {
 
   private resetTask = (): void => this.setState({ ...initialState() }, this.focusTaskName);
 
-  /**
-   * Renders the editor for all the other info except main task name.
-   *
-   * @return the rendered other info editor.
-   */
-  private renderOtherInfoEditor(): ReactElement {
+  public render(): ReactElement {
     const { view, groupMemberProfiles, assignedMember, clearAssignedMember } = this.props;
     const {
+      name,
       tag,
       member,
       date,
@@ -292,110 +288,6 @@ export class TaskCreator extends React.PureComponent<Props, State> {
       datePicked,
       needToSwitchFocus,
     } = this.state;
-    const existingSubTaskEditor = (
-      thisSubTask: SubTask,
-      i: number,
-      arr: SubTask[]
-    ): ReactElement => {
-      const refHandler = (inputElementRef: HTMLInputElement | null): void => {
-        if (i === arr.length - 1 && needToSwitchFocus && inputElementRef != null) {
-          inputElementRef.focus();
-          this.setState({ needToSwitchFocus: false });
-        }
-      };
-
-      const { order, name } = thisSubTask;
-      return (
-        <li key={order}>
-          <button type="button" tabIndex={-1} onClick={this.deleteSubTask(thisSubTask)}>
-            <SamwiseIcon iconName="x-dark" />
-          </button>
-          <input
-            type="text"
-            ref={refHandler}
-            value={name}
-            onChange={this.editSubTask(thisSubTask)}
-            onKeyDown={this.submitSubTask}
-            style={this.darkModeStyle}
-          />
-        </li>
-      );
-    };
-    return (
-      <>
-        <div className={styles.TitleText}>Add Task</div>
-        <div className={styles.NewTaskActive}>
-          <div className={styles.SubtitleText}>
-            <p>
-              <b>Add Subtasks</b>
-              &nbsp;(optional)
-            </p>
-          </div>
-          <div className={styles.DescText}>
-            <p>Add optional subtasks to break down your tasks into more manageable pieces.</p>
-          </div>
-          <div className={styles.NewTaskModal} style={this.darkModeStyle}>
-            <div className={styles.SubtasksContainer}>
-              <ul className={styles.SubtasksList}>{subTasks.map(existingSubTaskEditor)}</ul>
-              <SamwiseIcon iconName="edit" className={styles.EditIcon} tabIndex={-1} />
-              <input
-                className={styles.SubtaskInput}
-                type="text"
-                placeholder="Add a Subtask"
-                value=""
-                onChange={this.addNewSubTask}
-                onKeyDown={this.newSubTaskKeyPress}
-                style={this.darkModeStyle}
-              />
-            </div>
-            <button type="button" className={styles.ResetButton} onClick={this.resetTask}>
-              DISCARD TASK
-            </button>
-          </div>
-          {date instanceof Date && <FocusPicker pinned={inFocus} onPinChange={this.togglePin} />}
-          <div className={styles.TagPickWrap}>
-            {view === 'personal' ? (
-              <TagPicker
-                tag={tag}
-                opened={tagPickerOpened}
-                onTagChange={this.editTag}
-                onPickerOpened={this.openTagPicker}
-              />
-            ) : (
-              <GroupMemberPicker
-                member={assignedMember || member}
-                opened={tagPickerOpened}
-                onMemberChange={this.editMember}
-                onPickerOpened={this.openTagPicker}
-                groupMemberProfiles={groupMemberProfiles || []}
-                clearAssignedMember={clearAssignedMember}
-              />
-            )}
-          </div>
-          <DatePicker
-            date={date}
-            opened={datePickerOpened}
-            datePicked={datePicked}
-            inGroupView={false}
-            onDateChange={this.editDate}
-            onClearPicker={this.clearDate}
-            onPickerOpened={this.openDatePicker}
-          />
-          <button
-            type="submit"
-            className={view === 'personal' ? styles.SubmitNewTask : styles.GroupSubmitNewTask}
-            style={this.darkModeStyle}
-          >
-            <SamwiseIcon iconName="add-task" />
-          </button>
-        </div>
-      </>
-    );
-  }
-
-  public render(): ReactElement {
-    const { name } = this.state;
-    const { view } = this.props;
     const formClassname = view === 'personal' ? styles.NewTaskWrap : styles.GroupNewTaskWrap;
     if (!this.isOpen) {
       return (
@@ -415,6 +307,36 @@ export class TaskCreator extends React.PureComponent<Props, State> {
       );
     }
 
+    const existingSubTaskEditor = (
+      thisSubTask: SubTask,
+      i: number,
+      arr: SubTask[]
+    ): ReactElement => {
+      const refHandler = (inputElementRef: HTMLInputElement | null): void => {
+        if (i === arr.length - 1 && needToSwitchFocus && inputElementRef != null) {
+          inputElementRef.focus();
+          this.setState({ needToSwitchFocus: false });
+        }
+      };
+
+      const { order, name: subtaskName } = thisSubTask;
+      return (
+        <li key={order}>
+          <button type="button" tabIndex={-1} onClick={this.deleteSubTask(thisSubTask)}>
+            <SamwiseIcon iconName="x-dark" />
+          </button>
+          <input
+            type="text"
+            ref={refHandler}
+            value={subtaskName}
+            onChange={this.editSubTask(thisSubTask)}
+            onKeyDown={this.submitSubTask}
+            style={this.darkModeStyle}
+          />
+        </li>
+      );
+    };
+
     return (
       <div className={styles.TaskCreator} style={this.darkModeStyle}>
         <div onClick={this.closeNewTask} role="presentation" className={styles.CloseNewTask} />
@@ -430,7 +352,72 @@ export class TaskCreator extends React.PureComponent<Props, State> {
             }}
             style={this.darkModeStyle}
           />
-          {this.renderOtherInfoEditor()}
+          <div className={styles.TitleText}>Add Task</div>
+          <div className={styles.NewTaskActive}>
+            <div className={styles.SubtitleText}>
+              <p>
+                <b>Add Subtasks</b>
+                &nbsp;(optional)
+              </p>
+            </div>
+            <div className={styles.DescText}>
+              <p>Add optional subtasks to break down your tasks into more manageable pieces.</p>
+            </div>
+            <div className={styles.NewTaskModal} style={this.darkModeStyle}>
+              <div className={styles.SubtasksContainer}>
+                <ul className={styles.SubtasksList}>{subTasks.map(existingSubTaskEditor)}</ul>
+                <SamwiseIcon iconName="edit" className={styles.EditIcon} tabIndex={-1} />
+                <input
+                  className={styles.SubtaskInput}
+                  type="text"
+                  placeholder="Add a Subtask"
+                  value=""
+                  onChange={this.addNewSubTask}
+                  onKeyDown={this.newSubTaskKeyPress}
+                  style={this.darkModeStyle}
+                />
+              </div>
+              <button type="button" className={styles.ResetButton} onClick={this.resetTask}>
+                DISCARD TASK
+              </button>
+            </div>
+            {date instanceof Date && <FocusPicker pinned={inFocus} onPinChange={this.togglePin} />}
+            <div className={styles.TagPickWrap}>
+              {view === 'personal' ? (
+                <TagPicker
+                  tag={tag}
+                  opened={tagPickerOpened}
+                  onTagChange={this.editTag}
+                  onPickerOpened={this.openTagPicker}
+                />
+              ) : (
+                <GroupMemberPicker
+                  member={assignedMember || member}
+                  opened={tagPickerOpened}
+                  onMemberChange={this.editMember}
+                  onPickerOpened={this.openTagPicker}
+                  groupMemberProfiles={groupMemberProfiles || []}
+                  clearAssignedMember={clearAssignedMember}
+                />
+              )}
+            </div>
+            <DatePicker
+              date={date}
+              opened={datePickerOpened}
+              datePicked={datePicked}
+              inGroupView={false}
+              onDateChange={this.editDate}
+              onClearPicker={this.clearDate}
+              onPickerOpened={this.openDatePicker}
+            />
+            <button
+              type="submit"
+              className={view === 'personal' ? styles.SubmitNewTask : styles.GroupSubmitNewTask}
+              style={this.darkModeStyle}
+            >
+              <SamwiseIcon iconName="add-task" />
+            </button>
+          </div>
         </form>
       </div>
     );


### PR DESCRIPTION
### Summary <!-- Required -->

Inline the function to prepare for another diff that switch the order of input and other elements to avoid `position: absolute` hack.

### Test Plan <!-- Required -->

Still works:
<img width="1680" alt="Screen Shot 2020-11-07 at 16 43 38" src="https://user-images.githubusercontent.com/4290500/98451911-71f8e200-2118-11eb-9c59-edd481fc6926.png">
<img width="1792" alt="Screen Shot 2020-11-07 at 16 43 46" src="https://user-images.githubusercontent.com/4290500/98451912-71f8e200-2118-11eb-8197-32f5eea24d2d.png">

See the big-diff bot. It should report a significant line much less than diff lines, which shows that most lines are moved.
