### PR TITLE
Fix Focus View Filtered Subtasks SEV

### DIFF
--- a/frontend/src/components/TaskView/FocusView/FocusTask.tsx
+++ b/frontend/src/components/TaskView/FocusView/FocusTask.tsx
@@ -34,7 +34,7 @@ function FocusTask({ id, order, filterCompleted, original, filtered }: Props): R
             calendarPosition="bottom"
             original={original}
             filtered={filtered}
-            isFocusTask
+            isFocusTaskAndCompleted={filterCompleted}
           />
         </div>
       )}

--- a/frontend/src/components/TaskView/FocusView/FocusTask.tsx
+++ b/frontend/src/components/TaskView/FocusView/FocusTask.tsx
@@ -34,6 +34,7 @@ function FocusTask({ id, order, filterCompleted, original, filtered }: Props): R
             calendarPosition="bottom"
             original={original}
             filtered={filtered}
+            isFocusTask
           />
         </div>
       )}

--- a/frontend/src/components/Util/TaskEditors/InlineTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/InlineTaskEditor.tsx
@@ -12,7 +12,8 @@ type Props = {
   readonly memberName?: string; // only supplied if the task is a group task
   readonly memberEmail?: string; // only supplied if the task is a group task
   readonly groupID?: string; // only supplied if the task is a group task
-  readonly isFocusTask?: boolean; // only supplied if the task is a focus task
+  // True if filtering by completed.
+  readonly isFocusTaskAndCompleted?: boolean; // only supplied if the task is a focus task.
 };
 
 /**
@@ -26,7 +27,7 @@ export default function InlineTaskEditor({
   memberName,
   memberEmail,
   groupID,
-  isFocusTask,
+  isFocusTaskAndCompleted,
 }: Props): ReactElement {
   const [disabled, setDisabled] = useState(true);
   const { id } = original;
@@ -58,7 +59,8 @@ export default function InlineTaskEditor({
       memberName={memberName}
       memberEmail={memberEmail}
       groupID={groupID}
-      wholeTaskData={isFocusTask ? original : undefined}
+      wholeTaskData={isFocusTaskAndCompleted !== undefined ? original : undefined}
+      isFocusTaskAndCompleted={isFocusTaskAndCompleted}
     />
   );
 }

--- a/frontend/src/components/Util/TaskEditors/InlineTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/InlineTaskEditor.tsx
@@ -12,6 +12,7 @@ type Props = {
   readonly memberName?: string; // only supplied if the task is a group task
   readonly memberEmail?: string; // only supplied if the task is a group task
   readonly groupID?: string; // only supplied if the task is a group task
+  readonly isFocusTask?: boolean; // only supplied if the task is a focus task
 };
 
 /**
@@ -25,6 +26,7 @@ export default function InlineTaskEditor({
   memberName,
   memberEmail,
   groupID,
+  isFocusTask,
 }: Props): ReactElement {
   const [disabled, setDisabled] = useState(true);
   const { id } = original;
@@ -56,6 +58,7 @@ export default function InlineTaskEditor({
       memberName={memberName}
       memberEmail={memberEmail}
       groupID={groupID}
+      wholeTaskData={isFocusTask ? original : undefined}
     />
   );
 }


### PR DESCRIPTION
### Background (What happened)

Largely resulting from the changes in #635 (migration of SubTask -> Task in the types), checking off a pinned subtask in a task in focus view can delete other subtasks unintentionally. This is because since subtasks are now a part of the `Task` type, the filter between completed and uncompleted tasks in focus view actually creates two different forks of the same task. This is bad, since we apply changes through the `task-diff-reducer` using its hook which needs to have `Task` data. Also, as pointed out by Sam, since I nuked the subtask diffing functions, the task will not handle these forks correctly, and we now have unexpected behavior.

This issue was pointed out by Michael @mt-xing in #679 (with screenshots on how to reproduce on `master` atm), and this PR aims to fix it.

### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

In order to implement a fix to this problem, we pass the whole `Task` as `Task<TaskMetadata>` into the `TaskEditor` as an optional argument if it is a filtered task from focus view. This way, a filtered task can access its parent's data no matter what. Some undefined checks are implemented to deal with this, which may cause a bit of technical debt, but comments are provided so future developers can understand what the prop functions as. We then use the reducer to get the task data for the filtered part as well as the whole task so that it remains the single source of truth, and since the `OneSubTaskEditor` only cares about the subtask data, we can pass the callbacks from the whole task's reducer hook but sneakily render a list of these subtasks using the filtered data. This way, we can resolve the overwriting problem, as it behaves as if it is in FutureView again.

- [x] fixes #679

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

Create a task with several subtasks. Pin them to focus, and start checking them off. See that there is no unexpected deletion anymore. 

![demo](https://user-images.githubusercontent.com/7517829/101437913-38fe8980-38df-11eb-90f2-8b6dd324178f.gif)

### Notes <!-- Optional -->

RFC: An unintentional side effect (as of right now) of this implementation is that now the `OneSubTaskEditor` checkboxes seem hyper-sensitive to whether the task editor is currently active, i.e. there is a mouse pointer inside of it. This can be seen in the demo GIF, as I have to take my cursor outside of the editor card in order to see the changes happen. This does not affect functionality, however.