### PR TITLE
Fix subtask removal in repeated tasks post-migration

### DIFF
--- a/frontend/src/components/TaskView/FutureView/FutureViewSubTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewSubTask.tsx
@@ -66,12 +66,14 @@ function FutureViewSubTask({
     );
     applyUpdate(updatedChildren);
   };
-  const onRemove = (): void =>
-    editTaskWithDiff(taskData.id, getTaskEditType(), {
-      mainTaskEdits: {
-        children: taskData.children.filter((currSubTask) => !subTasksEqual(currSubTask, subTask)),
-      },
-    });
+
+  const onRemove = (): void => {
+    const updatedChildren = taskData.children.filter(
+      (currSubTask) => !subTasksEqual(currSubTask, subTask)
+    );
+    applyUpdate(updatedChildren);
+  };
+
   return (
     <div className={styles.SubTask}>
       <CheckBox


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

Forgot to update the `applyUpdate` function to be used for `onRemove` in `FutureViewSubTask`. This diff fixes that. Now, deleting a subtask should not remove all instances of the subtask across a template, but should fork the individual task with the deleted subtask instead.

### Test Plan <!-- Required -->

![img](https://user-images.githubusercontent.com/7517829/98634898-066a6c80-22f2-11eb-9ab4-8e1eb70d0f08.gif)

### Notes
#645 should be reviewable now after this PR.
