### PR TITLE
Fix group view css to make things more tidy and aligned

### DIFF
--- a/frontend/src/components/GroupView/RightView/CompletedTasks/CompletedTask.tsx
+++ b/frontend/src/components/GroupView/RightView/CompletedTasks/CompletedTask.tsx
@@ -17,10 +17,8 @@ function CompletedTask({ original, completedTaskCount, overflow }: Props): React
 
   const taskBar = (): ReactElement => (
     <li className={styles.CompletedTask}>
-      <span>
-        <SamwiseIcon iconName="grabber" className={styles.GrabberIcon} />
-        <span className={styles.CompletedTaskName}>{original.name}</span>
-      </span>
+      <SamwiseIcon iconName="grabber" className={styles.GrabberIcon} />
+      <span className={styles.CompletedTaskName}>{original.name}</span>
       <span className={styles.CompletedTaskDate}>{numericDate}</span>
     </li>
   );

--- a/frontend/src/components/GroupView/RightView/CompletedTasks/CompletedTasks.module.scss
+++ b/frontend/src/components/GroupView/RightView/CompletedTasks/CompletedTasks.module.scss
@@ -4,6 +4,7 @@
   font-size: 10px;
   margin: 0;
   margin-bottom: 2px;
+  padding-left: 16px;
 }
 
 .CompletedTask,
@@ -27,6 +28,11 @@
 
 .CompletedTaskName {
   padding-left: 4px;
+  flex: 1 1 auto;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .CompletedTaskDate {
@@ -42,8 +48,8 @@
 }
 
 .CompletedTasksBar {
-  width: 270px;
-  margin-right: 14px;
+  width: 260px;
+  margin-left: 14px;
 }
 
 .CompletedTasksContainer {

--- a/frontend/src/components/GroupView/RightView/GroupTask.module.scss
+++ b/frontend/src/components/GroupView/RightView/GroupTask.module.scss
@@ -1,8 +1,11 @@
+@import '../groupview-sizes.scss';
+
 .GroupTask {
   font-size: 12px;
   color: white;
   margin-left: 14px;
-  min-height: 200px;
+  width: 260px;
+  min-height: $group-task-row-content-height;
 }
 
 .TaskQueueGroupTask {

--- a/frontend/src/components/GroupView/RightView/GroupTaskRow.module.scss
+++ b/frontend/src/components/GroupView/RightView/GroupTaskRow.module.scss
@@ -1,3 +1,5 @@
+@import '../groupview-sizes.scss';
+
 .GroupTaskRow {
   display: flex;
   direction: row;
@@ -14,15 +16,15 @@
 }
 
 .AddTaskContainer {
-  width: 105px;
-  height: 121px;
+  width: 120px;
+  height: $group-task-row-content-height;
   border: 3px dashed rgba(255, 138, 138, 0.5);
   box-sizing: border-box;
   border-radius: 10px;
   display: flex;
   align-content: center;
   margin: auto;
-  margin-right: 26px;
+  margin-right: 8px;
   background-color: rgb(255, 255, 255);
 }
 
@@ -35,6 +37,7 @@
   flex-direction: column;
   width: 100%;
   height: 100%;
+  padding: 1em;
   justify-content: center;
   align-items: center;
 }

--- a/frontend/src/components/GroupView/RightView/GroupTasksContainer.module.scss
+++ b/frontend/src/components/GroupView/RightView/GroupTasksContainer.module.scss
@@ -1,9 +1,12 @@
+@import '../groupview-sizes.scss';
+
 .GroupTasksContainer {
   display: flex;
   flex-direction: row;
   overflow-y: hidden;
   overflow-x: auto;
   width: 100%;
+  height: $group-task-row-content-height;
 }
 
 .FlexibleRow {

--- a/frontend/src/components/GroupView/groupview-sizes.scss
+++ b/frontend/src/components/GroupView/groupview-sizes.scss
@@ -10,3 +10,5 @@ $taskqueue-height: 60vh;
 $peoplelist-height: 40vh;
 $addmember-height: 40px;
 $leavegroup-height: 32px;
+
+$group-task-row-content-height: 160px;


### PR DESCRIPTION
### Summary <!-- Required -->

Right now the group view components didn't align so well and look messy. This diff tidy them up by making them more aligned.

### Test Plan <!-- Required -->

Design:
<img width="536" alt="design" src="https://user-images.githubusercontent.com/4290500/101969797-6e171e80-3bf4-11eb-80ea-691f8c44081f.png">
Before:
<img width="1407" alt="before" src="https://user-images.githubusercontent.com/4290500/101969795-6e171e80-3bf4-11eb-9050-d18ae182239d.png">
After:
<img width="1407" alt="after" src="https://user-images.githubusercontent.com/4290500/101969794-6ce5f180-3bf4-11eb-859e-6da0b34586dc.png">
