### PR TITLE
Unbreak the left text in settings launched from sidebar

### DIFF
--- a/frontend/src/components/SideBar/AddGroupTags.tsx
+++ b/frontend/src/components/SideBar/AddGroupTags.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Tag } from 'common/types/store-types';
 import { store } from '../../store/store';
+import sideBarStyles from './index.module.scss';
 import styles from './AddGroupTags.module.scss';
 import { createGroup } from '../../firebase/actions';
 
@@ -43,7 +44,7 @@ export default function AddGroupTags({ show, setShow }: AddGroupTagsProps): Reac
                     <div className={styles.Color} style={{ backgroundColor: color }}>
                       {' '}
                     </div>
-                    <p>{classCode}</p>
+                    <p className={sideBarStyles.GroupManagerText}>{classCode}</p>
                   </button>
                 )}
               </div>

--- a/frontend/src/components/SideBar/index.module.scss
+++ b/frontend/src/components/SideBar/index.module.scss
@@ -63,7 +63,7 @@
   height: $sidebar-group-manager-height;
 }
 
-.GroupManager p {
+.GroupManager .GroupManagerText {
   font-family: 'DM Sans', sans-serif;
   font-style: normal;
   font-weight: 500;

--- a/frontend/src/components/SideBar/index.tsx
+++ b/frontend/src/components/SideBar/index.tsx
@@ -35,7 +35,7 @@ const SideBar = ({ groups, changeView }: Props): ReactElement => {
         </button>
       </div>
       <div className={styles.GroupManager}>
-        <p>My Groups</p>
+        <p className={styles.GroupManagerText}>My Groups</p>
         <div className={styles.GroupIcons}>
           {groups.map((g) => (
             <GroupIcon
@@ -55,7 +55,7 @@ const SideBar = ({ groups, changeView }: Props): ReactElement => {
           >
             <FontAwesomeIcon className={styles.PlusIcon} icon={faPlus} />
           </button>
-          {!showDropdown && <p>New Group</p>}
+          {!showDropdown && <p className={styles.GroupManagerText}>New Group</p>}
           <AddGroupTags show={showDropdown} setShow={setShowDropdown} />
         </div>
         <div className={styles.ExpandToFill} />


### PR DESCRIPTION
### Summary <!-- Required -->

Right now the settings launched from sidebar is broken:
<img width="1091" alt="Screen Shot 2020-12-16 at 20 18 39" src="https://user-images.githubusercontent.com/4290500/102425759-f4a87300-3fdb-11eb-93cc-0b7136964126.png">
For reference, the settings launched from personal view is fine:
<img width="1091" alt="Screen Shot 2020-12-16 at 20 18 42" src="https://user-images.githubusercontent.com/4290500/102425778-ff630800-3fdb-11eb-8ad3-113e14b5ddf4.png">

This PR fixes the problem that the left text is not shown. It is caused by some style being cascading down. This bug shows again that we should really avoid all those css blanketly targeting one type of html tag.

### Test Plan <!-- Required -->

Shown now:
<img width="1091" alt="Screen Shot 2020-12-16 at 20 20 47" src="https://user-images.githubusercontent.com/4290500/102425859-320d0080-3fdc-11eb-8415-0e5967aa2ba5.png">
