### PR TITLE
Make focus view task draggable only when floatingtask editor isn't open

### DIFF
--- a/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
@@ -37,10 +37,6 @@ type Props = OwnProps & {
   readonly settings: Settings;
 };
 
-type OpenedState = {
-  readonly isEditorOpened: boolean;
-};
-
 /**
  * The component used to render one task in backlog day.
  */

--- a/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
@@ -37,8 +37,8 @@ type Props = OwnProps & {
   readonly settings: Settings;
 };
 
-type MyState = {
-  readonly openedGlobal: boolean;
+type OpenedState = {
+  readonly isEditorOpened: boolean;
 };
 
 /**
@@ -57,14 +57,10 @@ function FutureViewTask({
 }: Props): ReactElement | null {
   const isSmallScreen = useMappedWindowSize(({ width }) => width <= 840);
 
-  const [{ openedGlobal }, setOpened] = useState<MyState>({
-    openedGlobal: false,
-  });
+  const [isEditorOpened, setOpened] = useState(false);
 
   const toggle = (opened: boolean): void => {
-    setOpened({
-      openedGlobal: opened,
-    });
+    setOpened(opened);
   };
 
   if (compoundTask === null) {
@@ -188,20 +184,10 @@ function FutureViewTask({
   const overdueComponentOpt = date < getTodayAtZeroAM() && !complete && (
     <OverdueAlert target="future-view-task" />
   );
-  // Construct the trigger for the floating task editor.
-  // const isDragDisabledCondition = (): boolean => {
-  //   console.log(openedGlobal);
-  //   return openedGlobal;
-  // };
 
   const trigger = (opened: boolean, opener: () => void): ReactElement => {
-    // openedGlobal = opened;
-    // console.log(openedGlobal)
-    // console.log(compoundTask.original.metadata.type === 'MASTER_TEMPLATE', isCanvasTask)
-    // console.log(openedGlobal && (compoundTask.original.metadata.type === 'MASTER_TEMPLATE' || true || isCanvasTask))
     const onClickHandler = getOnClickHandler(opener);
-    // toggle()
-    // const onClickHandlertwo = getOnClickHandler(toggle);
+
     const onSpaceHandler = (e: KeyboardEvent<HTMLDivElement>): void => {
       if (e.key === ' ') {
         onClickHandler();
@@ -230,8 +216,9 @@ function FutureViewTask({
       key={taskId}
       draggableId={taskId}
       index={index}
-      // isDragDisabled={ compoundTask.original.metadata.type === 'MASTER_TEMPLATE' || isCanvasTask}
-      isDragDisabled={openedGlobal}
+      isDragDisabled={
+        isEditorOpened || compoundTask.original.metadata.type === 'MASTER_TEMPLATE' || isCanvasTask
+      }
     >
       {(provided) => (
         // eslint-disable-next-line react/jsx-props-no-spreading
@@ -243,7 +230,7 @@ function FutureViewTask({
             taskAppearedDate={containerDate}
             trigger={trigger}
             toggle={toggle}
-            open={openedGlobal}
+            open={isEditorOpened}
           />
         </div>
       )}

--- a/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
@@ -174,7 +174,16 @@ function FutureViewTask({
     <OverdueAlert target="future-view-task" />
   );
   // Construct the trigger for the floating task editor.
+  const isDragDisabledCondition = (): boolean => {
+    console.log(openedGlobal);
+    return openedGlobal;
+  };
+  let openedGlobal = false;
   const trigger = (opened: boolean, opener: () => void): ReactElement => {
+    openedGlobal = opened;
+    // console.log(openedGlobal)
+    // console.log(compoundTask.original.metadata.type === 'MASTER_TEMPLATE', isCanvasTask)
+    // console.log(openedGlobal && (compoundTask.original.metadata.type === 'MASTER_TEMPLATE' || true || isCanvasTask))
     const onClickHandler = getOnClickHandler(opener);
     const onSpaceHandler = (e: KeyboardEvent<HTMLDivElement>): void => {
       if (e.key === ' ') {
@@ -204,7 +213,12 @@ function FutureViewTask({
       key={taskId}
       draggableId={taskId}
       index={index}
-      isDragDisabled={compoundTask.original.metadata.type === 'MASTER_TEMPLATE' || isCanvasTask}
+      // isDragDisabled={ compoundTask.original.metadata.type === 'MASTER_TEMPLATE' || isCanvasTask}
+      isDragDisabled={
+        isDragDisabledCondition() ||
+        compoundTask.original.metadata.type === 'MASTER_TEMPLATE' ||
+        isCanvasTask
+      }
     >
       {(provided) => (
         // eslint-disable-next-line react/jsx-props-no-spreading

--- a/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
@@ -1,4 +1,4 @@
-import React, { KeyboardEvent, ReactElement, SyntheticEvent, ReactNode } from 'react';
+import React, { KeyboardEvent, ReactElement, SyntheticEvent, ReactNode, useState } from 'react';
 import { connect } from 'react-redux';
 import { Draggable } from 'react-beautiful-dnd';
 import { Settings, State, SubTask, Task } from 'common/types/store-types';
@@ -37,6 +37,10 @@ type Props = OwnProps & {
   readonly settings: Settings;
 };
 
+type MyState = {
+  readonly openedGlobal: boolean;
+};
+
 /**
  * The component used to render one task in backlog day.
  */
@@ -53,9 +57,20 @@ function FutureViewTask({
 }: Props): ReactElement | null {
   const isSmallScreen = useMappedWindowSize(({ width }) => width <= 840);
 
+  const [{ openedGlobal }, setOpened] = useState<MyState>({
+    openedGlobal: false,
+  });
+
+  const toggle = (opened: boolean): void => {
+    setOpened({
+      openedGlobal: opened,
+    });
+  };
+
   if (compoundTask === null) {
     return null;
   }
+
   const { original, filteredSubTasks, color } = compoundTask;
 
   const { canvasCalendar } = settings;
@@ -174,17 +189,19 @@ function FutureViewTask({
     <OverdueAlert target="future-view-task" />
   );
   // Construct the trigger for the floating task editor.
-  const isDragDisabledCondition = (): boolean => {
-    console.log(openedGlobal);
-    return openedGlobal;
-  };
-  let openedGlobal = false;
+  // const isDragDisabledCondition = (): boolean => {
+  //   console.log(openedGlobal);
+  //   return openedGlobal;
+  // };
+
   const trigger = (opened: boolean, opener: () => void): ReactElement => {
-    openedGlobal = opened;
+    // openedGlobal = opened;
     // console.log(openedGlobal)
     // console.log(compoundTask.original.metadata.type === 'MASTER_TEMPLATE', isCanvasTask)
     // console.log(openedGlobal && (compoundTask.original.metadata.type === 'MASTER_TEMPLATE' || true || isCanvasTask))
     const onClickHandler = getOnClickHandler(opener);
+    // toggle()
+    // const onClickHandlertwo = getOnClickHandler(toggle);
     const onSpaceHandler = (e: KeyboardEvent<HTMLDivElement>): void => {
       if (e.key === ' ') {
         onClickHandler();
@@ -214,11 +231,7 @@ function FutureViewTask({
       draggableId={taskId}
       index={index}
       // isDragDisabled={ compoundTask.original.metadata.type === 'MASTER_TEMPLATE' || isCanvasTask}
-      isDragDisabled={
-        isDragDisabledCondition() ||
-        compoundTask.original.metadata.type === 'MASTER_TEMPLATE' ||
-        isCanvasTask
-      }
+      isDragDisabled={openedGlobal}
     >
       {(provided) => (
         // eslint-disable-next-line react/jsx-props-no-spreading
@@ -229,6 +242,8 @@ function FutureViewTask({
             initialTask={original}
             taskAppearedDate={containerDate}
             trigger={trigger}
+            toggle={toggle}
+            open={openedGlobal}
           />
         </div>
       )}

--- a/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
@@ -62,7 +62,9 @@ type Props = {
   readonly trigger: (opened: boolean, opener: () => void) => ReactNode;
   // the position of the calendar
   readonly calendarPosition: CalendarPosition;
+  // the toggle function to change the state of the editor
   readonly toggle: (opened: boolean) => void;
+  // the state of the editor
   readonly open: boolean;
 };
 

--- a/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
+++ b/frontend/src/components/Util/TaskEditors/FloatingTaskEditor.tsx
@@ -62,6 +62,8 @@ type Props = {
   readonly trigger: (opened: boolean, opener: () => void) => ReactNode;
   // the position of the calendar
   readonly calendarPosition: CalendarPosition;
+  readonly toggle: (opened: boolean) => void;
+  readonly open: boolean;
 };
 
 /**
@@ -74,10 +76,10 @@ export default function FloatingTaskEditor({
   initialTask: task,
   taskAppearedDate,
   trigger,
+  toggle,
+  open,
 }: Props): ReactElement {
   const icalUID = task.metadata.type === 'ONE_TIME' ? task.metadata.icalUID : '';
-
-  const [open, setOpen] = React.useState<boolean>(false);
 
   const editorRef = React.useRef<HTMLFormElement>(null);
 
@@ -89,8 +91,12 @@ export default function FloatingTaskEditor({
     updateFloatingEditorPosition(editorPosDiv, size, position);
   });
 
-  const openPopup = (): void => setOpen(true);
-  const closePopup = (): void => setOpen(false);
+  const openPopup = (): void => {
+    toggle(true);
+  };
+  const closePopup = (): void => {
+    toggle(false);
+  };
 
   const { id: _, metadata, children, ...taskData } = task;
   const actions = {


### PR DESCRIPTION
### Summary <!-- Required -->
Fixed error where floating task editor changes position when dragging focusviewtask. Now, one can only moving the focusview task when the floatingtaskeditor is closed. 

- [x] Fixed https://github.com/cornell-dti/samwise/issues/675#issue-757779245

### Test Plan <!-- Required -->
![task](https://user-images.githubusercontent.com/20613939/101975989-07ebc500-3c0f-11eb-8e4f-388c87924e14.gif)



