### PR TITLE
Add flex-shrink to group task row to unbreak group task in safari

### DIFF
--- a/frontend/src/components/GroupView/RightView/GroupTaskRow.module.scss
+++ b/frontend/src/components/GroupView/RightView/GroupTaskRow.module.scss
@@ -3,6 +3,7 @@
 .GroupTaskRow {
   display: flex;
   direction: row;
+  flex-shrink: 0;
   margin-bottom: 1.5em;
 }
 


### PR DESCRIPTION
### Summary <!-- Required -->

Credit: https://stackoverflow.com/questions/32689686/overlapping-css-flexbox-items-in-safari

### Test Plan <!-- Required -->

Before:
<img width="1928" alt="Screen Shot 2020-12-12 at 15 20 22" src="https://user-images.githubusercontent.com/4290500/101994090-ae76ab00-3c8d-11eb-970e-27afb829ad41.png">
After:
<img width="1928" alt="Screen Shot 2020-12-12 at 15 20 27" src="https://user-images.githubusercontent.com/4290500/101994091-ae76ab00-3c8d-11eb-9a78-44eaf0f09f2c.png">
