### PR TITLE
Give each group task a tag by using classId to show color with best effort

### DIFF
--- a/frontend/src/components/GroupView/index.tsx
+++ b/frontend/src/components/GroupView/index.tsx
@@ -77,7 +77,11 @@ const GroupView = ({ group, changeView }: Props): ReactElement => {
   const groupMemberProfiles = useGroupMemberProfiles(group.members);
 
   return (
-    <TaskCreatorContextProvider group={group.id} groupMemberProfiles={groupMemberProfiles}>
+    <TaskCreatorContextProvider
+      group={group.id}
+      groupClassCode={group.classCode}
+      groupMemberProfiles={groupMemberProfiles}
+    >
       <div className={styles.GroupView}>
         <MiddleBar
           group={group}

--- a/frontend/src/components/TaskCreator/index.tsx
+++ b/frontend/src/components/TaskCreator/index.tsx
@@ -47,24 +47,6 @@ type Props = { readonly view: 'personal' | 'group' };
  * The placeholder text in the main task input box.
  */
 const PLACEHOLDER_TEXT = 'What do you have to do?';
-/**
- * Generate the initial state.
- */
-const initialState = (): State => ({
-  id: randomId(),
-  owner: [''],
-  name: '',
-  tag: NONE_TAG_ID, // the id of the None tag.
-  member: undefined,
-  date: new Date(),
-  complete: false,
-  inFocus: false,
-  subTasks: [],
-  tagPickerOpened: false,
-  datePickerOpened: false,
-  datePicked: false,
-  needToSwitchFocus: false,
-});
 
 type TaskCreatorContextMutableValues = {
   readonly taskCreatorOpened?: boolean;
@@ -73,6 +55,7 @@ type TaskCreatorContextMutableValues = {
 
 type TaskCreatorContextValues = TaskCreatorContextMutableValues & {
   readonly group?: string;
+  readonly groupClassCode?: string;
   readonly groupMemberProfiles?: readonly SamwiseUserProfile[];
   readonly setTaskCreatorContext: React.Dispatch<
     React.SetStateAction<TaskCreatorContextMutableValues>
@@ -87,12 +70,14 @@ const TaskCreatorContext = createContext<TaskCreatorContextValues>({
 
 type TaskCreatorContextProviderProps = {
   readonly group?: string;
+  readonly groupClassCode?: string;
   readonly groupMemberProfiles?: readonly SamwiseUserProfile[];
   readonly children: ReactNode;
 };
 
 export const TaskCreatorContextProvider = ({
   group,
+  groupClassCode,
   groupMemberProfiles,
   children,
 }: TaskCreatorContextProviderProps): ReactElement => {
@@ -100,7 +85,13 @@ export const TaskCreatorContextProvider = ({
 
   return (
     <TaskCreatorContext.Provider
-      value={{ ...state, group, groupMemberProfiles, setTaskCreatorContext: setState }}
+      value={{
+        ...state,
+        group,
+        groupClassCode,
+        groupMemberProfiles,
+        setTaskCreatorContext: setState,
+      }}
     >
       {children}
     </TaskCreatorContext.Provider>
@@ -112,18 +103,36 @@ export const useTaskCreatorContextSetter = (): React.Dispatch<
 > => useContext(TaskCreatorContext).setTaskCreatorContext;
 
 export const TaskCreator = ({ view }: Props): ReactElement => {
-  const theme = useSelector((state: StoreState) => state.settings.theme);
-  const [state, setState] = useState(initialState);
-  const setPartialState = (partial: Partial<State>): void =>
-    setState((prev) => ({ ...prev, ...partial }));
-
   const {
     group,
+    groupClassCode,
     groupMemberProfiles,
     taskCreatorOpened,
     assignedMembers,
     setTaskCreatorContext,
   } = useContext(TaskCreatorContext);
+
+  const theme = useSelector((state: StoreState) => state.settings.theme);
+
+  const initialState = (): State => ({
+    id: randomId(),
+    owner: [''],
+    name: '',
+    tag: groupClassCode ?? NONE_TAG_ID,
+    member: undefined,
+    date: new Date(),
+    complete: false,
+    inFocus: false,
+    subTasks: [],
+    tagPickerOpened: false,
+    datePickerOpened: false,
+    datePicked: false,
+    needToSwitchFocus: false,
+  });
+
+  const [state, setState] = useState(initialState);
+  const setPartialState = (partial: Partial<State>): void =>
+    setState((prev) => ({ ...prev, ...partial }));
 
   const addTaskRef = useRef<HTMLInputElement | null>(null);
 

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -358,8 +358,20 @@ function TaskEditor({
   );
 }
 
-const Connected = connect(({ tags, settings }: State) => ({
-  getTag: (id: string) => tags.get(id) ?? NONE_TAG,
+const Connected = connect(({ tags, settings }: State, ownProps: OwnProps) => ({
+  getTag: (id: string) => {
+    if (ownProps.type === 'GROUP') {
+      // Treat tag id as class code
+      return (
+        Array.from(tags.values()).find(({ classId }) => {
+          if (classId == null) return false;
+          // classId has the format `<id from roster> <subject> <number>`, we take the later two parts.
+          return classId.substring(classId.indexOf(' ') + 1) === id;
+        }) ?? NONE_TAG
+      );
+    }
+    return tags.get(id) ?? NONE_TAG;
+  },
   settings,
 }))(TaskEditor);
 export default Connected;


### PR DESCRIPTION
### Summary <!-- Required -->

Using class id as the tag, so that people can see some color as long as they have the class tag.

### Test Plan <!-- Required -->

Try to create a group in a real class and see the color.

### Note

There is a bug in the context when the group info like group id and group code is not updating when you switch between groups, I will fix this in another diff