### PR TITLE
Fix css class typo in GroupViewMiddleBarTaskQueue

### DIFF
--- a/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarTaskQueue.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarTaskQueue.tsx
@@ -25,7 +25,7 @@ function renderTaskList(tasks: readonly Task[]): ReactNode {
 const TaskQueue = ({ tasks }: Props): ReactElement => (
   <div>
     {tasks.length > 0 ? (
-      <div className={styles.TastQueue}>
+      <div className={styles.TaskQueue}>
         <h2>Task Queue</h2>
         <div className={styles.TaskList}>{renderTaskList(tasks)}</div>
       </div>


### PR DESCRIPTION
### Summary <!-- Required -->

🤦 

### Test Plan <!-- Required -->

Before:
<img width="1404" alt="before" src="https://user-images.githubusercontent.com/4290500/101263156-30f0ef00-3711-11eb-9c4b-c2c970cfed6c.png">
After:
<img width="1404" alt="after" src="https://user-images.githubusercontent.com/4290500/101263159-32bab280-3711-11eb-8a9e-08b71f60e06f.png">
