### PR TITLE
Fix overdue alert to use absolute positioning once again

### DIFF
--- a/frontend/src/components/UI/OverdueAlert.module.scss
+++ b/frontend/src/components/UI/OverdueAlert.module.scss
@@ -1,5 +1,5 @@
 .OverdueAlertInTaskCard {
-  position: relative;
+  position: absolute;
   top: -5px;
   left: calc(100% - 20px);
   width: 2em;

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/EditorHeader.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/EditorHeader.tsx
@@ -5,6 +5,7 @@ import styles from './index.module.scss';
 import TagListPicker from '../../TagListPicker/TagListPicker';
 import { CalendarPosition } from '../editors-types';
 import SamwiseIcon from '../../../UI/SamwiseIcon';
+import OverdueAlert from '../../../UI/OverdueAlert';
 
 type TagAndDate = {
   readonly tag: string;
@@ -19,6 +20,7 @@ type Props = TagAndDate & {
   readonly icalUID?: string;
   readonly editorRef?: { current: HTMLFormElement | null };
   readonly memberName?: string; // only supplied if task is a group task
+  readonly isOverdue: boolean;
 };
 
 type EditorDisplayStatus = {
@@ -38,6 +40,7 @@ export default function EditorHeader({
   icalUID,
   editorRef,
   memberName,
+  isOverdue,
 }: Props): ReactElement {
   const [editorDisplayStatus, setEditorDisplayStatus] = React.useState<EditorDisplayStatus>({
     doesShowTagEditor: false,
@@ -139,6 +142,7 @@ export default function EditorHeader({
 
   return (
     <div className={headerClassName}>
+      {isOverdue && <OverdueAlert target="task-card" />}
       {displayGrabber && !memberName && (
         <SamwiseIcon iconName="grabber" className={styles.TaskEditorGrabberIcon} />
       )}

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -21,7 +21,6 @@ import {
   getFilteredCompletedInFocusTask,
   getFilteredNotCompletedInFocusTask,
 } from 'common/util/task-util';
-import OverdueAlert from '../../../UI/OverdueAlert';
 import {
   confirmRepeatedTaskEditMaster,
   promptRepeatedTaskEditChoice,
@@ -287,7 +286,6 @@ function TaskEditor({
       onBlur={onMouseLeave}
       ref={editorRef}
     >
-      {isOverdue && <OverdueAlert target="task-card" />}
       <div>
         <RepeatFrequencyHeader taskId={id} tag={tag} getTag={getTag} />
         <EditorHeader
@@ -300,6 +298,7 @@ function TaskEditor({
           icalUID={canvasLinked ? icalUID : undefined}
           editorRef={editorRef}
           memberName={memberName}
+          isOverdue={isOverdue}
         />
         <MainTaskEditor
           id={id}


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request fixes the extra space caused by the overdue alert after a quick and dirty fix in #605.


### Test Plan <!-- Required -->

![image](https://user-images.githubusercontent.com/7517829/101994157-1cbb6d80-3c8e-11eb-92f0-565eab9e22b8.png)

