### PR TITLE
Ensure the group task progress is always at the bottom of the screen

### DIFF
--- a/frontend/src/components/GroupView/RightView/index.module.scss
+++ b/frontend/src/components/GroupView/RightView/index.module.scss
@@ -1,13 +1,20 @@
 @import '../groupview-sizes.scss';
 
+$top-bottom-margin: 20px;
+
+.RightView {
+  padding: $top-bottom-margin;
+  clear: both;
+}
+
 .GroupTaskCreator {
   height: $taskcreator-height;
 }
 
-.RightView {
+.RightViewMain {
   display: flex;
   flex-direction: column;
-  height: calc(100vh - #{$taskcreator-height} - #{$progressbar-height});
+  height: calc(100vh - #{$taskcreator-height} - #{$progressbar-height} - #{$top-bottom-margin} * 2);
   width: calc(100vw - #{$sidebar-width} - #{$middlebar-width});
   padding: 20px;
   clear: both;

--- a/frontend/src/components/GroupView/RightView/index.tsx
+++ b/frontend/src/components/GroupView/RightView/index.tsx
@@ -53,7 +53,7 @@ const RightView = ({ group, groupMemberProfiles, tasks }: Props): ReactElement =
         />
       </div>
 
-      <div className={styles.RightView}>
+      <div className={styles.RightViewMain}>
         <div>
           <h2>{group.name}</h2>
           <SamwiseIcon


### PR DESCRIPTION
### Summary <!-- Required -->

Right now in the code, we are using RightView class twice, which is incorrect and caused we to have wrong layout with regard to replacing task progress at the bottom of the screen. This PR fixes that.

### Test Plan <!-- Required -->

<img width="1404" alt="Screen Shot 2020-12-05 at 15 41 55" src="https://user-images.githubusercontent.com/4290500/101263034-6e08b180-3710-11eb-9883-5942a51193ce.png">
