### PR TITLE
Fix forking and handle subtask updates on repeated tasks correctly post-migration

### DIFF
--- a/frontend/src/components/TaskView/FocusView/ClearFocus.tsx
+++ b/frontend/src/components/TaskView/FocusView/ClearFocus.tsx
@@ -19,9 +19,9 @@ function ClearFocus({ tasks }: Props): ReactElement | null {
       t.children.forEach((s) => {
         if (s.inFocus && s.complete) {
           const completedSubtasks = subTasksWithParentTaskId.get(t.id);
-          if (completedSubtasks === undefined) {
+          if (subTasksWithParentTaskId.has(t.id)) {
             subTasksWithParentTaskId = subTasksWithParentTaskId.set(t.id, [s]);
-          } else {
+          } else if (completedSubtasks !== undefined) {
             subTasksWithParentTaskId = subTasksWithParentTaskId.setIn(t.id, [
               s,
               ...completedSubtasks,

--- a/frontend/src/components/TaskView/FutureView/FutureViewSubTask.test.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewSubTask.test.tsx
@@ -20,7 +20,14 @@ const dummyTask: Task<TaskMetadata> = {
 
 it('FutureViewSubTask with null SubTask matches snapshot.', () => {
   const tree = renderer
-    .create(<FutureViewSubTask taskData={dummyTask} subTask={null} mainTaskCompleted />)
+    .create(
+      <FutureViewSubTask
+        taskData={dummyTask}
+        subTask={null}
+        mainTaskCompleted
+        replaceDateForFork={null}
+      />
+    )
     .toJSON();
   expect(tree).toMatchSnapshot();
 });
@@ -34,6 +41,7 @@ const createTest = (inFocus: boolean, complete: boolean, mainTaskCompleted: bool
           taskData={dummyTask}
           subTask={{ order: 1, name: 'foo', inFocus, complete }}
           mainTaskCompleted={mainTaskCompleted}
+          replaceDateForFork={null}
         />
       )
       .toJSON();

--- a/frontend/src/components/TaskView/FutureView/FutureViewSubTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewSubTask.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { RepeatingTaskMetadata, SubTask, Task, TaskMetadata } from 'common/types/store-types';
+import { SubTask, Task, TaskMetadata } from 'common/types/store-types';
 import { subTasksEqual } from 'common/util/task-util';
 import styles from './FutureViewTask.module.scss';
 import CheckBox from '../../UI/CheckBox';

--- a/frontend/src/components/TaskView/FutureView/FutureViewSubTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewSubTask.tsx
@@ -1,26 +1,45 @@
 import React, { ReactElement } from 'react';
-import { SubTask, Task, TaskMetadata } from 'common/types/store-types';
+import { RepeatingTaskMetadata, SubTask, Task, TaskMetadata } from 'common/types/store-types';
 import { subTasksEqual } from 'common/util/task-util';
 import styles from './FutureViewTask.module.scss';
 import CheckBox from '../../UI/CheckBox';
-import { editTaskWithDiff } from '../../../firebase/actions';
+import { editTaskWithDiff, EditType, forkTaskWithDiff } from '../../../firebase/actions';
 import SamwiseIcon from '../../UI/SamwiseIcon';
 
 type Props = {
   readonly subTask: SubTask | null;
   readonly taskData: Task<TaskMetadata>;
   readonly mainTaskCompleted: boolean;
+  readonly replaceDateForFork: Date | null;
 };
 
 /**
  * The component used to render one subtask in future view day.
  */
-function FutureViewSubTask({ subTask, taskData, mainTaskCompleted }: Props): ReactElement | null {
+function FutureViewSubTask({
+  subTask,
+  taskData,
+  mainTaskCompleted,
+  replaceDateForFork,
+}: Props): ReactElement | null {
+  const getTaskEditType = (): EditType => {
+    switch (taskData.metadata.type) {
+      case 'ONE_TIME':
+        return 'EDITING_ONE_TIME_TASK';
+      case 'MASTER_TEMPLATE':
+        return 'EDITING_MASTER_TEMPLATE';
+      case 'GROUP':
+        return 'EDITING_ONE_TIME_TASK';
+      default:
+        throw new Error('Invalid task type!');
+    }
+  };
+
   if (subTask == null) {
     return null;
   }
   const onCompleteChange = (): void =>
-    editTaskWithDiff(taskData.id, 'EDITING_ONE_TIME_TASK', {
+    editTaskWithDiff(taskData.id, getTaskEditType(), {
       mainTaskEdits: {
         children: taskData.children.map(({ complete, ...rest }) =>
           subTasksEqual({ complete, ...rest }, subTask)
@@ -29,18 +48,31 @@ function FutureViewSubTask({ subTask, taskData, mainTaskCompleted }: Props): Rea
         ),
       },
     });
-  const onFocusChange = (): void =>
-    editTaskWithDiff(taskData.id, 'EDITING_ONE_TIME_TASK', {
-      mainTaskEdits: {
-        children: taskData.children.map(({ inFocus, ...rest }) =>
-          subTasksEqual({ inFocus, ...rest }, subTask)
-            ? { inFocus: !inFocus, ...rest }
-            : { inFocus, ...rest }
-        ),
-      },
-    });
+  const onFocusChange = (): void => {
+    if (getTaskEditType() === 'EDITING_ONE_TIME_TASK') {
+      editTaskWithDiff(taskData.id, getTaskEditType(), {
+        mainTaskEdits: {
+          children: taskData.children.map(({ inFocus, ...rest }) =>
+            subTasksEqual({ inFocus, ...rest }, subTask)
+              ? { inFocus: !inFocus, ...rest }
+              : { inFocus, ...rest }
+          ),
+        },
+      });
+    } else if (replaceDateForFork != null) {
+      forkTaskWithDiff(taskData.id, replaceDateForFork, {
+        mainTaskEdits: {
+          children: taskData.children.map(({ inFocus, ...rest }) =>
+            subTasksEqual({ inFocus, ...rest }, subTask)
+              ? { inFocus: !inFocus, ...rest }
+              : { inFocus, ...rest }
+          ),
+        },
+      });
+    }
+  };
   const onRemove = (): void =>
-    editTaskWithDiff(taskData.id, 'EDITING_ONE_TIME_TASK', {
+    editTaskWithDiff(taskData.id, getTaskEditType(), {
       mainTaskEdits: {
         children: taskData.children.filter((currSubTask) => !subTasksEqual(currSubTask, subTask)),
       },

--- a/frontend/src/components/TaskView/FutureView/FutureViewSubTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewSubTask.tsx
@@ -35,41 +35,36 @@ function FutureViewSubTask({
     }
   };
 
+  const applyUpdate = (updatedChildren: SubTask[]): void => {
+    const mainTaskEdits = {
+      children: updatedChildren,
+    };
+    if (getTaskEditType() === 'EDITING_ONE_TIME_TASK') {
+      editTaskWithDiff(taskData.id, getTaskEditType(), { mainTaskEdits });
+    } else if (replaceDateForFork != null) {
+      forkTaskWithDiff(taskData.id, replaceDateForFork, { mainTaskEdits });
+    }
+  };
+
   if (subTask == null) {
     return null;
   }
-  const onCompleteChange = (): void =>
-    editTaskWithDiff(taskData.id, getTaskEditType(), {
-      mainTaskEdits: {
-        children: taskData.children.map(({ complete, ...rest }) =>
-          subTasksEqual({ complete, ...rest }, subTask)
-            ? { complete: !complete, ...rest }
-            : { complete, ...rest }
-        ),
-      },
-    });
+  const onCompleteChange = (): void => {
+    const updatedChildren = taskData.children.map(({ complete, ...rest }) =>
+      subTasksEqual({ complete, ...rest }, subTask)
+        ? { complete: !complete, ...rest }
+        : { complete, ...rest }
+    );
+    applyUpdate(updatedChildren);
+  };
+
   const onFocusChange = (): void => {
-    if (getTaskEditType() === 'EDITING_ONE_TIME_TASK') {
-      editTaskWithDiff(taskData.id, getTaskEditType(), {
-        mainTaskEdits: {
-          children: taskData.children.map(({ inFocus, ...rest }) =>
-            subTasksEqual({ inFocus, ...rest }, subTask)
-              ? { inFocus: !inFocus, ...rest }
-              : { inFocus, ...rest }
-          ),
-        },
-      });
-    } else if (replaceDateForFork != null) {
-      forkTaskWithDiff(taskData.id, replaceDateForFork, {
-        mainTaskEdits: {
-          children: taskData.children.map(({ inFocus, ...rest }) =>
-            subTasksEqual({ inFocus, ...rest }, subTask)
-              ? { inFocus: !inFocus, ...rest }
-              : { inFocus, ...rest }
-          ),
-        },
-      });
-    }
+    const updatedChildren = taskData.children.map(({ inFocus, ...rest }) =>
+      subTasksEqual({ inFocus, ...rest }, subTask)
+        ? { inFocus: !inFocus, ...rest }
+        : { inFocus, ...rest }
+    );
+    applyUpdate(updatedChildren);
   };
   const onRemove = (): void =>
     editTaskWithDiff(taskData.id, getTaskEditType(), {

--- a/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
@@ -162,6 +162,7 @@ function FutureViewTask({
         subTask={s}
         taskData={original}
         mainTaskCompleted={original.complete}
+        replaceDateForFork={replaceDateForForkOpt}
       />
     ));
 

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -63,6 +63,8 @@ export type TaskWithoutIdOrderChildren<M = TaskMetadata> = Omit<
   'id' | 'order' | 'children'
 >;
 
+export type TaskWithoutIdOrder<M = TaskMetadata> = Omit<Task<M>, 'id' | 'order'>;
+
 /*
  * --------------------------------------------------------------------------------
  * Section 1: Tags Actions
@@ -186,8 +188,9 @@ export const forkTaskWithDiff = (
   const { tasks } = store.getState();
   const repeatingTaskMaster = tasks.get(taskId) as Task<RepeatingTaskMetadata>;
   const { id, order, children, metadata, ...originalTaskWithoutId } = repeatingTaskMaster;
-  const newMainTask: TaskWithoutIdOrderChildren = {
+  const newMainTask: TaskWithoutIdOrder = {
     ...originalTaskWithoutId,
+    children,
     ...mainTaskEdits,
     metadata: {
       type: 'ONE_TIME',
@@ -198,7 +201,7 @@ export const forkTaskWithDiff = (
   const batch = database.db().batch();
   const forkId = getNewTaskId();
   const owner = [getAppUser().email];
-  asyncAddTask(forkId, owner, newMainTask, children, batch).then(() => {
+  asyncAddTask(forkId, owner, newMainTask, newMainTask.children, batch).then(() => {
     batch.update(database.tasksCollection().doc(id), {
       forks: firestore.FieldValue.arrayUnion({ forkId, replaceDate }),
     });

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -163,7 +163,7 @@ export const handleTaskDiffs = (taskId: string, { mainTaskEdits }: Diff): void =
   });
 };
 
-type EditType = 'EDITING_MASTER_TEMPLATE' | 'EDITING_ONE_TIME_TASK';
+export type EditType = 'EDITING_MASTER_TEMPLATE' | 'EDITING_ONE_TIME_TASK';
 
 export const editTaskWithDiff = (
   taskId: string,


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This PR fixes an issue with subtask editing on repeated tasks as pointed out by @meganyin13 in #645. Previously, we assumed that all tasks were one time when updating subtasks, which was a naive implementation by me since updating specific subtasks and their attributes can get messy across repeating tasks and their forks, and with the refactor, we still have to consider forked tasks. 

In this PR, we bring back the `replaceDateForFork` prop into `FutureViewSubTask` since we need that data to know which task fork to update with the specific subtask change that we are currently handling. We can then fork a task with a given diff change using our updated `children` array after a subtask is updated for a repeated task that has a `replaceDateForFork`, 

- [x] fixed repeated task subtask editing and focusing

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

![6mjBuew4rR](https://user-images.githubusercontent.com/7517829/98605076-e10a3e00-22b2-11eb-97ff-5d29bf6f2dfa.gif)

Create a repeating task on staging. Add some subtasks and apply it to all occurrences. See that all occurrences have been updated to match these subtasks. Attempt to add a subtask for a singular fork. See that the fork applies. Randomly focus subtasks and see they get added to focus view.



### Future Steps

Refactoring of the `Diff` type to just be a `PartialMainTask` (also renaming that, since there's just a `Task` now) will help reduce some LOC since we have only one property in the object. 

