### PR TITLE
Eliminate all stylelint css warnings

### DIFF
--- a/frontend/src/components/TaskCreator/DatePicker.tsx
+++ b/frontend/src/components/TaskCreator/DatePicker.tsx
@@ -284,10 +284,18 @@ export default function DatePicker(props: Props): ReactElement {
                   calendarType="US"
                 />
                 <p className={styles.RepeatSpecialEndDate}>
-                  <button type="button" onClick={() => testSetEndSem(LAST_DAY_OF_CLASS)}>
+                  <button
+                    className={styles.RepeatSpecialEndDateButton}
+                    type="button"
+                    onClick={() => testSetEndSem(LAST_DAY_OF_CLASS)}
+                  >
                     Last Day of Class ({LAST_DAY_OF_CLASS.toLocaleDateString()})
                   </button>
-                  <button type="button" onClick={() => testSetEndSem(LAST_DAY_OF_EXAMS)}>
+                  <button
+                    className={styles.RepeatSpecialEndDateButton}
+                    type="button"
+                    onClick={() => testSetEndSem(LAST_DAY_OF_EXAMS)}
+                  >
                     Last Day of Finals ({LAST_DAY_OF_EXAMS.toLocaleDateString()})
                   </button>
                 </p>

--- a/frontend/src/components/TaskCreator/Picker.module.scss
+++ b/frontend/src/components/TaskCreator/Picker.module.scss
@@ -274,7 +274,7 @@
   text-align: left;
 }
 
-.RepeatSpecialEndDate button {
+.RepeatSpecialEndDateButton {
   padding-top: 3px;
   padding-bottom: 3px;
   margin-top: 3px;

--- a/package.json
+++ b/package.json
@@ -57,12 +57,6 @@
     ],
     "rules": {
       "at-rule-no-unknown": null,
-      "no-descending-specificity": [
-        true,
-        {
-          "severity": "warning"
-        }
-      ],
       "scss/at-rule-no-unknown": true
     }
   },


### PR DESCRIPTION
### Summary <!-- Required -->

Remove the last 2 `no-descending-specificity` warnings by replacing the implicit button styling with explicit classnames.

We now eliminated all `no-descending-specificity` warnings, so we can finally convert the warning into error!

### Test Plan <!-- Required -->

the css is still being correctly applied:
<img width="1680" alt="Screen Shot 2020-12-16 at 20 45 12" src="https://user-images.githubusercontent.com/4290500/102427770-00963400-3fe0-11eb-9eba-08ac1a3acd25.png">
