### PR TITLE
Make SubTask merge migration script idempotent

### DIFF
--- a/functions/src/merge-task-subtask.ts
+++ b/functions/src/merge-task-subtask.ts
@@ -41,28 +41,30 @@ const mergeSubtaskTask = async (): Promise<void> => {
     const { id } = document;
     const data = document.data();
     if (data != null) {
-      const task = data as OldFirestoreTask;
-      const { children } = task;
-      const subtasks: NewSubTask[] = [];
-      if (children !== undefined && children.length !== 0) {
-        const subTaskOrderSet: Set<number> = new Set<number>();
-        children.forEach((subtaskId) => {
-          const subtask: NewSubTask | undefined = subTaskMap.get(subtaskId);
-          if (subtask !== undefined) {
-            const { complete, inFocus, name, order } = subtask;
-            if (subTaskOrderSet.has(order)) {
-              const uniqueOrder =
-                [...subTaskOrderSet].reduce((acc, curr) => Math.max(acc, curr), 0) + 1;
-              subTaskOrderSet.add(uniqueOrder);
-              subtasks.push({ complete, inFocus, name, order: uniqueOrder });
-            } else {
-              subTaskOrderSet.add(order);
-              subtasks.push({ complete, inFocus, name, order });
+      if (data.children.length !== 0 && typeof data.children[0] === 'string') {
+        const task = data as OldFirestoreTask;
+        const { children } = task;
+        const subtasks: NewSubTask[] = [];
+        if (children !== undefined && children.length !== 0) {
+          const subTaskOrderSet: Set<number> = new Set<number>();
+          children.forEach((subtaskId) => {
+            const subtask: NewSubTask | undefined = subTaskMap.get(subtaskId);
+            if (subtask !== undefined) {
+              const { complete, inFocus, name, order } = subtask;
+              if (subTaskOrderSet.has(order)) {
+                const uniqueOrder =
+                  [...subTaskOrderSet].reduce((acc, curr) => Math.max(acc, curr), 0) + 1;
+                subTaskOrderSet.add(uniqueOrder);
+                subtasks.push({ complete, inFocus, name, order: uniqueOrder });
+              } else {
+                subTaskOrderSet.add(order);
+                subtasks.push({ complete, inFocus, name, order });
+              }
             }
-          }
-        });
+          });
+        }
+        idListToUpdate.push({ id, subtasks });
       }
-      idListToUpdate.push({ id, subtasks });
     }
   });
   // Used to overcome to the 500 item per batch limit.


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request allows for the subtask -> task migration script to be run multiple times without changing the result beyond the initial execution for subtasks already in the new format. It does this by checking if a Task document has a children field that is an array, and if the array contains `string` elements, we know it must be in the old format. Otherwise, we assume it's been updated already.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

Create some tasks with subtasks in the old format using `master` from 3 commits ago. Use `ts-node` to run `merge-task-subtask.ts` with env var `DEV=true`. See that the functionality is preserved. Try running the script again and nothing changes.
