### PR TITLE
Make assign button (+) in the middle bar work

### DIFF
--- a/frontend/src/PersonalView.tsx
+++ b/frontend/src/PersonalView.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 import styles from './App.module.scss';
 import AllComplete from './components/Popup/AllComplete';
 import Onboard from './components/TitleBar/Onboarding/Onboard';
-import TaskCreator from './components/TaskCreator';
+import { TaskCreatorContextProvider, TaskCreator } from './components/TaskCreator';
 import TaskView from './components/TaskView';
 import TitleBar from './components/TitleBar';
 
@@ -13,7 +13,9 @@ const PersonalView = (): ReactElement => (
   <>
     <Onboard />
     <TitleBar />
-    <TaskCreator view="personal" />
+    <TaskCreatorContextProvider>
+      <TaskCreator view="personal" />
+    </TaskCreatorContextProvider>
     <TaskView className={styles.TaskView} />
     <AllComplete />
   </>

--- a/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarMemberRow.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarMemberRow.tsx
@@ -5,6 +5,7 @@ import firebase from 'firebase/app';
 import SamwiseIcon from '../../UI/SamwiseIcon';
 import styles from './GroupViewMiddleBarMemberRow.module.scss';
 import ProfileImage from './ProfileImage';
+import { useTaskCreatorContextSetter } from '../../TaskCreator';
 
 type Props = {
   memberName: string;
@@ -26,6 +27,14 @@ const sendNotification = (variant: string, email: string, group: string): void =
 };
 
 const Member = ({ memberName, profilePicURL, group, email }: Props): ReactElement => {
+  const setTaskCreatorContext = useTaskCreatorContextSetter();
+
+  const openTaskCreator = (): void =>
+    setTaskCreatorContext({
+      taskCreatorOpened: true,
+      assignedMembers: [{ email, name: memberName, photoURL: profilePicURL }],
+    });
+
   return (
     <div className={styles.Member}>
       <ProfileImage
@@ -35,7 +44,7 @@ const Member = ({ memberName, profilePicURL, group, email }: Props): ReactElemen
       />
       <p>{memberName}</p>
       <div className={styles.Plus}>
-        <FontAwesomeIcon icon={faPlus} />
+        <FontAwesomeIcon icon={faPlus} onClick={openTaskCreator} />
       </div>
       <SamwiseIcon
         className={styles.MemberIcon}

--- a/frontend/src/components/GroupView/RightView/index.tsx
+++ b/frontend/src/components/GroupView/RightView/index.tsx
@@ -1,17 +1,12 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement } from 'react';
 import type { Group, SamwiseUserProfile, Task } from 'common/types/store-types';
 import SamwiseIcon from '../../UI/SamwiseIcon';
 import GroupTaskRow from './GroupTaskRow';
 import styles from './index.module.scss';
-import TaskCreator from '../../TaskCreator';
+import { TaskCreator, useTaskCreatorContextSetter } from '../../TaskCreator';
 import GroupTaskProgress from './GroupTaskProgress';
 import { promptTextInput } from '../../Util/Modals';
 import { updateGroup } from '../../../firebase/actions';
-
-type State = {
-  readonly taskCreatorOpened: boolean;
-  readonly assignedMembers?: readonly SamwiseUserProfile[];
-};
 
 type Props = {
   readonly group: Group;
@@ -20,10 +15,7 @@ type Props = {
 };
 
 const RightView = ({ group, groupMemberProfiles, tasks }: Props): ReactElement => {
-  const [{ taskCreatorOpened, assignedMembers }, setState] = useState<State>({
-    taskCreatorOpened: false,
-    assignedMembers: undefined,
-  });
+  const setTaskCreatorContext = useTaskCreatorContextSetter();
 
   const onEditGroupNameClicked = (): void => {
     promptTextInput('Edit your group name', '', 'New Group Name', 'Submit', 'text').then((name) =>
@@ -32,31 +24,15 @@ const RightView = ({ group, groupMemberProfiles, tasks }: Props): ReactElement =
   };
 
   const openTaskCreator = (member: readonly SamwiseUserProfile[]): void =>
-    setState({
+    setTaskCreatorContext({
       taskCreatorOpened: true,
       assignedMembers: member,
     });
 
-  const closeTaskCreator = (): void =>
-    setState({
-      taskCreatorOpened: false,
-    });
-
-  const clearAssignedMembers = (): void =>
-    setState({ taskCreatorOpened, assignedMembers: undefined });
-
   return (
     <div className={styles.RightView}>
       <div className={styles.GroupTaskCreator}>
-        <TaskCreator
-          view="group"
-          group={group.id}
-          groupMemberProfiles={groupMemberProfiles}
-          taskCreatorOpened={taskCreatorOpened}
-          closeTaskCreator={closeTaskCreator}
-          assignedMembers={assignedMembers}
-          clearAssignedMembers={clearAssignedMembers}
-        />
+        <TaskCreator view="group" />
       </div>
 
       <div className={styles.RightViewMain}>

--- a/frontend/src/components/GroupView/index.tsx
+++ b/frontend/src/components/GroupView/index.tsx
@@ -5,6 +5,7 @@ import MiddleBar from './MiddleBar';
 import RightView from './RightView';
 import styles from './index.module.scss';
 import { database } from '../../firebase/db';
+import { TaskCreatorContextProvider } from '../TaskCreator';
 
 type Props = {
   readonly group: Group;
@@ -76,15 +77,17 @@ const GroupView = ({ group, changeView }: Props): ReactElement => {
   const groupMemberProfiles = useGroupMemberProfiles(group.members);
 
   return (
-    <div className={styles.GroupView}>
-      <MiddleBar
-        group={group}
-        groupMemberProfiles={groupMemberProfiles}
-        changeView={changeView}
-        tasks={groupTaskArray}
-      />
-      <RightView group={group} groupMemberProfiles={groupMemberProfiles} tasks={groupTaskArray} />
-    </div>
+    <TaskCreatorContextProvider group={group.id} groupMemberProfiles={groupMemberProfiles}>
+      <div className={styles.GroupView}>
+        <MiddleBar
+          group={group}
+          groupMemberProfiles={groupMemberProfiles}
+          changeView={changeView}
+          tasks={groupTaskArray}
+        />
+        <RightView group={group} groupMemberProfiles={groupMemberProfiles} tasks={groupTaskArray} />
+      </div>
+    </TaskCreatorContextProvider>
   );
 };
 

--- a/frontend/src/components/TaskCreator/index.test.tsx
+++ b/frontend/src/components/TaskCreator/index.test.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { ProviderForTesting } from '../../store';
-import TaskCreator from '.';
+import { TaskCreatorContextProvider, TaskCreator } from '.';
 
 it('TaskCreator matches snapshot', () => {
   const tree = renderer
     .create(
       <ProviderForTesting>
-        <TaskCreator view="personal" />
+        <TaskCreatorContextProvider>
+          <TaskCreator view="personal" />
+        </TaskCreatorContextProvider>
       </ProviderForTesting>
     )
     .toJSON();


### PR DESCRIPTION
### Summary <!-- Required -->

Currently, the right view in group view is communicating with TaskCreator by some ad hoc local state. Now if we want to add another similar communication for the purpose of implementing the + button in MiddleView, we need to duplicate the logic, which is bad.

It turns out that we can use React context to lift the state up, and use hooks to _reactively_ communicate with each other. This PR refactors the existing code to use hooks instead, and use the new setup to quickly implement the functionality for the assign button in the MiddleBar.

### Test Plan <!-- Required -->

- Try opening and closing task creator both in personal and group view.
- Try to click the assign button in both MiddleBar and RightView