### PR TITLE
Use DTI email as sender for group task reminder emails

### DIFF
--- a/functions/src/send-email.ts
+++ b/functions/src/send-email.ts
@@ -66,7 +66,7 @@ const sendEmail = async (data: Data, context: functions.https.CallableContext): 
 
   const msg = {
     to: recipientEmail,
-    from: 'jt568@cornell.edu',
+    from: 'samwise@cornelldti.org',
     subject: `You got a ${variant}!`,
     ...msgContent,
   };

--- a/functions/src/send-email.ts
+++ b/functions/src/send-email.ts
@@ -66,7 +66,7 @@ const sendEmail = async (data: Data, context: functions.https.CallableContext): 
 
   const msg = {
     to: recipientEmail,
-    from: 'samwise@cornelldti.org',
+    from: 'samwise.today.app@gmail.com',
     subject: `You got a ${variant}!`,
     ...msgContent,
   };


### PR DESCRIPTION
### Summary <!-- Required -->

It looks more professional, and emails are sent by sendgrid anyways.

### Test Plan <!-- Required -->

👀 