### PR TITLE
Unbreak buttons in settings view launched from sidebar

### DIFF
--- a/frontend/src/components/SideBar/GroupIcon.module.scss
+++ b/frontend/src/components/SideBar/GroupIcon.module.scss
@@ -1,6 +1,9 @@
 @import '../../colors.scss';
 
-.GroupIcon {
+button[type='button'].GroupIcon {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
   line-height: 44px;
   text-align: center;
   font-size: 32px;

--- a/frontend/src/components/SideBar/GroupIcon.tsx
+++ b/frontend/src/components/SideBar/GroupIcon.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { State, Tag } from 'common/types/store-types';
 import { NONE_TAG } from 'common/util/tag-util';
 import { Views } from './types';
+import sidebarStyles from './index.module.scss';
 import styles from './GroupIcon.module.scss';
 import { getOrderedTags } from '../../store/selectors';
 
@@ -29,7 +30,9 @@ const GroupIcon = ({ classCode, handleClick, selected, tags }: Props): ReactElem
     <button
       type="button"
       onClick={() => handleClick('group', classCode)}
-      className={styles.GroupIcon + (selected ? ` ${styles.Active}` : '')}
+      className={`${sidebarStyles.GroupLetterIcon} ${styles.GroupIcon}${
+        selected ? ` ${styles.Active}` : ''
+      }`}
       style={{ background: color }}
     >
       {classCode.charAt(0)}

--- a/frontend/src/components/SideBar/index.module.scss
+++ b/frontend/src/components/SideBar/index.module.scss
@@ -15,7 +15,9 @@
 }
 
 .PersonalViewButton,
-.GroupManager button {
+.GroupManager .GroupLetterIcon,
+.GroupManager .AddGroup,
+.SettingsButton {
   height: 4rem;
   width: 4rem;
   opacity: 0.7;
@@ -94,12 +96,6 @@
 
 .GroupIcons::-webkit-scrollbar {
   display: none;
-}
-
-.GroupIcons > button {
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
 }
 
 .Links {

--- a/frontend/src/components/SideBar/index.tsx
+++ b/frontend/src/components/SideBar/index.tsx
@@ -60,7 +60,7 @@ const SideBar = ({ groups, changeView }: Props): ReactElement => {
         </div>
         <div className={styles.ExpandToFill} />
         <div className={styles.Links}>
-          <SettingsButton />
+          <SettingsButton buttonClassname={styles.SettingsButton} />
         </div>
       </div>
     </div>

--- a/frontend/src/components/TitleBar/Settings/SettingsButton.tsx
+++ b/frontend/src/components/TitleBar/Settings/SettingsButton.tsx
@@ -3,7 +3,9 @@ import SettingsPage from './SettingsPage';
 import styles from './SettingsButton.module.scss';
 import SamwiseIcon from '../../UI/SamwiseIcon';
 
-export default function SettingsButton(): ReactElement {
+type Props = { readonly buttonClassname?: string };
+
+export default function SettingsButton({ buttonClassname }: Props): ReactElement {
   const [showSettings, setShowSettings] = React.useState(false);
 
   const displayModal = (): void => setShowSettings(true);
@@ -11,7 +13,11 @@ export default function SettingsButton(): ReactElement {
 
   return (
     <div className={styles.SettingsButtonContainer}>
-      <button type="submit" onClick={displayModal} className={styles.SettingsButton}>
+      <button
+        type="submit"
+        onClick={displayModal}
+        className={`${buttonClassname ?? ''} ${styles.SettingsButton}`}
+      >
         <p style={{ transform: 'scale(2)translateY(-5px)' }} title="Settings Button">
           <SamwiseIcon iconName="settings" />
         </p>

--- a/frontend/src/components/TitleBar/Settings/__snapshots__/SettingsButton.test.tsx.snap
+++ b/frontend/src/components/TitleBar/Settings/__snapshots__/SettingsButton.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`SettingsButton matches snapshot. 1`] = `
   className="SettingsButtonContainer"
 >
   <button
-    className="SettingsButton"
+    className=" SettingsButton"
     onClick={[Function]}
     type="submit"
   >


### PR DESCRIPTION
### Summary <!-- Required -->

As you can see in #707, all the buttons in the settings view is also broken. This PR fixes them in the same way: avoiding unpredictable cascades by explicitly applying css classes to the ones we want to style.

### Test Plan <!-- Required -->

Compared to staging, sidebar doesn't change
<img width="999" alt="dev" src="https://user-images.githubusercontent.com/4290500/102427268-ff183c00-3fde-11eb-8e5b-c29aa7073ecc.png">
<img width="1091" alt="staging" src="https://user-images.githubusercontent.com/4290500/102427269-ffb0d280-3fde-11eb-88d3-34607ab4e867.png">

Settings is fixed:
<img width="999" alt="fixed" src="https://user-images.githubusercontent.com/4290500/102427291-0b03fe00-3fdf-11eb-97d3-6ab49515893a.png">

