### PR TITLE
Do not fork group task in future view

### DIFF
--- a/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewTask.tsx
@@ -93,10 +93,11 @@ function FutureViewTask({
   };
 
   const replaceDateForFork = getDateWithDateString(
-    original.metadata.type === 'ONE_TIME' ? original.metadata.date : null,
+    original.metadata.type !== 'MASTER_TEMPLATE' ? original.metadata.date : null,
     containerDate
   );
-  const replaceDateForForkOpt = original.metadata.type === 'ONE_TIME' ? null : replaceDateForFork;
+  const replaceDateForForkOpt =
+    original.metadata.type !== 'MASTER_TEMPLATE' ? null : replaceDateForFork;
   const TaskCheckBox = (): ReactElement => {
     const { id, complete } = original;
     const onChange = (): void => editMainTask(id, replaceDateForForkOpt, { complete: !complete });


### PR DESCRIPTION
### Summary <!-- Required -->

We are forking it rn because we are treating it like repeating task due to this check. This PR fixes it

### Test Plan <!-- Required -->

👀 
