### PR TITLE
Take the margin width into account to fix group task squzzed problem

### DIFF
--- a/frontend/src/components/GroupView/RightView/GroupTask.module.scss
+++ b/frontend/src/components/GroupView/RightView/GroupTask.module.scss
@@ -1,10 +1,13 @@
 @import '../groupview-sizes.scss';
 
+$group-task-width: 260px;
+$group-task-margin: 14px;
+
 .GroupTask {
   font-size: 12px;
   color: white;
-  margin-left: 14px;
-  width: 260px;
+  margin-left: $group-task-margin;
+  width: $group-task-width;
   min-height: $group-task-row-content-height;
 }
 
@@ -15,8 +18,8 @@
 }
 
 .GroupTaskContainer {
-  height: 200px;
-  min-width: 250px;
+  height: $group-task-row-content-height;
+  min-width: calc(#{$group-task-width + $group-task-margin});
   overflow-x: hidden;
   padding: 0;
   overflow-y: scroll;


### PR DESCRIPTION
### Summary <!-- Required -->

Current implementation doesn't take the margin in the child component into account, so things are squzzed.

(See jason's last task in the screenshot)

<img width="1818" alt="Screen Shot 2020-12-12 at 14 57 24" src="https://user-images.githubusercontent.com/4290500/101993673-6c983580-3c8a-11eb-8a78-5b6a206bf656.png">

### Test Plan <!-- Required -->

Fixed:

<img width="1818" alt="Screen Shot 2020-12-12 at 14 57 38" src="https://user-images.githubusercontent.com/4290500/101993674-6efa8f80-3c8a-11eb-99f1-0bb4e21edcd1.png">

