### PR TITLE
Fix Editor shifting problem

### DIFF
--- a/frontend/src/components/Util/TaskEditors/TaskEditor/RepeatFrequencyHeader.module.scss
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/RepeatFrequencyHeader.module.scss
@@ -1,7 +1,7 @@
 .Header {
   background: rgba(255, 255, 255, 0.6);
   padding: 9px 9px 6px 9px;
-  height: 100%;
+  height: 36px;
 }
 
 .Icon {


### PR DESCRIPTION
### Summary <!-- Required -->

Give the frequency header a constant height, so that browser can easily pre-compute the height. In this way, there will be no height discrepancy between initial render and subsequent render. This is the root cause of #652, so this PR can close #652.

### Test Plan <!-- Required -->

No longer shifting!
![fix](https://user-images.githubusercontent.com/4290500/99732246-2a197980-2a8d-11eb-86de-7be671a7c8fa.gif)
