### PR TITLE
Fix TaskCreator and member assignment bugs

### DIFF
--- a/frontend/src/components/GroupView/RightView/index.tsx
+++ b/frontend/src/components/GroupView/RightView/index.tsx
@@ -33,8 +33,13 @@ const RightView = ({ group, groupMemberProfiles, tasks }: Props): ReactElement =
 
   const openTaskCreator = (member: readonly SamwiseUserProfile[]): void =>
     setState({
-      taskCreatorOpened: !taskCreatorOpened,
+      taskCreatorOpened: true,
       assignedMembers: member,
+    });
+
+  const closeTaskCreator = (): void =>
+    setState({
+      taskCreatorOpened: false,
     });
 
   const clearAssignedMembers = (): void =>
@@ -48,6 +53,7 @@ const RightView = ({ group, groupMemberProfiles, tasks }: Props): ReactElement =
           group={group.id}
           groupMemberProfiles={groupMemberProfiles}
           taskCreatorOpened={taskCreatorOpened}
+          closeTaskCreator={closeTaskCreator}
           assignedMembers={assignedMembers}
           clearAssignedMembers={clearAssignedMembers}
         />

--- a/frontend/src/components/TaskCreator/index.tsx
+++ b/frontend/src/components/TaskCreator/index.tsx
@@ -96,7 +96,7 @@ export class TaskCreator extends React.PureComponent<Props, State> {
   private openNewTask = (): void => this.setState({ opened: true });
 
   private closeNewTask = (): void => {
-    this.setState({ opened: false});
+    this.setState({ opened: false });
     // Call function to set the prop 'taskCreatorOpened' to be false
     const { closeTaskCreator } = this.props;
     if (closeTaskCreator) {
@@ -145,7 +145,7 @@ export class TaskCreator extends React.PureComponent<Props, State> {
       return;
     }
 
-    const {assignedMembers} = this.props;
+    const { assignedMembers } = this.props;
     const selectedMembers = member || assignedMembers;
     if (selectedMembers) {
       const newOwners = selectedMembers.map((profile) => profile.email);

--- a/frontend/src/components/TaskCreator/index.tsx
+++ b/frontend/src/components/TaskCreator/index.tsx
@@ -43,6 +43,7 @@ type Props = OwnProps & {
   readonly group?: string;
   readonly groupMemberProfiles?: readonly SamwiseUserProfile[];
   readonly taskCreatorOpened?: boolean;
+  readonly closeTaskCreator?: (opened: boolean) => void;
   readonly assignedMembers?: readonly SamwiseUserProfile[];
   readonly clearAssignedMembers?: () => void;
 };
@@ -94,7 +95,14 @@ export class TaskCreator extends React.PureComponent<Props, State> {
 
   private openNewTask = (): void => this.setState({ opened: true });
 
-  private closeNewTask = (): void => this.setState({ opened: false });
+  private closeNewTask = (): void => {
+    this.setState({ opened: false});
+    // Call function to set the prop 'taskCreatorOpened' to be false
+    const { closeTaskCreator } = this.props;
+    if (closeTaskCreator) {
+      closeTaskCreator(false);
+    }
+  };
 
   /**
    * Open the tag picker and close the date picker.

--- a/frontend/src/components/TaskCreator/index.tsx
+++ b/frontend/src/components/TaskCreator/index.tsx
@@ -145,8 +145,10 @@ export class TaskCreator extends React.PureComponent<Props, State> {
       return;
     }
 
-    if (member) {
-      const newOwners = member.map((profile) => profile.email);
+    const {assignedMembers} = this.props;
+    const selectedMembers = member || assignedMembers;
+    if (selectedMembers) {
+      const newOwners = selectedMembers.map((profile) => profile.email);
       owner = newOwners;
     }
 
@@ -387,7 +389,7 @@ export class TaskCreator extends React.PureComponent<Props, State> {
                 />
               ) : (
                 <GroupMemberPicker
-                  member={assignedMembers || member}
+                  member={member || assignedMembers}
                   opened={tagPickerOpened}
                   onMemberChange={this.editMember}
                   onPickerOpened={this.openTagPicker}


### PR DESCRIPTION
### Summary
This pull request fixes `TaskCreator` bugs.

- [x] Fixed `TaskCreator` not closing when opened through the 'Assign new task' button.
- [x] Group tasks are now correctly assigned when using the 'Assign new task' button.
- [x] Manual assignment takes precedence over auto-filled assignment through the button.

### Test Plan
`TaskCreator` now closes correctly.
![close_taskcreator](https://user-images.githubusercontent.com/48143149/101929900-6c723a00-3ba5-11eb-84c0-74bbaaacb244.gif)

Manual member assignment takes precedence.
![assignment_precedence](https://user-images.githubusercontent.com/48143149/101929991-8c096280-3ba5-11eb-92ca-c2ffc31b97c5.gif)

