### PR TITLE
Update clearFocus to await on database operations to complete

### DIFF
--- a/frontend/src/components/TaskView/FocusView/ClearFocus.tsx
+++ b/frontend/src/components/TaskView/FocusView/ClearFocus.tsx
@@ -34,7 +34,7 @@ function ClearFocus({ tasks }: Props): ReactElement | null {
   if (taskIds.length === 0) {
     return null;
   }
-  const handleClick = (): void => clearFocus(taskIds, subTasksWithParentTaskId);
+  const handleClick = (): Promise<void> => clearFocus(taskIds, subTasksWithParentTaskId);
   return <SquareTextButton text="Clear Focus" onClick={handleClick} />;
 }
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request fixes the clear focus functionality caused by refactoring in #635. Previously, we did not await on the asynchronous operations of iterating through the tasks and subtasks needed to be cleared from focus, and `batch.commit()` would execute while we were still adding operations to the batch. This PR ensures that these asynchronous operations are completed before committing using `Promise.all`.

- [x] fixes Clear Focus functionality
- [x] fixes push-blocking issue in #645

### Test Plan <!-- Required -->
![s](https://user-images.githubusercontent.com/7517829/98497557-53771180-2212-11eb-921f-e5a810811f28.gif)

Make some tasks and focus them. Complete them and see confetti. Click clear focus.
