### PR TITLE
Make leave group pinned to bottom of the screen

### DIFF
--- a/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarPeopleList.module.scss
+++ b/frontend/src/components/GroupView/MiddleBar/GroupViewMiddleBarPeopleList.module.scss
@@ -50,6 +50,7 @@
   border: none;
   background-color: transparent;
   height: $leavegroup-height;
+  bottom: 0;
 }
 
 .LeaveGroup p {


### PR DESCRIPTION
### Summary

Leave group gets pushed off screen if there are too many elements in the MiddleBar. This PR adds `bottom: 0` to pin it to the bottom of the MiddleBar.

### Test Plan

<img width="232" alt="Screen Shot 2020-12-12 at 3 37 37 PM" src="https://user-images.githubusercontent.com/20008134/101994376-f8609080-3c8f-11eb-8711-241d8c932387.png">
