### PR TITLE
Let cancel button close searchbox

### DIFF
--- a/frontend/src/components/TaskCreator/GroupMemberPicker.tsx
+++ b/frontend/src/components/TaskCreator/GroupMemberPicker.tsx
@@ -14,6 +14,7 @@ type OwnProps = {
 type Props = OwnProps & {
   readonly clearAssignedMembers?: () => void;
   readonly groupMemberProfiles: readonly SamwiseUserProfile[];
+  readonly resetTask: () => void;
 };
 
 export default function GroupMemberPicker({
@@ -23,6 +24,7 @@ export default function GroupMemberPicker({
   onPickerOpened,
   clearAssignedMembers,
   groupMemberProfiles,
+  resetTask,
 }: Props): ReactElement {
   // Controllers
   const clickPicker = (): void => {
@@ -53,6 +55,9 @@ export default function GroupMemberPicker({
     const remainingMemberCount = selectedMembers.length - i;
     if (remainingMemberCount > 0) memberNames += ` +${remainingMemberCount}`;
 
+    if (memberNames.length === 0) {
+      memberNames = 'assign to';
+    }
     return memberNames;
   };
 
@@ -91,7 +96,11 @@ export default function GroupMemberPicker({
       {displayedNode(member === undefined)}
       {opened && (
         <div>
-          <SearchGroupMember members={groupMemberProfiles} onMemberChange={onMemberChange} />
+          <SearchGroupMember
+            members={groupMemberProfiles}
+            onMemberChange={onMemberChange}
+            resetTask={resetTask}
+          />
         </div>
       )}
     </div>

--- a/frontend/src/components/TaskCreator/index.tsx
+++ b/frontend/src/components/TaskCreator/index.tsx
@@ -445,7 +445,7 @@ export const TaskCreator = ({ view }: Props): ReactElement => {
                   clearAssignedMembers={() =>
                     setTaskCreatorContext((prev) => ({ ...prev, assignedMembers: [] }))
                   }
-                  resetTask = {resetTask}
+                  resetTask={resetTask}
                 />
               )}
             </div>

--- a/frontend/src/components/TaskCreator/index.tsx
+++ b/frontend/src/components/TaskCreator/index.tsx
@@ -445,6 +445,7 @@ export const TaskCreator = ({ view }: Props): ReactElement => {
                   clearAssignedMembers={() =>
                     setTaskCreatorContext((prev) => ({ ...prev, assignedMembers: [] }))
                   }
+                  resetTask = {resetTask}
                 />
               )}
             </div>

--- a/frontend/src/components/Util/GroupMemberListPicker/SearchGroupMember.tsx
+++ b/frontend/src/components/Util/GroupMemberListPicker/SearchGroupMember.tsx
@@ -5,6 +5,7 @@ import styles from './SearchGroupMember.module.scss';
 type Props = {
   readonly members: readonly SamwiseUserProfile[];
   readonly onMemberChange: (member: readonly SamwiseUserProfile[] | undefined) => void;
+  readonly resetTask: () => void;
 };
 
 type State = {
@@ -13,7 +14,11 @@ type State = {
   readonly selectedMembers: readonly SamwiseUserProfile[];
 };
 
-export default function SearchGroupMember({ members, onMemberChange }: Props): ReactElement | null {
+export default function SearchGroupMember({
+  members,
+  onMemberChange,
+  resetTask,
+}: Props): ReactElement | null {
   const [{ searchInput, searchResults, selectedMembers }, setState] = useState<State>({
     searchInput: '',
     searchResults: members,
@@ -54,6 +59,7 @@ export default function SearchGroupMember({ members, onMemberChange }: Props): R
   const clearSelection = () => (e: SyntheticEvent<HTMLButtonElement>) => {
     e.preventDefault();
     setState({ searchInput: '', searchResults: members, selectedMembers: [] });
+    resetTask();
   };
 
   const isChecked = (member: SamwiseUserProfile | undefined): boolean => {


### PR DESCRIPTION
### Summary 
Fixes bugs relating to the assign to button in TaskCreator.

- [x] The 'cancel' button in 'assign to' button now clears selected options and closes the search box.
- [x] Empty member selection does not result in a blank button title.

### Test Plan
Tested through frontend in GroupView.