### PR TITLE
SubTask -> Task migration release

### DIFF
--- a/common/firebase/database.ts
+++ b/common/firebase/database.ts
@@ -150,6 +150,8 @@ export default class Database {
 
   tasksCollection = (): Collection => this.db().collection('samwise-tasks');
 
+  subTasksCollection = (): Collection => this.db().collection('samwise-subtasks');
+
   groupsCollection = (): Collection => this.db().collection('samwise-groups');
 
   usersCollection = (): Collection => this.db().collection('samwise-users');

--- a/common/firebase/database.ts
+++ b/common/firebase/database.ts
@@ -150,8 +150,6 @@ export default class Database {
 
   tasksCollection = (): Collection => this.db().collection('samwise-tasks');
 
-  subTasksCollection = (): Collection => this.db().collection('samwise-subtasks');
-
   groupsCollection = (): Collection => this.db().collection('samwise-groups');
 
   usersCollection = (): Collection => this.db().collection('samwise-users');

--- a/common/types/action-types.ts
+++ b/common/types/action-types.ts
@@ -1,5 +1,5 @@
 import { Map } from 'immutable';
-import { Course, Settings, SubTask, Task, Tag, BannerMessageStatus, Group } from './store-types';
+import { Course, Settings, Task, Tag, BannerMessageStatus, Group } from './store-types';
 
 export type PatchTags = {
   readonly type: 'PATCH_TAGS';
@@ -8,21 +8,10 @@ export type PatchTags = {
   readonly deleted: string[];
 };
 
-export type TaskWithChildrenId = Omit<Task, 'children'> & {
-  readonly children: readonly string[];
-};
-
 export type PatchTasks = {
   readonly type: 'PATCH_TASKS';
-  readonly created: TaskWithChildrenId[];
-  readonly edited: TaskWithChildrenId[];
-  readonly deleted: string[];
-};
-
-export type PatchSubTasks = {
-  readonly type: 'PATCH_SUBTASKS';
-  readonly created: SubTask[];
-  readonly edited: SubTask[];
+  readonly created: Task[];
+  readonly edited: Task[];
   readonly deleted: string[];
 };
 
@@ -58,7 +47,6 @@ export type PatchGroupInvites = {
 export type Action =
   | PatchTags
   | PatchTasks
-  | PatchSubTasks
   | PatchSettings
   | PatchBannerMessageStatus
   | PatchCourses

--- a/common/types/firestore-types.ts
+++ b/common/types/firestore-types.ts
@@ -1,5 +1,5 @@
 import { firestore } from 'firebase/app';
-import { RepeatingPattern } from './store-types';
+import { RepeatingPattern, SubTask } from './store-types';
 
 export type FirestoreCommon = {
   readonly owner: string | readonly string[];
@@ -17,13 +17,7 @@ export type FirestoreCommonTask = FirestoreCommon & {
   readonly tag: string;
   readonly complete: boolean;
   readonly inFocus: boolean;
-  readonly children: readonly string[];
-};
-
-export type FirestoreSubTask = FirestoreCommon & {
-  readonly name: string;
-  readonly complete: boolean;
-  readonly inFocus: boolean;
+  readonly children: readonly SubTask[];
 };
 
 export type ForkedTaskMetaData = {

--- a/common/types/store-types.ts
+++ b/common/types/store-types.ts
@@ -9,19 +9,17 @@ export type Tag = {
 };
 
 export type SubTask = {
-  readonly id: string;
   readonly order: number;
   readonly name: string; // Example: "SubTask 1 Name"
   readonly complete: boolean;
   readonly inFocus: boolean; // Whether the subtask is in focus
 };
 
-export type SubTaskWithoutId = Pick<SubTask, 'order' | 'name' | 'complete' | 'inFocus'>;
-export type SubTaskWithoutIdOrder = Pick<SubTask, 'name' | 'complete' | 'inFocus'>;
+export type SubTaskWithoutOrder = Pick<SubTask, 'name' | 'complete' | 'inFocus'>;
 /**
  * The subtask type without id order and with every field as optional.
  */
-export type PartialSubTask = Partial<SubTaskWithoutIdOrder>;
+export type PartialSubTask = Partial<SubTaskWithoutOrder>;
 
 // TODO: refactor ical task to a separate category
 export type OneTimeTaskMetadata = {
@@ -72,18 +70,25 @@ export type Task<M = TaskMetadata> = {
   readonly metadata: M;
 };
 
-export type MainTask = {
+export type TaskMainData = {
   readonly owner: readonly string[];
   readonly name: string;
   readonly tag: string;
   readonly date: Date | RepeatingDate;
   readonly complete: boolean;
   readonly inFocus: boolean;
+  readonly children: readonly SubTask[];
 };
 /**
- * The task type without id and subtask, and with all properties as optional.
+ * The task type without id, and with all properties as optional.
  */
-export type PartialMainTask = Partial<MainTask>;
+export type PartialTaskMainData = Partial<TaskMainData>;
+
+export type SubTaskEditData = {
+  update?: Partial<SubTask>;
+  order: number;
+  isDelete: boolean;
+};
 
 /**
  * The type of user settings.
@@ -138,12 +143,6 @@ export type Course = {
 export type State = {
   readonly tags: Map<string, Tag>;
   readonly tasks: Map<string, Task>;
-  // Mapping of subtask id to main task id.
-  // It contains all subtask ids that the main task knows but the redux store does not have yet.
-  readonly missingSubTasks: Map<string, string>;
-  // Mapping of subtask id to its object for fast access.
-  // It contains all subtasks that the redux store knows but belongs to no known main task yet.
-  readonly orphanSubTasks: Map<string, SubTask>;
   // A fast access map to quickly find all main task id within a date.
   readonly dateTaskMap: Map<string, Set<string>>;
   // A fast access map to quickly find all task ids under a certain group ID.

--- a/common/util/task-util.test.ts
+++ b/common/util/task-util.test.ts
@@ -5,6 +5,7 @@ import {
   computeTaskProgress,
   TasksProgressProps,
   subTasksEqual,
+  sortTask,
 } from './task-util';
 
 // unimportant common attributes.
@@ -148,4 +149,133 @@ it('subTaskEqual works', () => {
   expect(subTask1).toEqual(subTask1Duplicate);
   expect(subTasksEqual(subTask1, subTask1Duplicate)).toBeTruthy();
   expect(subTasksEqual(subTask1, subTask1AlteredName)).toBeFalsy();
+});
+
+it('sortTask works', () => {
+  const groupTask1FromGroup1: Task = {
+    id: '1',
+    order: 1,
+    name: '',
+    tag: '',
+    owner: [],
+    inFocus: true,
+    complete: true,
+    children: [],
+    metadata: { type: 'GROUP', group: 'g1', date: new Date() },
+  };
+  const groupTask2FromGroup1: Task = {
+    id: '2',
+    order: 2,
+    name: '',
+    tag: '',
+    owner: [],
+    inFocus: true,
+    complete: true,
+    children: [],
+    metadata: { type: 'GROUP', group: 'g1', date: new Date() },
+  };
+  const groupTask1FromGroup2: Task = {
+    id: '3',
+    order: 1,
+    name: '',
+    tag: '',
+    owner: [],
+    inFocus: true,
+    complete: true,
+    children: [],
+    metadata: { type: 'GROUP', group: 'g2', date: new Date() },
+  };
+  const groupTask2FromGroup2: Task = {
+    id: '4',
+    order: 2,
+    name: '',
+    tag: '',
+    owner: [],
+    inFocus: true,
+    complete: true,
+    children: [],
+    metadata: { type: 'GROUP', group: 'g2', date: new Date() },
+  };
+  const repeatingTask1: Task = {
+    id: '5',
+    order: 1,
+    name: '',
+    tag: '',
+    owner: [],
+    inFocus: true,
+    complete: true,
+    children: [],
+    metadata: {
+      type: 'MASTER_TEMPLATE',
+      date: {
+        startDate: new Date(),
+        endDate: new Date(),
+        pattern: { type: 'BIWEEKLY', bitSet: 1 },
+      },
+      forks: [],
+    },
+  };
+  const repeatingTask2: Task = {
+    id: '6',
+    order: 2,
+    name: '',
+    tag: '',
+    owner: [],
+    inFocus: true,
+    complete: true,
+    children: [],
+    metadata: {
+      type: 'MASTER_TEMPLATE',
+      date: {
+        startDate: new Date(),
+        endDate: new Date(),
+        pattern: { type: 'BIWEEKLY', bitSet: 1 },
+      },
+      forks: [],
+    },
+  };
+  const oneTimeTask1: Task = {
+    id: '7',
+    order: 1,
+    name: '',
+    tag: '',
+    owner: [],
+    inFocus: true,
+    complete: true,
+    children: [],
+    metadata: { type: 'ONE_TIME', date: new Date() },
+  };
+  const oneTimeTask2: Task = {
+    id: '8',
+    order: 2,
+    name: '',
+    tag: '',
+    owner: [],
+    inFocus: true,
+    complete: true,
+    children: [],
+    metadata: { type: 'ONE_TIME', date: new Date() },
+  };
+
+  expect(
+    [
+      groupTask1FromGroup2,
+      oneTimeTask1,
+      repeatingTask2,
+      repeatingTask1,
+      oneTimeTask2,
+      groupTask1FromGroup1,
+      groupTask2FromGroup2,
+      groupTask2FromGroup1,
+    ].sort(sortTask)
+  ).toEqual([
+    groupTask1FromGroup1,
+    groupTask2FromGroup1,
+    groupTask1FromGroup2,
+    groupTask2FromGroup2,
+    repeatingTask1,
+    repeatingTask2,
+    oneTimeTask1,
+    oneTimeTask2,
+  ]);
 });

--- a/common/util/task-util.ts
+++ b/common/util/task-util.ts
@@ -165,3 +165,46 @@ export function dateMatchRepeats(
 
 export const subTasksEqual = (firstSubTask: SubTask, secondSubTask: SubTask): boolean =>
   shallowEqual(firstSubTask, secondSubTask);
+
+export const sortTask = (a: Task, b: Task): number => {
+  switch (a.metadata.type) {
+    case 'GROUP': {
+      switch (b.metadata.type) {
+        case 'GROUP': {
+          const groupIdOrder = a.metadata.group.localeCompare(b.metadata.group);
+          return groupIdOrder === 0 ? a.order - b.order : groupIdOrder;
+        }
+        case 'ONE_TIME':
+        case 'MASTER_TEMPLATE':
+          return -1;
+        default:
+          throw new Error('Impossible Case');
+      }
+    }
+    case 'ONE_TIME': {
+      switch (b.metadata.type) {
+        case 'GROUP':
+        case 'MASTER_TEMPLATE':
+          return 1;
+        case 'ONE_TIME':
+          return a.order - b.order;
+        default:
+          throw new Error('Impossible Case');
+      }
+    }
+    case 'MASTER_TEMPLATE': {
+      switch (b.metadata.type) {
+        case 'GROUP':
+          return 1;
+        case 'ONE_TIME':
+          return -1;
+        case 'MASTER_TEMPLATE':
+          return a.order - b.order;
+        default:
+          throw new Error('Impossible Case');
+      }
+    }
+    default:
+      throw new Error('Impossible Case');
+  }
+};

--- a/common/util/task-util.ts
+++ b/common/util/task-util.ts
@@ -1,5 +1,6 @@
 import { SubTask, Task, RepeatingPattern, RepeatingTaskMetadata } from '../types/store-types';
 import { isBitSet } from './bitwise-util';
+import { shallowEqual } from './general-util';
 
 /**
  * This is the utility module for array of tasks and subtasks.
@@ -161,3 +162,6 @@ export function dateMatchRepeats(
   }
   return dateMatchRepeatPattern(date, pattern);
 }
+
+export const subTasksEqual = (firstSubTask: SubTask, secondSubTask: SubTask): boolean =>
+  shallowEqual(firstSubTask, secondSubTask);

--- a/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarTaskQueue.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarTaskQueue.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, ReactElement } from 'react';
 
 import { Task } from 'common/types/store-types';
+import { sortTask } from 'common/util/task-util';
 import styles from './GroupViewMiddleBarTaskQueue.module.scss';
 import GroupTask from '../RightView/GroupTask';
 
@@ -16,8 +17,11 @@ const EmptyTaskQueue = (): React.ReactElement => (
 );
 
 function renderTaskList(tasks: readonly Task[]): ReactNode {
-  return tasks.map((task) => <GroupTask key={task.id} original={task} memberName="" />);
+  return [...tasks].sort(sortTask).map((task) => {
+    return <GroupTask key={task.id} original={task} memberName="" />;
+  });
 }
+
 const TaskQueue = ({ tasks }: Props): React.ReactElement => (
   <div>
     {tasks.length > 0 ? (

--- a/frontend/src/components/GroupView/RightView/GroupTasksContainer.tsx
+++ b/frontend/src/components/GroupView/RightView/GroupTasksContainer.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, ReactNode } from 'react';
 import { Task } from 'common/types/store-types';
+import { sortTask } from 'common/util/task-util';
 import styles from './GroupTasksContainer.module.scss';
 import GroupTask from './GroupTask';
 import CompletedTasksContainer from './CompletedTasks/CompletedTasksContainer';
@@ -15,7 +16,9 @@ type IdOrder = {
 };
 
 function renderTaskList(tasks: readonly Task[], memberName: string): ReactNode {
-  return tasks.map((task) => <GroupTask key={task.id} original={task} memberName={memberName} />);
+  return [...tasks]
+    .sort(sortTask)
+    .map((task) => <GroupTask key={task.id} original={task} memberName={memberName} />);
 }
 
 function GroupTasksContainer({ tasks, memberName }: Props): ReactElement {

--- a/frontend/src/components/TaskView/FocusView/ClearFocus.tsx
+++ b/frontend/src/components/TaskView/FocusView/ClearFocus.tsx
@@ -34,7 +34,7 @@ function ClearFocus({ tasks }: Props): ReactElement | null {
   if (taskIds.length === 0) {
     return null;
   }
-  const handleClick = (): void => clearFocus(taskIds, subTasksWithParentTaskId);
+  const handleClick = (): Promise<void> => clearFocus(taskIds, subTasksWithParentTaskId);
   return <SquareTextButton text="Clear Focus" onClick={handleClick} />;
 }
 

--- a/frontend/src/components/TaskView/FocusView/ClearFocus.tsx
+++ b/frontend/src/components/TaskView/FocusView/ClearFocus.tsx
@@ -19,9 +19,9 @@ function ClearFocus({ tasks }: Props): ReactElement | null {
       t.children.forEach((s) => {
         if (s.inFocus && s.complete) {
           const completedSubtasks = subTasksWithParentTaskId.get(t.id);
-          if (completedSubtasks === undefined) {
+          if (subTasksWithParentTaskId.has(t.id)) {
             subTasksWithParentTaskId = subTasksWithParentTaskId.set(t.id, [s]);
-          } else {
+          } else if (completedSubtasks !== undefined) {
             subTasksWithParentTaskId = subTasksWithParentTaskId.setIn(t.id, [
               s,
               ...completedSubtasks,

--- a/frontend/src/components/TaskView/FocusView/ClearFocus.tsx
+++ b/frontend/src/components/TaskView/FocusView/ClearFocus.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Map } from 'immutable';
 import { connect } from 'react-redux';
-import { Task, State } from 'common/types/store-types';
+import { Task, State, SubTask } from 'common/types/store-types';
 import SquareTextButton from '../../UI/SquareTextButton';
 import { clearFocus } from '../../../firebase/actions';
 
@@ -11,14 +11,22 @@ type Props = {
 
 function ClearFocus({ tasks }: Props): ReactElement | null {
   const taskIds: string[] = [];
-  const subTaskIds: string[] = [];
+  let subTasksWithParentTaskId: Map<string, SubTask[]> = Map();
   tasks.forEach((t) => {
     if (t.inFocus && t.complete) {
       taskIds.push(t.id);
     } else {
       t.children.forEach((s) => {
         if (s.inFocus && s.complete) {
-          subTaskIds.push(s.id);
+          const completedSubtasks = subTasksWithParentTaskId.get(t.id);
+          if (completedSubtasks === undefined) {
+            subTasksWithParentTaskId = subTasksWithParentTaskId.set(t.id, [s]);
+          } else {
+            subTasksWithParentTaskId = subTasksWithParentTaskId.setIn(t.id, [
+              s,
+              ...completedSubtasks,
+            ]);
+          }
         }
       });
     }
@@ -26,7 +34,7 @@ function ClearFocus({ tasks }: Props): ReactElement | null {
   if (taskIds.length === 0) {
     return null;
   }
-  const handleClick = (): void => clearFocus(taskIds, subTaskIds);
+  const handleClick = (): void => clearFocus(taskIds, subTasksWithParentTaskId);
   return <SquareTextButton text="Clear Focus" onClick={handleClick} />;
 }
 

--- a/frontend/src/components/TaskView/FutureView/FutureViewSubTask.test.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewSubTask.test.tsx
@@ -20,7 +20,14 @@ const dummyTask: Task<TaskMetadata> = {
 
 it('FutureViewSubTask with null SubTask matches snapshot.', () => {
   const tree = renderer
-    .create(<FutureViewSubTask taskData={dummyTask} subTask={null} mainTaskCompleted />)
+    .create(
+      <FutureViewSubTask
+        taskData={dummyTask}
+        subTask={null}
+        mainTaskCompleted
+        replaceDateForFork={null}
+      />
+    )
     .toJSON();
   expect(tree).toMatchSnapshot();
 });
@@ -34,6 +41,7 @@ const createTest = (inFocus: boolean, complete: boolean, mainTaskCompleted: bool
           taskData={dummyTask}
           subTask={{ order: 1, name: 'foo', inFocus, complete }}
           mainTaskCompleted={mainTaskCompleted}
+          replaceDateForFork={null}
         />
       )
       .toJSON();

--- a/frontend/src/components/TaskView/FutureView/FutureViewSubTask.test.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewSubTask.test.tsx
@@ -1,17 +1,26 @@
+import { Task, TaskMetadata } from 'common/types/store-types';
 import React from 'react';
 import renderer from 'react-test-renderer';
 import FutureViewSubTask from './FutureViewSubTask';
 
+const dummyTask: Task<TaskMetadata> = {
+  id: 'foo',
+  order: 1,
+  owner: ['foo'],
+  name: 'Foo',
+  tag: 'foo',
+  complete: true,
+  inFocus: false,
+  children: [{ order: 1, name: 'Foo', complete: true, inFocus: false }],
+  metadata: {
+    type: 'ONE_TIME',
+    date: new Date('2030-01-01'),
+  },
+};
+
 it('FutureViewSubTask with null SubTask matches snapshot.', () => {
   const tree = renderer
-    .create(
-      <FutureViewSubTask
-        mainTaskId="foo"
-        subTask={null}
-        replaceDateForFork={null}
-        mainTaskCompleted
-      />
-    )
+    .create(<FutureViewSubTask taskData={dummyTask} subTask={null} mainTaskCompleted />)
     .toJSON();
   expect(tree).toMatchSnapshot();
 });
@@ -22,9 +31,8 @@ const createTest = (inFocus: boolean, complete: boolean, mainTaskCompleted: bool
     const tree = renderer
       .create(
         <FutureViewSubTask
-          mainTaskId="foo"
-          subTask={{ id: 'id', order: 1, name: 'foo', inFocus, complete }}
-          replaceDateForFork={null}
+          taskData={dummyTask}
+          subTask={{ order: 1, name: 'foo', inFocus, complete }}
           mainTaskCompleted={mainTaskCompleted}
         />
       )

--- a/frontend/src/components/TaskView/FutureView/FutureViewSubTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewSubTask.tsx
@@ -3,44 +3,71 @@ import { SubTask, Task, TaskMetadata } from 'common/types/store-types';
 import { subTasksEqual } from 'common/util/task-util';
 import styles from './FutureViewTask.module.scss';
 import CheckBox from '../../UI/CheckBox';
-import { editTaskWithDiff } from '../../../firebase/actions';
+import { editTaskWithDiff, EditType, forkTaskWithDiff } from '../../../firebase/actions';
 import SamwiseIcon from '../../UI/SamwiseIcon';
 
 type Props = {
   readonly subTask: SubTask | null;
   readonly taskData: Task<TaskMetadata>;
   readonly mainTaskCompleted: boolean;
+  readonly replaceDateForFork: Date | null;
 };
 
 /**
  * The component used to render one subtask in future view day.
  */
-function FutureViewSubTask({ subTask, taskData, mainTaskCompleted }: Props): ReactElement | null {
+function FutureViewSubTask({
+  subTask,
+  taskData,
+  mainTaskCompleted,
+  replaceDateForFork,
+}: Props): ReactElement | null {
+  const getTaskEditType = (): EditType => {
+    switch (taskData.metadata.type) {
+      case 'ONE_TIME':
+        return 'EDITING_ONE_TIME_TASK';
+      case 'MASTER_TEMPLATE':
+        return 'EDITING_MASTER_TEMPLATE';
+      case 'GROUP':
+        return 'EDITING_ONE_TIME_TASK';
+      default:
+        throw new Error('Invalid task type!');
+    }
+  };
+
+  const applyUpdate = (updatedChildren: SubTask[]): void => {
+    const mainTaskEdits = {
+      children: updatedChildren,
+    };
+    if (getTaskEditType() === 'EDITING_ONE_TIME_TASK') {
+      editTaskWithDiff(taskData.id, getTaskEditType(), { mainTaskEdits });
+    } else if (replaceDateForFork != null) {
+      forkTaskWithDiff(taskData.id, replaceDateForFork, { mainTaskEdits });
+    }
+  };
+
   if (subTask == null) {
     return null;
   }
-  const onCompleteChange = (): void =>
-    editTaskWithDiff(taskData.id, 'EDITING_ONE_TIME_TASK', {
-      mainTaskEdits: {
-        children: taskData.children.map(({ complete, ...rest }) =>
-          subTasksEqual({ complete, ...rest }, subTask)
-            ? { complete: !complete, ...rest }
-            : { complete, ...rest }
-        ),
-      },
-    });
-  const onFocusChange = (): void =>
-    editTaskWithDiff(taskData.id, 'EDITING_ONE_TIME_TASK', {
-      mainTaskEdits: {
-        children: taskData.children.map(({ inFocus, ...rest }) =>
-          subTasksEqual({ inFocus, ...rest }, subTask)
-            ? { inFocus: !inFocus, ...rest }
-            : { inFocus, ...rest }
-        ),
-      },
-    });
+  const onCompleteChange = (): void => {
+    const updatedChildren = taskData.children.map(({ complete, ...rest }) =>
+      subTasksEqual({ complete, ...rest }, subTask)
+        ? { complete: !complete, ...rest }
+        : { complete, ...rest }
+    );
+    applyUpdate(updatedChildren);
+  };
+
+  const onFocusChange = (): void => {
+    const updatedChildren = taskData.children.map(({ inFocus, ...rest }) =>
+      subTasksEqual({ inFocus, ...rest }, subTask)
+        ? { inFocus: !inFocus, ...rest }
+        : { inFocus, ...rest }
+    );
+    applyUpdate(updatedChildren);
+  };
   const onRemove = (): void =>
-    editTaskWithDiff(taskData.id, 'EDITING_ONE_TIME_TASK', {
+    editTaskWithDiff(taskData.id, getTaskEditType(), {
       mainTaskEdits: {
         children: taskData.children.filter((currSubTask) => !subTasksEqual(currSubTask, subTask)),
       },

--- a/frontend/src/components/TaskView/FutureView/FutureViewSubTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewSubTask.tsx
@@ -66,12 +66,14 @@ function FutureViewSubTask({
     );
     applyUpdate(updatedChildren);
   };
-  const onRemove = (): void =>
-    editTaskWithDiff(taskData.id, getTaskEditType(), {
-      mainTaskEdits: {
-        children: taskData.children.filter((currSubTask) => !subTasksEqual(currSubTask, subTask)),
-      },
-    });
+
+  const onRemove = (): void => {
+    const updatedChildren = taskData.children.filter(
+      (currSubTask) => !subTasksEqual(currSubTask, subTask)
+    );
+    applyUpdate(updatedChildren);
+  };
+
   return (
     <div className={styles.SubTask}>
       <CheckBox

--- a/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
@@ -158,10 +158,9 @@ function FutureViewTask({
   const renderSubTasks = (): ReactNode =>
     filteredSubTasks.map((s) => (
       <FutureViewSubTask
-        key={s.id}
+        key={s.order}
         subTask={s}
-        mainTaskId={original.id}
-        replaceDateForFork={replaceDateForForkOpt}
+        taskData={original}
         mainTaskCompleted={original.complete}
       />
     ));

--- a/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
@@ -162,6 +162,7 @@ function FutureViewTask({
         subTask={s}
         taskData={original}
         mainTaskCompleted={original.complete}
+        replaceDateForFork={replaceDateForForkOpt}
       />
     ));
 

--- a/frontend/src/components/TaskView/FutureView/index.tsx
+++ b/frontend/src/components/TaskView/FutureView/index.tsx
@@ -212,7 +212,7 @@ export default function FutureView({ config, onConfigChange }: Props): ReactElem
                 ...task.metadata,
                 date: new Date(destination.droppableId),
               },
-              children: task.children.map((child) => child.id),
+              children: task.children,
             },
           ],
           []

--- a/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
@@ -92,7 +92,7 @@ export default function FloatingTaskEditor({
   const openPopup = (): void => setOpen(true);
   const closePopup = (): void => setOpen(false);
 
-  const { id: _, metadata, children, ...mainTask } = task;
+  const { id: _, metadata, children, ...taskData } = task;
   const actions = {
     onChange: (): void => {
       const editorPosDiv = editorRef.current;
@@ -122,12 +122,12 @@ export default function FloatingTaskEditor({
             type={metadata.type}
             icalUID={icalUID}
             taskAppearedDate={taskAppearedDate}
-            mainTask={{ ...mainTask, date: metadata.date }}
-            subTasks={children}
+            taskData={{ ...taskData, date: metadata.date, children }}
             actions={actions}
             className={styles.Editor}
             editorRef={editorRef}
             calendarPosition={calendarPosition}
+            active
           />
           <div className={styles.BackgroundBlocker} role="presentation" onClick={closePopup} />
         </>

--- a/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
@@ -127,7 +127,6 @@ export default function FloatingTaskEditor({
             className={styles.Editor}
             editorRef={editorRef}
             calendarPosition={calendarPosition}
-            active
           />
           <div className={styles.BackgroundBlocker} role="presentation" onClick={closePopup} />
         </>

--- a/frontend/src/components/Util/TaskEditors/InlineTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/InlineTaskEditor.tsx
@@ -24,7 +24,7 @@ export default function InlineTaskEditor({
 }: Props): ReactElement {
   const [disabled, setDisabled] = useState(true);
   const { id } = original;
-  const { id: _, metadata, children, ...mainTask } = filtered;
+  const { id: _, metadata, children, ...taskData } = filtered;
   const icalUID = original.metadata.type === 'ONE_TIME' ? original.metadata.icalUID : '';
   const taskAppearedDate = metadata.date instanceof Date ? metadata.date.toDateString() : null;
   // To un-mount the editor when finished editing.
@@ -41,8 +41,7 @@ export default function InlineTaskEditor({
       icalUID={icalUID}
       taskAppearedDate={taskAppearedDate}
       className={className}
-      mainTask={{ ...mainTask, date: metadata.date }}
-      subTasks={children}
+      taskData={{ ...taskData, date: metadata.date, children }}
       actions={actions}
       displayGrabber
       calendarPosition={calendarPosition}

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/OneSubTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/OneSubTaskEditor.tsx
@@ -1,20 +1,15 @@
 import React, { KeyboardEvent, ReactElement, SyntheticEvent, useEffect, useRef } from 'react';
-import { PartialSubTask, SubTask } from 'common/types/store-types';
-import { getDateWithDateString } from 'common/util/datetime-util';
+import { SubTask } from 'common/types/store-types';
 import CheckBox from '../../../UI/CheckBox';
 import SamwiseIcon from '../../../UI/SamwiseIcon';
-import { editSubTask } from '../../../../firebase/actions';
 import styles from './index.module.scss';
 
 type Props = {
   readonly subTask: SubTask; // the subtask to edit
   readonly mainTaskComplete: boolean; // whether the main task is completed
-  readonly mainTaskId: string;
-  readonly taskDate: Date | null;
-  readonly dateAppeared: string;
   readonly needToBeFocused: boolean; // whether it needs to be focused.
-  readonly editThisSubTask: (subtaskId: string, partialSubTask: PartialSubTask) => void;
-  readonly removeSubTask: (subtaskId: string) => void;
+  readonly onEdit: (update: Partial<SubTask>, subTaskToUpdate: SubTask) => void;
+  readonly onRemove: (subTaskToRemove: SubTask) => void;
   readonly onPressEnter: (id: 'main-task' | number) => void;
   readonly memberName?: string; // only supplied if task is a group task
 };
@@ -25,28 +20,24 @@ const deleteIconClass = [styles.TaskEditorIcon, styles.TaskEditorIconLeftPad].jo
 function OneSubTaskEditor({
   subTask,
   mainTaskComplete,
-  mainTaskId,
-  taskDate,
-  dateAppeared,
   needToBeFocused,
-  editThisSubTask,
-  removeSubTask,
+  onEdit,
+  onRemove,
   onPressEnter,
   memberName,
 }: Props): ReactElement {
-  const replaceDateForFork =
-    taskDate == null ? getDateWithDateString(taskDate, dateAppeared) : null;
+  const editThisSubTask = (update: Partial<SubTask>): void => {
+    onEdit(update, subTask);
+  };
+
   const onCompleteChange = (): void => {
     const complete = !subTask.complete;
-    editThisSubTask(subTask.id, { complete });
-    editSubTask(mainTaskId, subTask.id, replaceDateForFork, { complete });
+    editThisSubTask({ complete });
   };
   const onInFocusChange = (): void => {
     const inFocus = !subTask.inFocus;
-    editThisSubTask(subTask.id, { inFocus });
-    editSubTask(mainTaskId, subTask.id, replaceDateForFork, { inFocus });
+    editThisSubTask({ inFocus });
   };
-  const onRemove = (): void => removeSubTask(subTask.id);
 
   const onKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
     if (event.key !== 'Enter') {
@@ -58,7 +49,7 @@ function OneSubTaskEditor({
   const onInputChange = (event: SyntheticEvent<HTMLInputElement>): void => {
     event.stopPropagation();
     const newValue = event.currentTarget.value;
-    editThisSubTask(subTask.id, { name: newValue });
+    editThisSubTask({ name: newValue });
   };
   const onBlur = (event: SyntheticEvent<HTMLInputElement>): void => {
     event.stopPropagation();
@@ -107,7 +98,11 @@ function OneSubTaskEditor({
           onClick={onInFocusChange}
         />
       )}
-      <SamwiseIcon iconName="x-light" onClick={onRemove} className={deleteIconClass} />
+      <SamwiseIcon
+        iconName="x-light"
+        onClick={() => onRemove(subTask)}
+        className={deleteIconClass}
+      />
     </div>
   );
 }

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -63,6 +63,8 @@ export type TaskWithoutIdOrderChildren<M = TaskMetadata> = Omit<
   'id' | 'order' | 'children'
 >;
 
+export type TaskWithoutIdOrder<M = TaskMetadata> = Omit<Task<M>, 'id' | 'order'>;
+
 /*
  * --------------------------------------------------------------------------------
  * Section 1: Tags Actions
@@ -163,7 +165,7 @@ export const handleTaskDiffs = (taskId: string, { mainTaskEdits }: Diff): void =
   });
 };
 
-type EditType = 'EDITING_MASTER_TEMPLATE' | 'EDITING_ONE_TIME_TASK';
+export type EditType = 'EDITING_MASTER_TEMPLATE' | 'EDITING_ONE_TIME_TASK';
 
 export const editTaskWithDiff = (
   taskId: string,
@@ -186,8 +188,9 @@ export const forkTaskWithDiff = (
   const { tasks } = store.getState();
   const repeatingTaskMaster = tasks.get(taskId) as Task<RepeatingTaskMetadata>;
   const { id, order, children, metadata, ...originalTaskWithoutId } = repeatingTaskMaster;
-  const newMainTask: TaskWithoutIdOrderChildren = {
+  const newMainTask: TaskWithoutIdOrder = {
     ...originalTaskWithoutId,
+    children,
     ...mainTaskEdits,
     metadata: {
       type: 'ONE_TIME',
@@ -198,7 +201,7 @@ export const forkTaskWithDiff = (
   const batch = database.db().batch();
   const forkId = getNewTaskId();
   const owner = [getAppUser().email];
-  asyncAddTask(forkId, owner, newMainTask, children, batch).then(() => {
+  asyncAddTask(forkId, owner, newMainTask, newMainTask.children, batch).then(() => {
     batch.update(database.tasksCollection().doc(id), {
       forks: firestore.FieldValue.arrayUnion({ forkId, replaceDate }),
     });

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -1,13 +1,12 @@
 import { firestore } from 'firebase/app';
-import { Map, Set } from 'immutable';
+import { Map } from 'immutable';
 import {
   Course,
   SubTask,
   Tag,
   Task,
   BannerMessageIds,
-  PartialMainTask,
-  PartialSubTask,
+  PartialTaskMainData,
   TaskMetadata,
   RepeatingTaskMetadata,
   OneTimeTaskMetadata,
@@ -17,13 +16,13 @@ import { error, ignore } from 'common/util/general-util';
 import {
   FirestoreCommon,
   FirestoreTask,
-  FirestoreSubTask,
   FirestoreGroup,
   FirestoreUserData,
+  FirestoreCommonTask,
 } from 'common/types/firestore-types';
 import { WriteBatch } from 'common/firebase/database';
 import Actions from 'common/firebase/common-actions';
-import { TaskWithChildrenId } from 'common/types/action-types';
+import { subTasksEqual } from 'common/util/task-util';
 import {
   reportAddTagEvent,
   reportEditTagEvent,
@@ -31,9 +30,6 @@ import {
   reportAddTaskEvent,
   reportEditTaskEvent,
   reportDeleteTaskEvent,
-  reportAddSubTaskEvent,
-  reportEditSubTaskEvent,
-  reportDeleteSubTaskEvent,
   reportCompleteTaskEvent,
   reportFocusTaskEvent,
 } from '../util/ga-util';
@@ -41,7 +37,7 @@ import { getAppUser } from './auth-util';
 import { db, database } from './db';
 import { getNewTaskId } from './id-provider';
 import { store } from '../store/store';
-import { patchTags, patchTasks, patchSubTasks } from '../store/actions';
+import { patchTags, patchTasks } from '../store/actions';
 import { Diff } from '../components/Util/TaskEditors/TaskEditor/task-diff-reducer';
 
 const actions = new Actions(() => getAppUser().email, database);
@@ -100,22 +96,15 @@ const asyncAddTask = async (
   newTaskId: string,
   owner: readonly string[],
   task: TaskWithoutIdOrderChildren,
-  subTasks: WithoutId<SubTask>[],
+  subTasks: readonly SubTask[],
   batch: WriteBatch
-): Promise<{ readonly firestoreTask: FirestoreTask; readonly createdSubTasks: SubTask[] }> => {
+): Promise<FirestoreTask> => {
   const baseTask: FirestoreCommon = await createFirestoreObject('tasks', {}, owner);
-  const createdSubTasks: SubTask[] = subTasks.map((subtask) => {
-    const firebaseSubTask: FirestoreSubTask = mergeWithOwner(subtask);
-    const subtaskDoc = database.subTasksCollection().doc();
-    batch.set(subtaskDoc, firebaseSubTask);
-    return { ...subtask, id: subtaskDoc.id };
-  });
-  const subtaskIds = createdSubTasks.map((s) => s.id);
   const { metadata, ...rest } = task;
   rest.owner = baseTask.owner as readonly string[];
-  const firestoreTask: FirestoreTask = { ...baseTask, ...rest, ...metadata, children: subtaskIds };
+  const firestoreTask: FirestoreTask = { ...baseTask, ...rest, ...metadata, children: subTasks };
   batch.set(database.tasksCollection().doc(newTaskId), firestoreTask);
-  return { firestoreTask, createdSubTasks };
+  return firestoreTask;
 };
 
 export const addTask = (
@@ -126,10 +115,9 @@ export const addTask = (
   const taskOwner = [''].toString() === owner.toString() ? [getAppUser().email] : owner;
   const newTaskId = getNewTaskId();
   const batch = db().batch();
-  asyncAddTask(newTaskId, taskOwner, task, subTasks, batch).then(({ createdSubTasks }) => {
+  asyncAddTask(newTaskId, taskOwner, task, subTasks, batch).then(() => {
     batch.commit().then(() => {
       reportAddTaskEvent();
-      createdSubTasks.forEach(reportAddSubTaskEvent);
     });
   });
 };
@@ -143,15 +131,7 @@ export const removeAllForks = (taskId: string): void => {
     const batch = database.db().batch();
     forkIds.forEach((id) => {
       if (id !== null) {
-        // delete forked main task
         batch.delete(database.tasksCollection().doc(id));
-        // delete forked subtasks
-        const forkedTask = tasks.get(id);
-        if (forkedTask != null) {
-          forkedTask.children.forEach((subTask) =>
-            batch.delete(database.subTasksCollection().doc(subTask.id))
-          );
-        }
       }
     });
     // clear the forked array
@@ -160,34 +140,8 @@ export const removeAllForks = (taskId: string): void => {
   })();
 };
 
-export const handleTaskDiffs = (
-  taskId: string,
-  { subTaskCreations, subTaskEdits, subTaskDeletions, mainTaskEdits }: Diff
-): void => {
+export const handleTaskDiffs = (taskId: string, { mainTaskEdits }: Diff): void => {
   const batch = database.db().batch();
-  if (subTaskCreations.size !== 0) {
-    subTaskCreations.forEach((subTask, id) => {
-      const newSubTaskDoc = database.subTasksCollection().doc(id);
-      const firebaseSubTask: FirestoreSubTask = mergeWithOwner(subTask);
-      batch.set(newSubTaskDoc, firebaseSubTask);
-      batch.update(database.tasksCollection().doc(taskId), {
-        children: firestore.FieldValue.arrayUnion(newSubTaskDoc.id),
-      });
-    });
-  }
-  if (subTaskEdits.size !== 0) {
-    subTaskEdits.forEach((partialSubTask, id) => {
-      batch.update(database.subTasksCollection().doc(id), partialSubTask);
-    });
-  }
-  if (subTaskDeletions.size !== 0) {
-    subTaskDeletions.forEach((id) => {
-      batch.delete(database.subTasksCollection().doc(id));
-      batch.update(database.tasksCollection().doc(taskId), {
-        children: firestore.FieldValue.arrayRemove(id),
-      });
-    });
-  }
   batch.update(database.tasksCollection().doc(taskId), mainTaskEdits);
   batch.commit().then(() => {
     if (
@@ -195,7 +149,8 @@ export const handleTaskDiffs = (
       mainTaskEdits.complete ||
       mainTaskEdits.date ||
       mainTaskEdits.inFocus ||
-      mainTaskEdits.tag
+      mainTaskEdits.tag ||
+      mainTaskEdits.children
     ) {
       reportEditTaskEvent();
     }
@@ -205,9 +160,6 @@ export const handleTaskDiffs = (
     if (mainTaskEdits.inFocus) {
       reportFocusTaskEvent();
     }
-    subTaskCreations.forEach(reportAddSubTaskEvent);
-    subTaskEdits.forEach(reportEditSubTaskEvent);
-    subTaskDeletions.forEach(reportDeleteSubTaskEvent);
   });
 };
 
@@ -216,20 +168,20 @@ type EditType = 'EDITING_MASTER_TEMPLATE' | 'EDITING_ONE_TIME_TASK';
 export const editTaskWithDiff = (
   taskId: string,
   editType: EditType,
-  { mainTaskEdits, subTaskCreations, subTaskEdits, subTaskDeletions }: Diff
+  { mainTaskEdits }: Diff
 ): void => {
   (async () => {
     if (editType === 'EDITING_MASTER_TEMPLATE') {
       await removeAllForks(taskId);
     }
-    handleTaskDiffs(taskId, { subTaskCreations, subTaskEdits, subTaskDeletions, mainTaskEdits });
+    handleTaskDiffs(taskId, { mainTaskEdits });
   })();
 };
 
 export const forkTaskWithDiff = (
   taskId: string,
   replaceDate: Date,
-  { mainTaskEdits, subTaskCreations, subTaskEdits, subTaskDeletions }: Diff
+  { mainTaskEdits }: Diff
 ): void => {
   const { tasks } = store.getState();
   const repeatingTaskMaster = tasks.get(taskId) as Task<RepeatingTaskMetadata>;
@@ -242,24 +194,11 @@ export const forkTaskWithDiff = (
       date: replaceDate,
     },
   };
-  const newSubTasks: WithoutId<SubTask>[] = [];
-  subTaskCreations.forEach((s) => newSubTasks.push(s));
-  children.forEach((subTask) => {
-    if (subTaskDeletions.has(subTask.id)) {
-      return;
-    }
-    const { id: _, ...subTaskContent } = subTask;
-    const subTaskEdit = subTaskEdits.get(subTask.id);
-    if (subTaskEdit != null) {
-      newSubTasks.push({ ...subTaskContent, ...subTaskEdit });
-    } else {
-      newSubTasks.push(subTaskContent);
-    }
-  });
+
   const batch = database.db().batch();
   const forkId = getNewTaskId();
   const owner = [getAppUser().email];
-  asyncAddTask(forkId, owner, newMainTask, newSubTasks, batch).then(() => {
+  asyncAddTask(forkId, owner, newMainTask, children, batch).then(() => {
     batch.update(database.tasksCollection().doc(id), {
       forks: firestore.FieldValue.arrayUnion({ forkId, replaceDate }),
     });
@@ -271,7 +210,6 @@ export const removeTask = (task: Task): void => {
   const { tasks, repeatedTaskSet } = store.getState();
   const batch = database.db().batch();
   batch.delete(database.tasksCollection().doc(task.id));
-  task.children.forEach((subTask) => batch.delete(database.subTasksCollection().doc(subTask.id)));
   if (task.metadata.type === 'ONE_TIME' || task.metadata.type === 'GROUP') {
     // remove fork mentions
     repeatedTaskSet.forEach((repeatedTaskId) => {
@@ -303,12 +241,6 @@ export const removeTask = (task: Task): void => {
         return;
       }
       batch.delete(database.tasksCollection().doc(forkId));
-      const forkedTask = tasks.get(forkId);
-      if (forkedTask != null) {
-        forkedTask.children.forEach((subTask) =>
-          batch.delete(database.subTasksCollection().doc(subTask.id))
-        );
-      }
     });
   }
   batch.commit().then(() => {
@@ -328,57 +260,15 @@ export const removeOneRepeatedTask = (taskId: string, replaceDate: Date): void =
 export const editMainTask = (
   taskId: string,
   replaceDate: Date | null,
-  mainTaskEdits: PartialMainTask
+  mainTaskEdits: PartialTaskMainData
 ): void => {
-  const diff: Diff = {
-    mainTaskEdits,
-    subTaskCreations: Map(),
-    subTaskEdits: Map(),
-    subTaskDeletions: Set(),
-  };
+  const diff: Diff = { mainTaskEdits };
   if (replaceDate === null) {
     editTaskWithDiff(taskId, 'EDITING_ONE_TIME_TASK', diff);
   } else {
     const dateEdit = mainTaskEdits.date != null ? mainTaskEdits.date : replaceDate;
     const newDiff = { ...diff, mainTaskEdits: { ...diff.mainTaskEdits, date: dateEdit } };
     forkTaskWithDiff(taskId, replaceDate, newDiff);
-  }
-};
-
-export const editSubTask = (
-  taskId: string,
-  subtaskId: string,
-  replaceDate: Date | null,
-  partialSubTask: PartialSubTask
-): void => {
-  const diff: Diff = {
-    mainTaskEdits: replaceDate == null ? {} : { date: replaceDate },
-    subTaskCreations: Map(),
-    subTaskEdits: Map<string, PartialSubTask>().set(subtaskId, partialSubTask),
-    subTaskDeletions: Set(),
-  };
-  if (replaceDate === null) {
-    editTaskWithDiff(taskId, 'EDITING_ONE_TIME_TASK', diff);
-  } else {
-    forkTaskWithDiff(taskId, replaceDate, diff);
-  }
-};
-
-export const removeSubTask = (
-  taskId: string,
-  subtaskId: string,
-  replaceDate: Date | null
-): void => {
-  const diff: Diff = {
-    mainTaskEdits: replaceDate == null ? {} : { date: replaceDate },
-    subTaskCreations: Map(),
-    subTaskEdits: Map(),
-    subTaskDeletions: Set.of(subtaskId),
-  };
-  if (replaceDate === null) {
-    editTaskWithDiff(taskId, 'EDITING_ONE_TIME_TASK', diff);
-  } else {
-    forkTaskWithDiff(taskId, replaceDate, diff);
   }
 };
 
@@ -587,12 +477,35 @@ export const addUserInfo = async (
 /**
  * Clear all the completed tasks in focus view.
  */
-export const clearFocus = (taskIds: string[], subTaskIds: string[]): void => {
+export const clearFocus = (
+  taskIds: string[],
+  subTasksWithParentTaskId: Map<string, SubTask[]>
+): void => {
   const batch = database.db().batch();
-  taskIds.forEach((id) => batch.update(database.tasksCollection().doc(id), { inFocus: false }));
-  subTaskIds.forEach((id) =>
-    batch.update(database.subTasksCollection().doc(id), { inFocus: false })
-  );
+  taskIds.forEach(async (id) => {
+    const doc = database.tasksCollection().doc(id);
+    const snapshot = await doc.get();
+    const { children } = (await snapshot.data()) as FirestoreCommonTask;
+    batch.update(doc, { inFocus: false });
+    batch.set(doc, {
+      children: children.map(({ inFocus, ...rest }) => ({ inFocus: false, ...rest })),
+    });
+  });
+  subTasksWithParentTaskId.forEach(async (childrenToBeUpdated, taskId) => {
+    const doc = database.tasksCollection().doc(taskId);
+    const snapshot = await doc.get();
+    const { children } = (await snapshot.data()) as FirestoreCommonTask;
+
+    batch.set(doc, {
+      children: children.map(({ inFocus, ...rest }) =>
+        childrenToBeUpdated.some((s) =>
+          subTasksEqual(s, { inFocus, ...rest })
+            ? { inFocus: false, ...rest }
+            : { inFocus, ...rest }
+        )
+      ),
+    });
+  });
   batch.commit().then(ignore);
 };
 
@@ -612,25 +525,25 @@ export function completeTaskInFocus<T extends { readonly id: string; readonly or
   store.dispatch(
     patchTasks(
       [],
-      [{ ...task, complete: true, children: task.children.map((child) => child.id) }],
-      []
-    )
-  );
-  store.dispatch(
-    patchSubTasks(
-      [],
-      task.children.map((subTask) => ({ ...subTask, complete: true })),
+      [
+        {
+          ...task,
+          complete: true,
+          children: task.children.map((subTask) => ({ ...subTask, complete: true })),
+        },
+      ],
       []
     )
   );
   const batch = database.db().batch();
+  const doc = database.tasksCollection().doc(task.id);
   if (task.inFocus) {
-    batch.update(database.tasksCollection().doc(task.id), { complete: true });
+    batch.update(doc, { complete: true });
   }
-  task.children.forEach((s) => {
-    if (s.inFocus) {
-      batch.update(database.subTasksCollection().doc(s.id), { complete: true });
-    }
+  batch.set(doc, {
+    children: task.children.map(({ inFocus, complete, ...rest }) =>
+      inFocus ? { inFocus, complete: true, rest } : { inFocus, complete, rest }
+    ),
   });
   batch.commit().then(ignore);
 }
@@ -654,14 +567,14 @@ export function applyReorder(orderFor: 'tags' | 'tasks', reorderMap: Map<string,
     });
     store.dispatch(patchTags([], editedTags, []));
   } else {
-    const editedTasks: TaskWithChildrenId[] = [];
+    const editedTasks: Task[] = [];
     Array.from(reorderMap.entries()).forEach(([id, order]) => {
       const existingTask = tasks.get(id);
       if (existingTask !== undefined) {
         editedTasks.push({
           ...existingTask,
           order,
-          children: existingTask.children.map((child) => child.id),
+          children: existingTask.children,
         });
       }
     });

--- a/frontend/src/firebase/id-provider.ts
+++ b/frontend/src/firebase/id-provider.ts
@@ -16,8 +16,3 @@ export const getNewTagId = (): string => database.tagsCollection().doc().id;
  * @returns a safe to use id for a new task.
  */
 export const getNewTaskId = (): string => database.tasksCollection().doc().id;
-
-/**
- * @returns a safe to use id for a new subtask.
- */
-export const getNewSubTaskId = (): string => database.subTasksCollection().doc().id;

--- a/frontend/src/store/actions.ts
+++ b/frontend/src/store/actions.ts
@@ -1,23 +1,14 @@
 import { Map } from 'immutable';
 import {
   PatchCourses,
-  PatchSubTasks,
   PatchTags,
   PatchTasks,
   PatchSettings,
   PatchBannerMessageStatus,
   PatchGroups,
   PatchGroupInvites,
-  TaskWithChildrenId,
 } from 'common/types/action-types';
-import {
-  Course,
-  Tag,
-  SubTask,
-  Settings,
-  BannerMessageStatus,
-  Group,
-} from 'common/types/store-types';
+import { Course, Tag, Settings, BannerMessageStatus, Group, Task } from 'common/types/store-types';
 
 export const patchTags = (created: Tag[], edited: Tag[], deleted: string[]): PatchTags => ({
   type: 'PATCH_TAGS',
@@ -26,23 +17,8 @@ export const patchTags = (created: Tag[], edited: Tag[], deleted: string[]): Pat
   deleted,
 });
 
-export const patchTasks = (
-  created: TaskWithChildrenId[],
-  edited: TaskWithChildrenId[],
-  deleted: string[]
-): PatchTasks => ({
+export const patchTasks = (created: Task[], edited: Task[], deleted: string[]): PatchTasks => ({
   type: 'PATCH_TASKS',
-  created,
-  edited,
-  deleted,
-});
-
-export const patchSubTasks = (
-  created: SubTask[],
-  edited: SubTask[],
-  deleted: string[]
-): PatchSubTasks => ({
-  type: 'PATCH_SUBTASKS',
   created,
   edited,
   deleted,

--- a/frontend/src/store/reducers.test.ts
+++ b/frontend/src/store/reducers.test.ts
@@ -1,9 +1,24 @@
+import { SubTask } from 'common/types/store-types';
 import rootReducer from './reducers';
 import { initialStateForTesting } from './state';
 
 const date = new Date('2031-01-01');
 
-it('reducer works: new task creation -> subtask creation', () => {
+const subTask1: SubTask = {
+  order: 0,
+  name: 'foo subtask',
+  complete: false,
+  inFocus: true,
+};
+
+const subTask2: SubTask = {
+  order: 1,
+  name: 'boo bubtask',
+  complete: false,
+  inFocus: false,
+};
+
+it('reducer works: new task creation with subtasks', () => {
   const intermediateState1 = rootReducer(undefined, {
     type: 'PATCH_TASKS',
     created: [
@@ -15,7 +30,7 @@ it('reducer works: new task creation -> subtask creation', () => {
         tag: 'foo',
         complete: true,
         inFocus: true,
-        children: ['s1', 's2'],
+        children: [subTask1, subTask2],
         metadata: {
           type: 'ONE_TIME',
           date,
@@ -25,85 +40,10 @@ it('reducer works: new task creation -> subtask creation', () => {
     edited: [],
     deleted: [],
   });
-  expect(intermediateState1.tasks.get('1')?.children).toEqual([]);
-  expect(Array.from(intermediateState1.missingSubTasks.entries())).toEqual([
-    ['s1', '1'],
-    ['s2', '1'],
-  ]);
-  expect(Array.from(intermediateState1.orphanSubTasks.entries())).toEqual([]);
-
-  const intermediateState2 = rootReducer(intermediateState1, {
-    type: 'PATCH_SUBTASKS',
-    created: [{ id: 's1', order: 1, name: 'foo', complete: true, inFocus: false }],
-    edited: [],
-    deleted: [],
-  });
-  expect(intermediateState2.tasks.get('1')?.children).toEqual([
-    { id: 's1', order: 1, name: 'foo', complete: true, inFocus: false },
-  ]);
-  expect(Array.from(intermediateState2.missingSubTasks.entries())).toEqual([['s2', '1']]);
-  expect(Array.from(intermediateState2.orphanSubTasks.entries())).toEqual([]);
-
-  const finalState = rootReducer(intermediateState2, {
-    type: 'PATCH_SUBTASKS',
-    created: [{ id: 's2', order: 2, name: 'bar', complete: true, inFocus: false }],
-    edited: [],
-    deleted: [],
-  });
-  expect(finalState.tasks.get('1')?.children).toEqual([
-    { id: 's1', order: 1, name: 'foo', complete: true, inFocus: false },
-    { id: 's2', order: 2, name: 'bar', complete: true, inFocus: false },
-  ]);
-  expect(Array.from(finalState.missingSubTasks.entries())).toEqual([]);
-  expect(Array.from(finalState.orphanSubTasks.entries())).toEqual([]);
+  expect(intermediateState1.tasks.get('1')?.children).toEqual([subTask1, subTask2]);
 });
 
-it('reducer works: subtask creation -> new task creation', () => {
-  const intermediateState = rootReducer(undefined, {
-    type: 'PATCH_SUBTASKS',
-    created: [
-      { id: 's2', order: 2, name: 'bar', complete: true, inFocus: false },
-      { id: 's1', order: 1, name: 'foo', complete: true, inFocus: false },
-    ],
-    edited: [],
-    deleted: [],
-  });
-  expect(Array.from(intermediateState.missingSubTasks.entries())).toEqual([]);
-  expect(Array.from(intermediateState.orphanSubTasks.entries())).toEqual([
-    ['s2', { id: 's2', order: 2, name: 'bar', complete: true, inFocus: false }],
-    ['s1', { id: 's1', order: 1, name: 'foo', complete: true, inFocus: false }],
-  ]);
-
-  const finalState = rootReducer(intermediateState, {
-    type: 'PATCH_TASKS',
-    created: [
-      {
-        id: '1',
-        order: 4,
-        owner: ['foo'],
-        name: 'test',
-        tag: 'foo',
-        complete: true,
-        inFocus: true,
-        children: ['s1', 's2'],
-        metadata: {
-          type: 'ONE_TIME',
-          date,
-        },
-      },
-    ],
-    edited: [],
-    deleted: [],
-  });
-  expect(finalState.tasks.get('1')?.children).toEqual([
-    { id: 's1', order: 1, name: 'foo', complete: true, inFocus: false },
-    { id: 's2', order: 2, name: 'bar', complete: true, inFocus: false },
-  ]);
-  expect(Array.from(finalState.missingSubTasks.entries())).toEqual([]);
-  expect(Array.from(finalState.orphanSubTasks.entries())).toEqual([]);
-});
-
-it('reducer works, task edit -> subtask creation', () => {
+it('reducer works, task edit to create subtask', () => {
   const intermediateState = rootReducer(initialStateForTesting, {
     type: 'PATCH_TASKS',
     created: [],
@@ -116,7 +56,7 @@ it('reducer works, task edit -> subtask creation', () => {
         tag: 'foo',
         complete: true,
         inFocus: false,
-        children: ['foo', 'foo1'],
+        children: [subTask1, subTask2],
         metadata: {
           type: 'ONE_TIME',
           date,
@@ -125,34 +65,13 @@ it('reducer works, task edit -> subtask creation', () => {
     ],
     deleted: [],
   });
-  expect(Array.from(intermediateState.missingSubTasks.entries())).toEqual([['foo1', 'foo']]);
-  expect(Array.from(intermediateState.orphanSubTasks.entries())).toEqual([]);
 
-  const finalState = rootReducer(intermediateState, {
-    type: 'PATCH_SUBTASKS',
-    created: [{ id: 'foo1', order: 0, name: 'Foo1', complete: true, inFocus: false }],
-    edited: [{ id: 'foo', order: 1, name: 'Bar', complete: true, inFocus: false }],
-    deleted: [],
-  });
-  expect(finalState.tasks.get('foo')?.children).toEqual([
-    { id: 'foo1', order: 0, name: 'Foo1', complete: true, inFocus: false },
-    { id: 'foo', order: 1, name: 'Bar', complete: true, inFocus: false },
-  ]);
-  expect(Array.from(finalState.missingSubTasks.entries())).toEqual([]);
-  expect(Array.from(finalState.orphanSubTasks.entries())).toEqual([]);
-});
-
-it('reducer works, subtask creation -> task edit', () => {
-  const intermediateState = rootReducer(initialStateForTesting, {
-    type: 'PATCH_SUBTASKS',
-    created: [{ id: 'foo1', order: 0, name: 'Foo1', complete: true, inFocus: false }],
-    edited: [{ id: 'foo', order: 1, name: 'Bar', complete: true, inFocus: false }],
-    deleted: [],
-  });
-  expect(Array.from(intermediateState.missingSubTasks.entries())).toEqual([]);
-  expect(Array.from(intermediateState.orphanSubTasks.entries())).toEqual([
-    ['foo1', { id: 'foo1', order: 0, name: 'Foo1', complete: true, inFocus: false }],
-  ]);
+  const subTask2Edited: SubTask = {
+    order: 1,
+    name: 'bars',
+    complete: true,
+    inFocus: false,
+  };
 
   const finalState = rootReducer(intermediateState, {
     type: 'PATCH_TASKS',
@@ -166,7 +85,7 @@ it('reducer works, subtask creation -> task edit', () => {
         tag: 'foo',
         complete: true,
         inFocus: false,
-        children: ['foo', 'foo1'],
+        children: [subTask1, subTask2Edited],
         metadata: {
           type: 'ONE_TIME',
           date,
@@ -175,10 +94,6 @@ it('reducer works, subtask creation -> task edit', () => {
     ],
     deleted: [],
   });
-  expect(finalState.tasks.get('foo')?.children).toEqual([
-    { id: 'foo1', order: 0, name: 'Foo1', complete: true, inFocus: false },
-    { id: 'foo', order: 1, name: 'Bar', complete: true, inFocus: false },
-  ]);
-  expect(Array.from(finalState.missingSubTasks.entries())).toEqual([]);
-  expect(Array.from(finalState.orphanSubTasks.entries())).toEqual([]);
+
+  expect(finalState.tasks.get('foo')?.children).toEqual([subTask1, subTask2Edited]);
 });

--- a/frontend/src/store/reducers.ts
+++ b/frontend/src/store/reducers.ts
@@ -4,13 +4,12 @@ import {
   PatchCourses,
   PatchTags,
   PatchTasks,
-  PatchSubTasks,
   PatchSettings,
   PatchBannerMessageStatus,
   PatchGroups,
   PatchGroupInvites,
 } from 'common/types/action-types';
-import { State, SubTask, Task } from 'common/types/store-types';
+import { State, Task } from 'common/types/store-types';
 import { error } from 'common/util/general-util';
 import { initialState } from './state';
 
@@ -146,53 +145,21 @@ function patchTasks(state: State, { created, edited, deleted }: PatchTasks): Sta
     deleted.forEach((id) => s.remove(id));
   });
 
-  const missingSubTasksMap = new Map<string, string>();
-  const orphanSubTasksToClear: string[] = [];
   const newTasks = state.tasks.withMutations((tasks) => {
-    const unfoldSubTasks = (
-      taskId: string,
-      subTaskIds: readonly string[],
-      existingSubTasks: readonly SubTask[]
-    ): readonly SubTask[] => {
-      let newIdSet = Set(subTaskIds);
-      const unfolded: SubTask[] = [];
-      existingSubTasks.forEach((subTask) => {
-        if (newIdSet.has(subTask.id)) {
-          newIdSet = newIdSet.remove(subTask.id);
-          unfolded.push(subTask);
-        }
-      });
-      // Remaining ids represent subtask that has not appeared yet.
-      newIdSet.forEach((id) => {
-        const orphanSubTask = state.orphanSubTasks.get(id);
-        if (orphanSubTask != null) {
-          orphanSubTasksToClear.push(id);
-          newIdSet = newIdSet.remove(id);
-          unfolded.push(orphanSubTask);
-          return;
-        }
-        missingSubTasksMap.set(id, taskId);
-      });
-      return unfolded;
-    };
-
     let dirtyMainTaskIds = Set<string>();
 
     created.forEach((createdMainTask) => {
       const { children, ...mainTaskRest } = createdMainTask;
-      const updatedChildren = unfoldSubTasks(createdMainTask.id, children, []);
-      const mainTask: Task = { ...mainTaskRest, children: updatedChildren };
+      const taskData: Task = { ...mainTaskRest, children };
       dirtyMainTaskIds = dirtyMainTaskIds.add(createdMainTask.id);
-      tasks.set(createdMainTask.id, mainTask);
+      tasks.set(createdMainTask.id, taskData);
     });
 
     edited.forEach((editedMainTask) => {
       const { children, ...mainTaskRest } = editedMainTask;
-      const existingSubTasks = tasks.get(mainTaskRest.id)?.children ?? [];
-      const updatedChildren = unfoldSubTasks(editedMainTask.id, children, existingSubTasks);
-      const mainTask: Task = { ...mainTaskRest, children: updatedChildren };
+      const taskData: Task = { ...mainTaskRest, children };
       dirtyMainTaskIds = dirtyMainTaskIds.add(editedMainTask.id);
-      tasks.set(editedMainTask.id, mainTask);
+      tasks.set(editedMainTask.id, taskData);
     });
 
     deleted.forEach((id) => tasks.delete(id));
@@ -202,95 +169,13 @@ function patchTasks(state: State, { created, edited, deleted }: PatchTasks): Sta
     });
   });
 
-  // Final updates
-  const updatedMissingSubTasks = state.missingSubTasks.withMutations((map) => {
-    missingSubTasksMap.forEach((mainTaskId, subTaskId) => map.set(subTaskId, mainTaskId));
-  });
-  const updatedOrphanSubTasks = state.orphanSubTasks.deleteAll(orphanSubTasksToClear);
-
   return {
     ...state,
     tasks: newTasks,
-    missingSubTasks: updatedMissingSubTasks,
-    orphanSubTasks: updatedOrphanSubTasks,
     dateTaskMap: newDateTaskMap,
     groupTaskMap: newGroupTaskMap,
     repeatedTaskSet: newRepeatedTaskSet,
     groupTaskSet: newGroupTaskSet,
-  };
-}
-
-function patchSubTasks(state: State, { created, edited, deleted }: PatchSubTasks): State {
-  const existingSubTaskToTaskMap = new Map<string, string>();
-  Array.from(state.tasks.entries()).forEach(([id, task]) => {
-    task.children.forEach((subTask) => existingSubTaskToTaskMap.set(subTask.id, id));
-  });
-
-  const missingSubTaskToClear: string[] = [];
-  const newOrphanSubTasks: SubTask[] = [];
-  const updatedTasks = state.tasks.withMutations((mutableTaskMap) => {
-    let dirtyMainTaskIds = Set<string>();
-
-    created.forEach((createdSubTask) => {
-      // By the time a subtask is created, a main task may or may not exist.
-      const mainTaskId = state.missingSubTasks.get(createdSubTask.id);
-      if (mainTaskId == null) {
-        // For those that does not exist, we must put them into orphan sub-tasks for now.
-        // The hope is that they will be stick to correct place in a later task patch.
-        newOrphanSubTasks.push(createdSubTask);
-      } else {
-        // For those that do exist, they must have some missing subtasks.
-        // We must stick them into correct places,
-        mutableTaskMap.update(mainTaskId, (mainTask) => ({
-          ...mainTask,
-          children: [...mainTask.children, createdSubTask],
-        }));
-        missingSubTaskToClear.push(createdSubTask.id);
-        dirtyMainTaskIds = dirtyMainTaskIds.add(mainTaskId);
-      }
-    });
-
-    edited.forEach((editedSubTask) => {
-      // By the time a subtask is edited, the subtask, along with its parent, must exist!
-      const mainTaskId = existingSubTaskToTaskMap.get(editedSubTask.id) ?? error('Must exist!');
-      mutableTaskMap.update(mainTaskId, (mainTask) => {
-        const children = mainTask.children.map((subTask) =>
-          subTask.id === editedSubTask.id ? editedSubTask : subTask
-        );
-        return { ...mainTask, children };
-      });
-      dirtyMainTaskIds = dirtyMainTaskIds.add(mainTaskId);
-    });
-
-    deleted.forEach((deletedSubTaskId) => {
-      const mainTaskId = existingSubTaskToTaskMap.get(deletedSubTaskId);
-      if (mainTaskId == null) {
-        // We might delete main task and subtask together, and main task is deleted before subtask.
-        return;
-      }
-      mutableTaskMap.update(mainTaskId, (mainTask) => ({
-        ...mainTask,
-        children: mainTask.children.filter((subTask) => subTask.id !== deletedSubTaskId),
-      }));
-      dirtyMainTaskIds = dirtyMainTaskIds.add(mainTaskId);
-    });
-
-    dirtyMainTaskIds.forEach((mainTaskId) => {
-      mutableTaskMap.update(mainTaskId, (task) => normalizeTaskChildrenOrder(task));
-    });
-  });
-
-  // Final batch updates for helper store tables.
-  const updatedMissingSubTasks = state.missingSubTasks.deleteAll(missingSubTaskToClear);
-  const updatedOrphanSubTasks = state.orphanSubTasks.withMutations((mutableOrphanSubTasks) => {
-    newOrphanSubTasks.forEach((subTask) => mutableOrphanSubTasks.set(subTask.id, subTask));
-  });
-
-  return {
-    ...state,
-    tasks: updatedTasks,
-    missingSubTasks: updatedMissingSubTasks,
-    orphanSubTasks: updatedOrphanSubTasks,
   };
 }
 
@@ -330,8 +215,6 @@ export default function rootReducer(state: State = initialState, action: Action)
       return patchTags(state, action);
     case 'PATCH_TASKS':
       return patchTasks(state, action);
-    case 'PATCH_SUBTASKS':
-      return patchSubTasks(state, action);
     case 'PATCH_SETTINGS':
       return patchSettings(state, action);
     case 'PATCH_BANNER_MESSAGES':

--- a/frontend/src/store/state.ts
+++ b/frontend/src/store/state.ts
@@ -10,8 +10,6 @@ import { NONE_TAG_ID, NONE_TAG } from 'common/util/tag-util';
 export const initialState: State = {
   tags: Map({ [NONE_TAG_ID]: NONE_TAG }),
   tasks: Map(),
-  missingSubTasks: Map(),
-  orphanSubTasks: Map(),
   dateTaskMap: Map(),
   groupTaskMap: Map(),
   repeatedTaskSet: Set(),
@@ -44,7 +42,7 @@ export const initialStateForTesting: State = {
       tag: 'foo',
       complete: true,
       inFocus: false,
-      children: [{ id: 'foo', order: 1, name: 'Foo', complete: true, inFocus: false }],
+      children: [{ order: 1, name: 'Foo', complete: true, inFocus: false }],
       metadata: {
         type: 'ONE_TIME',
         date: new Date('2030-01-01'),
@@ -58,7 +56,7 @@ export const initialStateForTesting: State = {
       tag: 'bar',
       complete: false,
       inFocus: true,
-      children: [{ id: 'bar', order: 2, name: 'Bar', complete: false, inFocus: true }],
+      children: [{ order: 2, name: 'Bar', complete: false, inFocus: true }],
       metadata: {
         type: 'ONE_TIME',
         date: new Date('2030-01-01'),
@@ -72,7 +70,7 @@ export const initialStateForTesting: State = {
       tag: 'baz',
       complete: true,
       inFocus: true,
-      children: [{ id: 'baz', order: 3, name: 'Baz', complete: true, inFocus: true }],
+      children: [{ order: 3, name: 'Baz', complete: true, inFocus: true }],
       metadata: {
         type: 'ONE_TIME',
         date: new Date('2030-01-01'),
@@ -89,8 +87,6 @@ export const initialStateForTesting: State = {
     groupId2: Set(['bar', 'baz']),
     groupId3: Set(),
   }),
-  missingSubTasks: Map(),
-  orphanSubTasks: Map(),
   repeatedTaskSet: Set(),
   groupTaskSet: Set(),
   settings: { canvasCalendar: null, completedOnboarding: true, theme: 'light' },

--- a/frontend/src/util/ga-util.ts
+++ b/frontend/src/util/ga-util.ts
@@ -36,9 +36,5 @@ export const reportAddTaskEvent = (): void => reportEvent('add-task');
 export const reportEditTaskEvent = (): void => reportEvent('edit-task');
 export const reportDeleteTaskEvent = (): void => reportEvent('delete-task');
 
-export const reportAddSubTaskEvent = (): void => reportEvent('add-sub-task');
-export const reportEditSubTaskEvent = (): void => reportEvent('edit-sub-task');
-export const reportDeleteSubTaskEvent = (): void => reportEvent('delete-sub-task');
-
 export const reportCompleteTaskEvent = (): void => reportEvent('complete');
 export const reportFocusTaskEvent = (): void => reportEvent('focus');

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,6 +17,7 @@
     "firebase-admin": "^9.2.0",
     "firebase-functions": "^3.11.0",
     "ical": "^0.6.0",
+    "immutable": "^4.0.0-rc.12",
     "json-bigint": "^0.3.0",
     "node-fetch": "^2.6.0"
   },

--- a/functions/src/db.ts
+++ b/functions/src/db.ts
@@ -7,7 +7,9 @@ if (process.env.TEST_MODE) {
   console.log('We are in test mode. Skip initializing firebase-admin.');
 } else if (process.env.DEV) {
   admin.initializeApp({
-    credential: JSON.parse(readFileSync('./firebase-adminsdk.json').toString()),
+    credential: admin.credential.cert(
+      JSON.parse(readFileSync('./firebase-adminsdk.json').toString())
+    ),
     databaseURL: 'https://samwise-dev.firebaseio.com',
   });
 } else {

--- a/functions/src/merge-task-subtask.ts
+++ b/functions/src/merge-task-subtask.ts
@@ -1,0 +1,83 @@
+import { FirestoreCommon } from 'common/types/firestore-types';
+import { Map } from 'immutable';
+import { partition } from './util';
+import database from './db';
+
+type OldFirestoreTask = FirestoreCommon & {
+  readonly name: string;
+  readonly tag: string;
+  readonly complete: boolean;
+  readonly inFocus: boolean;
+  readonly children: readonly string[];
+};
+
+type OldFirestoreSubTask = {
+  complete: boolean;
+  inFocus: boolean;
+  name: string;
+  order: number;
+  owner: string;
+};
+
+type NewSubTask = Omit<OldFirestoreSubTask, 'owner'>;
+
+type TaskUpdateData = { id: string; subtasks: NewSubTask[] };
+
+const mergeSubtaskTask = async (): Promise<void> => {
+  const tasksSnapshot = await database.tasksCollection().get();
+  const subTasksSnapshot = await database.subTasksCollection().get();
+  // Initialize map from subtask ID to FirestoreCommonTask representing its data
+  let subTaskMap: Map<string, OldFirestoreSubTask> = Map();
+
+  // Populate map for constant time retrieval of subtasks by ID
+  subTasksSnapshot.forEach((document) => {
+    const data = document.data();
+    const subTask = data as OldFirestoreSubTask;
+    subTaskMap = subTaskMap.set(document.id, subTask);
+  });
+
+  const idListToUpdate: TaskUpdateData[] = [];
+  tasksSnapshot.docs.forEach((document) => {
+    const { id } = document;
+    const data = document.data();
+    if (data != null) {
+      const task = data as OldFirestoreTask;
+      const { children } = task;
+      const subtasks: NewSubTask[] = [];
+      if (children !== undefined && children.length !== 0) {
+        const subTaskOrderSet: Set<number> = new Set<number>();
+        children.forEach((subtaskId) => {
+          const subtask: NewSubTask | undefined = subTaskMap.get(subtaskId);
+          if (subtask !== undefined) {
+            const { complete, inFocus, name, order } = subtask;
+            if (subTaskOrderSet.has(order)) {
+              const uniqueOrder =
+                [...subTaskOrderSet].reduce((acc, curr) => Math.max(acc, curr), 0) + 1;
+              subTaskOrderSet.add(uniqueOrder);
+              subtasks.push({ complete, inFocus, name, order: uniqueOrder });
+            } else {
+              subTaskOrderSet.add(order);
+              subtasks.push({ complete, inFocus, name, order });
+            }
+          }
+        });
+      }
+      idListToUpdate.push({ id, subtasks });
+    }
+  });
+  // Used to overcome to the 500 item per batch limit.
+  const partitioned = partition<TaskUpdateData>(idListToUpdate, 500);
+  // eslint-disable-next-line no-restricted-syntax
+  for (const idOwnerList of partitioned) {
+    const batch = database.db().batch();
+    idOwnerList.forEach(({ id, subtasks }) =>
+      batch.update(database.tasksCollection().doc(id), {
+        children: subtasks,
+      })
+    );
+    // eslint-disable-next-line no-await-in-loop
+    await batch.commit();
+  }
+};
+
+export default mergeSubtaskTask;

--- a/functions/src/merge-task-subtask.ts
+++ b/functions/src/merge-task-subtask.ts
@@ -41,28 +41,30 @@ const mergeSubtaskTask = async (): Promise<void> => {
     const { id } = document;
     const data = document.data();
     if (data != null) {
-      const task = data as OldFirestoreTask;
-      const { children } = task;
-      const subtasks: NewSubTask[] = [];
-      if (children !== undefined && children.length !== 0) {
-        const subTaskOrderSet: Set<number> = new Set<number>();
-        children.forEach((subtaskId) => {
-          const subtask: NewSubTask | undefined = subTaskMap.get(subtaskId);
-          if (subtask !== undefined) {
-            const { complete, inFocus, name, order } = subtask;
-            if (subTaskOrderSet.has(order)) {
-              const uniqueOrder =
-                [...subTaskOrderSet].reduce((acc, curr) => Math.max(acc, curr), 0) + 1;
-              subTaskOrderSet.add(uniqueOrder);
-              subtasks.push({ complete, inFocus, name, order: uniqueOrder });
-            } else {
-              subTaskOrderSet.add(order);
-              subtasks.push({ complete, inFocus, name, order });
+      if (data.children.length !== 0 && typeof data.children[0] === 'string') {
+        const task = data as OldFirestoreTask;
+        const { children } = task;
+        const subtasks: NewSubTask[] = [];
+        if (children !== undefined && children.length !== 0) {
+          const subTaskOrderSet: Set<number> = new Set<number>();
+          children.forEach((subtaskId) => {
+            const subtask: NewSubTask | undefined = subTaskMap.get(subtaskId);
+            if (subtask !== undefined) {
+              const { complete, inFocus, name, order } = subtask;
+              if (subTaskOrderSet.has(order)) {
+                const uniqueOrder =
+                  [...subTaskOrderSet].reduce((acc, curr) => Math.max(acc, curr), 0) + 1;
+                subTaskOrderSet.add(uniqueOrder);
+                subtasks.push({ complete, inFocus, name, order: uniqueOrder });
+              } else {
+                subTaskOrderSet.add(order);
+                subtasks.push({ complete, inFocus, name, order });
+              }
             }
-          }
-        });
+          });
+        }
+        idListToUpdate.push({ id, subtasks });
       }
-      idListToUpdate.push({ id, subtasks });
     }
   });
   // Used to overcome to the 500 item per batch limit.

--- a/functions/src/remove-old-tasks.ts
+++ b/functions/src/remove-old-tasks.ts
@@ -1,4 +1,3 @@
-import { FirestoreCommonTask } from 'common/types/firestore-types';
 import { partition } from './util';
 import database from './db';
 
@@ -20,7 +19,7 @@ const removeOldTasks = async (): Promise<void> => {
     if (data == null) {
       return idListToDelete.push(id);
     }
-    return idListToDelete.push(id, ...(data as FirestoreCommonTask).children);
+    return idListToDelete.push(id);
   });
   // Used to overcome to the 500 item per batch limit.
   const partitioned = partition(idListToDelete, 500);


### PR DESCRIPTION
### Summary <!-- Required -->

It contains @ptwu's change on the subtask -> task frontend migration and a script to migrate existing DB data. The script is already run.

I also merged in the order change in #636, forgetting this release PR still exists... This PR sorts the tasks in the order of [group, repeating, one-time], then by order. Please make sure it doesn't break as well.

### Test Plan <!-- Required -->

Please help test on staging site to ensure nothing breaks, including but not limited to:

- creating tasks
- editing subtask from focus view/future view
- deleting individual subtask in focus view/future view
- focus/complete individual subtask or entire task in focus/future view
