### PR TITLE
Eliminate all vh that is not 100vh

### DIFF
--- a/frontend/src/components/GroupView/groupview-sizes.scss
+++ b/frontend/src/components/GroupView/groupview-sizes.scss
@@ -1,5 +1,5 @@
 $middlebar-width: 280px;
-$taskcreator-height: 60px;
+$taskcreator-height: 50px;
 $progressbar-height: 80px;
 
 $sidebar-width: 80px;

--- a/frontend/src/components/TaskCreator/index.module.scss
+++ b/frontend/src/components/TaskCreator/index.module.scss
@@ -1,7 +1,10 @@
+@import '../../layout-sizes.scss';
+
 .TaskCreator {
   display: flex;
   flex-direction: row;
   justify-content: center;
+  height: $task-creator-height;
 }
 
 .NewTaskComponent {
@@ -49,7 +52,7 @@
   }
   .SubmitNewTask,
   .GroupSubmitNewTask.GroupSubmitNewTask {
-    height: 50px;
+    height: $task-creator-height;
   }
   .NewTaskModal {
     width: calc(30vw + 60px);
@@ -64,17 +67,8 @@
   .SubmitNewTask .GroupSubmitNewTask {
     height: 80px;
   }
-  .TaskCreator {
-    height: auto;
-  }
   .NewTaskModal {
     width: calc(90vw + 60px);
-  }
-}
-
-@media only screen and (min-width: 800px) and (min-height: 650px) {
-  .TaskCreator {
-    height: 5vh;
   }
 }
 

--- a/frontend/src/components/TaskView/index.module.scss
+++ b/frontend/src/components/TaskView/index.module.scss
@@ -1,8 +1,10 @@
+@import '../../layout-sizes.scss';
+
 .TaskView {
   padding: 0 32px;
   display: flex;
   flex-direction: row;
-  height: 85vh;
+  height: calc(100vh - #{$title-bar-height} - #{$task-creator-height});
 }
 
 @media only screen and (min-width: 840px) {

--- a/frontend/src/components/TitleBar/index.module.scss
+++ b/frontend/src/components/TitleBar/index.module.scss
@@ -1,14 +1,10 @@
+@import '../../layout-sizes.scss';
+
 .Main {
   position: relative;
   margin: 0;
   padding: 32px 32px 16px 32px;
-  height: 10vh;
-}
-
-@media only screen and (max-width: 840px) {
-  .Main {
-    height: auto;
-  }
+  height: $title-bar-height;
 }
 
 .Time {

--- a/frontend/src/layout-sizes.scss
+++ b/frontend/src/layout-sizes.scss
@@ -1,0 +1,2 @@
+$title-bar-height: 100px;
+$task-creator-height: 50px;


### PR DESCRIPTION
### Summary <!-- Required -->

Non-100vh is almost always bad, because it usually has some hidden assumption of screen size. This PR changes them to px.

### Test Plan <!-- Required -->

<img width="1792" alt="Screen Shot 2020-11-16 at 15 57 39" src="https://user-images.githubusercontent.com/4290500/99307924-2daac780-2825-11eb-8695-9d71a87829e6.png">
<img width="1792" alt="Screen Shot 2020-11-16 at 16 00 16" src="https://user-images.githubusercontent.com/4290500/99307926-2daac780-2825-11eb-8cc7-59c18aa4c950.png">
