### PR TITLE
Use 840px as desktop-mobile breakpoint. Close #432

### DIFF
--- a/frontend/src/components/TaskCreator/index.module.scss
+++ b/frontend/src/components/TaskCreator/index.module.scss
@@ -64,7 +64,7 @@
   }
 }
 
-@media only screen and (min-width: 800px) {
+@media only screen and (min-width: 840px) {
   .NewTaskWrap {
     width: 30vw;
   }
@@ -77,7 +77,7 @@
   }
 }
 
-@media only screen and (max-width: 800px) {
+@media only screen and (max-width: 840px) {
   .NewTaskWrap {
     width: 90vw;
   }

--- a/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
@@ -51,7 +51,7 @@ function FutureViewTask({
   calendarPosition,
   settings,
 }: Props): ReactElement | null {
-  const isSmallScreen = useMappedWindowSize(({ width }) => width <= 768);
+  const isSmallScreen = useMappedWindowSize(({ width }) => width <= 840);
 
   if (compoundTask === null) {
     return null;

--- a/frontend/src/components/TitleBar/Onboarding/Onboard.module.scss
+++ b/frontend/src/components/TitleBar/Onboarding/Onboard.module.scss
@@ -35,7 +35,7 @@ p.SettingsSectionTitle {
   vertical-align: top;
 }
 
-@media only screen and (min-width: 768px) {
+@media only screen and (min-width: 840px) {
   p.SettingsSectionTitle {
     width: 200px;
     display: inline-block;

--- a/frontend/src/components/TitleBar/Settings/SettingsPage.module.scss
+++ b/frontend/src/components/TitleBar/Settings/SettingsPage.module.scss
@@ -12,7 +12,7 @@ p.SettingsSectionTitle {
   vertical-align: top;
 }
 
-@media only screen and (min-width: 768px) {
+@media only screen and (min-width: 840px) {
   p.SettingsSectionTitle {
     width: 200px;
     display: inline-block;

--- a/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
@@ -29,7 +29,7 @@ const updateFloatingEditorPosition = (
   let posTop: number;
   let posLeft: number | undefined;
   let posRight: number | undefined;
-  if (windowWidth <= 768) {
+  if (windowWidth <= 840) {
     posTop = (windowHeight - myHeight) / 2;
     editorPosDiv.style.left = `${windowWidth - EDITOR_WIDTH}px`;
     posLeft = (windowWidth - EDITOR_WIDTH) / 2;


### PR DESCRIPTION
### Summary <!-- Required -->

Make it consistent with the rest of the codebase. Close #432.

### Test Plan <!-- Required -->

Before: 
<img width="944" alt="Screen Shot 2020-11-19 at 12 04 32" src="https://user-images.githubusercontent.com/4290500/99699180-a72dfa00-2a5f-11eb-97cb-041d0ac5eaf8.png">

After:
<img width="944" alt="Screen Shot 2020-11-19 at 12 04 30" src="https://user-images.githubusercontent.com/4290500/99699176-a72dfa00-2a5f-11eb-9f82-7e504e289ad7.png">