### PR TITLE
Fix mobile view to be usable after group tasks launch

### DIFF
--- a/frontend/src/App.module.scss
+++ b/frontend/src/App.module.scss
@@ -11,6 +11,16 @@
   display: flex;
 }
 
+.MobileScreen {
+  position: fixed;
+  flex-direction: column;
+  overflow: hidden;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
 .GroupScreenContent {
   flex: 1 1 auto;
 }

--- a/frontend/src/ViewSwitcher.tsx
+++ b/frontend/src/ViewSwitcher.tsx
@@ -5,6 +5,7 @@ import SideBar from './components/SideBar';
 import PersonalView from './PersonalView';
 import GroupView from './components/GroupView';
 import styles from './App.module.scss';
+import { useMappedWindowSize } from './hooks/window-size-hook';
 
 /** Handles switching the view from Personal to Group */
 const ViewSwitcher = (): React.ReactElement => {
@@ -12,10 +13,11 @@ const ViewSwitcher = (): React.ReactElement => {
 
   const [selectedGroupID, setSelectedGroupID] = useState<string | undefined>();
   const selectedGroup = groups.find((oneGroup) => oneGroup.id === selectedGroupID);
+  const isSmallScreen = useMappedWindowSize(({ width }) => width <= 840);
 
   return (
-    <div className={styles.GroupScreen}>
-      <SideBar groups={groups} changeView={setSelectedGroupID} />
+    <div className={isSmallScreen ? styles.MobileScreen : styles.GroupScreen}>
+      {!isSmallScreen && <SideBar groups={groups} changeView={setSelectedGroupID} />}
       <div className={styles.GroupScreenContent}>
         {selectedGroup === undefined ? (
           <PersonalView />


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

In anticipation of our soon launch, we still want mobile to be usable. To do this, we just remove the group tasks feature on mobile devices :( since we have no mobile designs.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

Before:
![image](https://user-images.githubusercontent.com/7517829/101995391-82f8be00-3c97-11eb-9dbc-1b7d198ef3be.png)


After:
![image](https://user-images.githubusercontent.com/7517829/101995381-75433880-3c97-11eb-8833-e6e9ab0de3be.png)
