### PR TITLE
Avoid using position: absolute to construct TaskCreator. Close #618

### DIFF
--- a/frontend/src/components/TaskCreator/Picker.module.scss
+++ b/frontend/src/components/TaskCreator/Picker.module.scss
@@ -6,7 +6,6 @@
   position: relative;
   color: white;
   margin-left: 5px;
-  transform: translateY(-30px);
   z-index: 2;
 }
 

--- a/frontend/src/components/TaskCreator/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/TaskCreator/__snapshots__/index.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`TaskCreator matches snapshot 1`] = `
   className="TaskCreator TaskCreatorClosed"
 >
   <form
-    className="NewTaskWrap"
+    className="NewTaskWrap "
     onFocus={[Function]}
     onSubmit={[Function]}
   >

--- a/frontend/src/components/TaskCreator/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/TaskCreator/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`TaskCreator matches snapshot 1`] = `
 <div
-  className="TaskCreator"
+  className="TaskCreator TaskCreatorClosed"
 >
   <form
     className="NewTaskWrap"

--- a/frontend/src/components/TaskCreator/index.module.scss
+++ b/frontend/src/components/TaskCreator/index.module.scss
@@ -4,7 +4,22 @@
   display: flex;
   flex-direction: row;
   justify-content: center;
+  &.TaskCreatorClosed {
+    height: $task-creator-height;
+  }
+}
+
+.TaskCreatorOpenedPlaceHolder {
   height: $task-creator-height;
+}
+
+/** The row with new task name input and submit button */
+.TaskCreatorRow {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 100%;
+  margin-bottom: 1em;
 }
 
 .NewTaskComponent {
@@ -20,7 +35,8 @@
   font-family: 'Open Sans', sans-serif;
 
   &.NewTaskComponentOpened {
-    margin-top: 20px;
+    width: unset;
+    flex: 1 1 auto;
   }
 }
 
@@ -37,17 +53,10 @@
 
 .NewTaskWrap {
   position: relative;
-  text-align: center;
-  z-index: 5;
-  bottom: 20px;
-  height: initial;
-  max-height: 44px;
-  margin-bottom: 0;
 }
 
 @media only screen and (min-width: 800px) {
-  .NewTaskWrap,
-  .GroupNewTaskWrap {
+  .NewTaskWrap {
     width: 30vw;
   }
   .SubmitNewTask,
@@ -60,8 +69,7 @@
 }
 
 @media only screen and (max-width: 800px) {
-  .NewTaskWrap,
-  .GroupNewTaskWrap {
+  .NewTaskWrap {
     width: 90vw;
   }
   .SubmitNewTask .GroupSubmitNewTask {
@@ -87,50 +95,22 @@
   height: 100vh;
 }
 
-/**
- * Wrapper for all options only visible when adding task
- */
-.NewTaskActive {
-  position: absolute;
-  top: 12px;
-  height: 20px;
-  width: 100%;
-  right: 0;
-  padding-right: 40px;
-  text-align: right;
-  pointer-events: none;
-}
-
 .TitleText {
-  position: absolute;
-  top: -10px;
-  height: 20px;
-  width: 100%;
+  flex: 1 1 auto;
   text-align: left;
-  padding-bottom: 40px;
   font-weight: bold;
   font-size: 24px;
   pointer-events: none;
 }
 
 .SubtitleText {
-  position: absolute;
-  top: 56px;
-  height: 19px;
-  width: 100%;
   text-align: left;
-  padding-bottom: 40px;
   font-size: 16px;
   pointer-events: none;
 }
 
 .DescText {
-  position: absolute;
-  top: 76px;
-  height: 17px;
-  width: 100%;
   text-align: left;
-  padding-bottom: 40px;
   font-size: 14px;
   pointer-events: none;
   color: #848484;
@@ -146,11 +126,19 @@
 }
 
 .SubmitNewTask {
-  position: absolute;
-  right: 0;
-  top: 7px;
   width: 42px;
   padding-left: 10px;
+  background: white;
+  border: none;
+  cursor: pointer;
+  margin: 0;
+  font-size: 48px;
+}
+
+.GroupSubmitNewTask {
+  width: 42px;
+  padding-left: 13px;
+  height: 50px;
   background: white;
   border: none;
   cursor: pointer;
@@ -162,31 +150,28 @@
  * Pop Open Modal
  */
 .NewTaskModal {
-  background: white;
-  position: absolute;
-  top: -40px;
-  right: -30px;
-  padding: 90px 10px 120px 10px;
-  z-index: -1;
+  position: fixed;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  background-color: white;
+  padding: 1em 2em;
+  z-index: 5;
   box-shadow: 0 8px 65px 3px #444;
-  text-align: center;
 }
 
 .NewTaskModal ul {
   list-style-type: none;
-  margin: 0;
   padding: 0;
-  top: 72px;
 }
 
 .NewTaskModal input[type='text'] {
   border-top: none;
   border-left: none;
   border-right: none;
-  width: calc(100% - 60px);
+  width: calc(100% - 40px);
   padding: 10px 20px 10px 50px;
   outline: none;
-  top: 72px;
 }
 
 .NewTaskModal input[type='text']::placeholder {
@@ -195,51 +180,34 @@
 
 .NewTaskModal .AddSubTask::before {
   content: '+';
-  position: relative;
   font-size: 20px;
 }
 
-.NewTaskModal li {
+.ExistingSubTaskRow {
   position: relative;
 }
 
-.NewTaskModal li button {
+.DeleteSubTaskButton {
   position: absolute;
   width: 20px;
   height: 20px;
-  bottom: 10px;
   border: none;
   background: none;
-  left: 40px;
+  top: 9px;
+  left: 31px;
   cursor: pointer;
 }
 
-.NewTaskModal i {
-  position: absolute;
-  font-size: 30px;
-  color: gray;
-  bottom: 8px;
-}
-
-.NewTaskModal li i {
-  display: block;
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  bottom: 0;
-  left: 0;
-  margin: 0;
-  padding: 0;
-  font-size: 15px;
+input[type='text'].ExistingSubTaskInput {
+  padding: 10px 20px 10px 50px;
+  width: calc(100% - 60px);
 }
 
 .ResetButton {
-  position: absolute;
   background: none;
   border: none;
   cursor: pointer;
-  bottom: 10px;
-  left: 23px;
+  margin-top: 3em;
   color: #ff1a1a;
   font-size: 14px;
   font-weight: 600;
@@ -268,8 +236,7 @@
   color: black;
   box-shadow: -3px 3px 8px rgba(0, 0, 0, 0.25);
   border-radius: 5px;
-  margin-right: 20px !important;
-  margin-left: 40px !important;
+  margin: 0 10px 0 30px;
 }
 
 .TagPickWrap {
@@ -282,42 +249,17 @@
 .EditIcon {
   font-size: 1.3em;
   position: relative;
-  top: 9px;
-  left: 64px;
+  top: 4px;
+  left: 54px;
   color: grey;
 }
 
 .SubtasksContainer {
-  width: calc(90%);
-  margin-top: 84px;
+  text-align: center;
+  width: calc(100% - 42px);
 }
 
 .PlusIcon {
   font-size: 2em;
-  position: relative;
-  left: 25px;
   color: grey;
-}
-
-.GroupNewTaskWrap {
-  position: relative;
-  text-align: center;
-  z-index: 5;
-  height: initial;
-  max-height: 44px;
-  font-family: 'Open Sans', sans-serif;
-}
-
-.GroupSubmitNewTask {
-  position: absolute;
-  right: 0;
-  top: 7px;
-  width: 42px;
-  padding-left: 13px;
-  height: 50px;
-  background: white;
-  border: none;
-  cursor: pointer;
-  margin: 0;
-  font-size: 48px;
 }

--- a/frontend/src/components/TaskCreator/index.module.scss
+++ b/frontend/src/components/TaskCreator/index.module.scss
@@ -58,6 +58,10 @@
 .NewTaskWrap {
   position: relative;
   bottom: 20px;
+
+  &.GroupTaskWrap {
+    bottom: unset;
+  }
 }
 
 @media only screen and (min-width: 800px) {

--- a/frontend/src/components/TaskCreator/index.module.scss
+++ b/frontend/src/components/TaskCreator/index.module.scss
@@ -114,6 +114,7 @@
   font-size: 14px;
   pointer-events: none;
   color: #848484;
+  margin-bottom: 0.5em;
 }
 
 .NewTaskActive * {
@@ -159,11 +160,6 @@
   padding: 1em 2em;
   z-index: 5;
   box-shadow: 0 8px 65px 3px #444;
-}
-
-.NewTaskModal ul {
-  list-style-type: none;
-  padding: 0;
 }
 
 .NewTaskModal input[type='text']::placeholder {
@@ -235,6 +231,8 @@
 }
 
 .SubtasksList {
+  list-style-type: none;
+  padding: 0;
   font-family: 'Open Sans', sans-serif;
   font-size: 12px;
   color: black;

--- a/frontend/src/components/TaskCreator/index.module.scss
+++ b/frontend/src/components/TaskCreator/index.module.scss
@@ -165,15 +165,6 @@
   padding: 0;
 }
 
-.NewTaskModal input[type='text'] {
-  border-top: none;
-  border-left: none;
-  border-right: none;
-  width: calc(100% - 40px);
-  padding: 10px 20px 10px 50px;
-  outline: none;
-}
-
 .NewTaskModal input[type='text']::placeholder {
   color: gray;
 }
@@ -198,8 +189,17 @@
   cursor: pointer;
 }
 
-input[type='text'].ExistingSubTaskInput {
+@mixin subtask-input {
+  border-top: none;
+  border-left: none;
+  border-right: none;
   padding: 10px 20px 10px 50px;
+  outline: none;
+}
+
+.ExistingSubTaskInput {
+  @include subtask-input;
+
   width: calc(100% - 60px);
 }
 
@@ -223,11 +223,14 @@ input[type='text'].ExistingSubTaskInput {
 }
 
 .SubtaskInput {
+  @include subtask-input;
+
   font-family: 'Open Sans', sans-serif;
   font-size: 12px;
   color: black;
   background: #e3e3e3;
-  padding-left: 80px !important;
+  width: calc(100% - 40px);
+  padding-left: 80px;
 }
 
 .SubtasksList {

--- a/frontend/src/components/TaskCreator/index.module.scss
+++ b/frontend/src/components/TaskCreator/index.module.scss
@@ -151,6 +151,7 @@
  */
 .NewTaskModal {
   position: fixed;
+  top: 50px;
   left: 0;
   right: 0;
   margin: 0 auto;

--- a/frontend/src/components/TaskCreator/index.module.scss
+++ b/frontend/src/components/TaskCreator/index.module.scss
@@ -53,6 +53,7 @@
 
 .NewTaskWrap {
   position: relative;
+  bottom: 20px;
 }
 
 @media only screen and (min-width: 800px) {
@@ -155,6 +156,7 @@
   top: 50px;
   left: 0;
   right: 0;
+  bottom: unset;
   margin: 0 auto;
   background-color: white;
   padding: 1em 2em;

--- a/frontend/src/components/TaskCreator/index.module.scss
+++ b/frontend/src/components/TaskCreator/index.module.scss
@@ -20,6 +20,10 @@
   align-items: center;
   width: 100%;
   margin-bottom: 1em;
+
+  &.FirstRow {
+    width: calc(100% - 40px);
+  }
 }
 
 .NewTaskComponent {

--- a/frontend/src/components/TaskCreator/index.tsx
+++ b/frontend/src/components/TaskCreator/index.tsx
@@ -411,13 +411,11 @@ export class TaskCreator extends React.PureComponent<Props, State> {
             </button>
           </div>
           <div className={styles.SubtitleText}>
-            <p>
-              <b>Add Subtasks</b>
-              &nbsp;(optional)
-            </p>
+            <b>Add Subtasks</b>
+            &nbsp;(optional)
           </div>
           <div className={styles.DescText}>
-            <p>Add optional subtasks to break down your tasks into more manageable pieces.</p>
+            Add optional subtasks to break down your tasks into more manageable pieces.
           </div>
           <div style={this.darkModeStyle}>
             <div className={styles.SubtasksContainer}>

--- a/frontend/src/components/TaskCreator/index.tsx
+++ b/frontend/src/components/TaskCreator/index.tsx
@@ -295,7 +295,7 @@ export class TaskCreator extends React.PureComponent<Props, State> {
           style={this.darkModeStyle}
         >
           <form
-            className={styles.NewTaskWrap}
+            className={`${styles.NewTaskWrap} ${groupMemberProfiles ? styles.GroupTaskWrap : ''}`}
             onSubmit={this.handleSave}
             onFocus={this.openNewTask}
           >

--- a/frontend/src/components/TaskCreator/index.tsx
+++ b/frontend/src/components/TaskCreator/index.tsx
@@ -288,11 +288,17 @@ export class TaskCreator extends React.PureComponent<Props, State> {
       datePicked,
       needToSwitchFocus,
     } = this.state;
-    const formClassname = view === 'personal' ? styles.NewTaskWrap : styles.GroupNewTaskWrap;
     if (!this.isOpen) {
       return (
-        <div className={styles.TaskCreator} style={this.darkModeStyle}>
-          <form className={formClassname} onSubmit={this.handleSave} onFocus={this.openNewTask}>
+        <div
+          className={`${styles.TaskCreator} ${styles.TaskCreatorClosed}`}
+          style={this.darkModeStyle}
+        >
+          <form
+            className={styles.NewTaskWrap}
+            onSubmit={this.handleSave}
+            onFocus={this.openNewTask}
+          >
             <input
               required
               type="text"
@@ -321,12 +327,18 @@ export class TaskCreator extends React.PureComponent<Props, State> {
 
       const { order, name: subtaskName } = thisSubTask;
       return (
-        <li key={order}>
-          <button type="button" tabIndex={-1} onClick={this.deleteSubTask(thisSubTask)}>
+        <li key={order} className={styles.ExistingSubTaskRow}>
+          <button
+            className={styles.DeleteSubTaskButton}
+            type="button"
+            tabIndex={-1}
+            onClick={this.deleteSubTask(thisSubTask)}
+          >
             <SamwiseIcon iconName="x-dark" />
           </button>
           <input
             type="text"
+            className={styles.ExistingSubTaskInput}
             ref={refHandler}
             value={subtaskName}
             onChange={this.editSubTask(thisSubTask)}
@@ -340,47 +352,14 @@ export class TaskCreator extends React.PureComponent<Props, State> {
     return (
       <div className={styles.TaskCreator} style={this.darkModeStyle}>
         <div onClick={this.closeNewTask} role="presentation" className={styles.CloseNewTask} />
-        <form className={formClassname} onSubmit={this.handleSave} onFocus={this.openNewTask}>
-          <input
-            required
-            type="text"
-            value={name}
-            onChange={this.editTaskName}
-            className={`${styles.NewTaskComponent} ${styles.NewTaskComponentOpened}`}
-            ref={(e) => {
-              this.addTask = e;
-            }}
-            style={this.darkModeStyle}
-          />
-          <div className={styles.TitleText}>Add Task</div>
-          <div className={styles.NewTaskActive}>
-            <div className={styles.SubtitleText}>
-              <p>
-                <b>Add Subtasks</b>
-                &nbsp;(optional)
-              </p>
-            </div>
-            <div className={styles.DescText}>
-              <p>Add optional subtasks to break down your tasks into more manageable pieces.</p>
-            </div>
-            <div className={styles.NewTaskModal} style={this.darkModeStyle}>
-              <div className={styles.SubtasksContainer}>
-                <ul className={styles.SubtasksList}>{subTasks.map(existingSubTaskEditor)}</ul>
-                <SamwiseIcon iconName="edit" className={styles.EditIcon} tabIndex={-1} />
-                <input
-                  className={styles.SubtaskInput}
-                  type="text"
-                  placeholder="Add a Subtask"
-                  value=""
-                  onChange={this.addNewSubTask}
-                  onKeyDown={this.newSubTaskKeyPress}
-                  style={this.darkModeStyle}
-                />
-              </div>
-              <button type="button" className={styles.ResetButton} onClick={this.resetTask}>
-                DISCARD TASK
-              </button>
-            </div>
+        <div className={styles.TaskCreatorOpenedPlaceHolder} />
+        <form
+          className={`${styles.NewTaskWrap} ${styles.NewTaskModal}`}
+          onSubmit={this.handleSave}
+          onFocus={this.openNewTask}
+        >
+          <div className={styles.TaskCreatorRow}>
+            <div className={styles.TitleText}>Add Task</div>
             {date instanceof Date && <FocusPicker pinned={inFocus} onPinChange={this.togglePin} />}
             <div className={styles.TagPickWrap}>
               {view === 'personal' ? (
@@ -410,6 +389,19 @@ export class TaskCreator extends React.PureComponent<Props, State> {
               onClearPicker={this.clearDate}
               onPickerOpened={this.openDatePicker}
             />
+          </div>
+          <div className={styles.TaskCreatorRow}>
+            <input
+              required
+              type="text"
+              value={name}
+              onChange={this.editTaskName}
+              className={`${styles.NewTaskComponent} ${styles.NewTaskComponentOpened}`}
+              ref={(e) => {
+                this.addTask = e;
+              }}
+              style={this.darkModeStyle}
+            />
             <button
               type="submit"
               className={view === 'personal' ? styles.SubmitNewTask : styles.GroupSubmitNewTask}
@@ -418,6 +410,33 @@ export class TaskCreator extends React.PureComponent<Props, State> {
               <SamwiseIcon iconName="add-task" />
             </button>
           </div>
+          <div className={styles.SubtitleText}>
+            <p>
+              <b>Add Subtasks</b>
+              &nbsp;(optional)
+            </p>
+          </div>
+          <div className={styles.DescText}>
+            <p>Add optional subtasks to break down your tasks into more manageable pieces.</p>
+          </div>
+          <div style={this.darkModeStyle}>
+            <div className={styles.SubtasksContainer}>
+              <ul className={styles.SubtasksList}>{subTasks.map(existingSubTaskEditor)}</ul>
+              <SamwiseIcon iconName="edit" containerClassName={styles.EditIcon} tabIndex={-1} />
+              <input
+                className={styles.SubtaskInput}
+                type="text"
+                placeholder="Add a Subtask"
+                value=""
+                onChange={this.addNewSubTask}
+                onKeyDown={this.newSubTaskKeyPress}
+                style={this.darkModeStyle}
+              />
+            </div>
+          </div>
+          <button type="button" className={styles.ResetButton} onClick={this.resetTask}>
+            DISCARD TASK
+          </button>
         </form>
       </div>
     );

--- a/frontend/src/components/TaskCreator/index.tsx
+++ b/frontend/src/components/TaskCreator/index.tsx
@@ -358,7 +358,7 @@ export class TaskCreator extends React.PureComponent<Props, State> {
           onSubmit={this.handleSave}
           onFocus={this.openNewTask}
         >
-          <div className={styles.TaskCreatorRow}>
+          <div className={`${styles.TaskCreatorRow} ${styles.FirstRow}`}>
             <div className={styles.TitleText}>Add Task</div>
             {date instanceof Date && <FocusPicker pinned={inFocus} onPinChange={this.togglePin} />}
             <div className={styles.TagPickWrap}>


### PR DESCRIPTION
### Summary <!-- Required -->

After #617, #628, #630, #644, we are finally in a good position to fix the bad code in `TaskCreator`.

As a recap, the existing code is only `position: absolute` to hack code positions of varies components of `TaskCreator`, merely to overcome the difficulty to place some content before the `input` without input appearing after those content in JSX.

This PR almost completely rewrites the css related to positioning in `TaskCreator`. I also moved some jsx code around to make the layout make more sense.

### Test Plan <!-- Required -->

Old:
<img width="1792" alt="old" src="https://user-images.githubusercontent.com/4290500/99331290-dec55800-284d-11eb-94c3-6348deda9c23.png">

New personal:
<img width="1362" alt="new-personal" src="https://user-images.githubusercontent.com/4290500/99331340-e258df00-284d-11eb-8a40-04305ccb4200.png">

New group:
<img width="1362" alt="new-group" src="https://user-images.githubusercontent.com/4290500/99331382-e5ec6600-284d-11eb-94cb-017138040169.png">
