### PR TITLE
Fix clear focus

### DIFF
--- a/common/firebase/common-actions.ts
+++ b/common/firebase/common-actions.ts
@@ -469,8 +469,8 @@ export default class Actions {
       const doc = this.database.tasksCollection().doc(id);
       const snapshot = await doc.get();
       const { children } = snapshot.data() as FirestoreCommonTask;
-      batch.update(doc, { inFocus: false });
-      batch.set(doc, {
+      batch.update(doc, {
+        inFocus: false,
         children: children.map(({ inFocus, ...rest }) => ({ inFocus: false, ...rest })),
       });
     });
@@ -480,7 +480,7 @@ export default class Actions {
         const snapshot = await doc.get();
         const { children } = snapshot.data() as FirestoreCommonTask;
 
-        batch.set(doc, {
+        batch.update(doc, {
           children: children.map(({ inFocus, ...rest }) =>
             childrenToBeUpdated.some((s) =>
               subTasksEqual(s, { inFocus, ...rest })

--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -186,7 +186,7 @@ export const clearFocus = async (
     const snapshot = await doc.get();
     const { children } = (await snapshot.data()) as FirestoreCommonTask;
     batch.update(doc, { inFocus: false });
-    batch.set(doc, {
+    batch.update(doc, {
       children: children.map(({ inFocus, ...rest }) => ({ inFocus: false, ...rest })),
     });
   });
@@ -195,7 +195,7 @@ export const clearFocus = async (
     const snapshot = await doc.get();
     const { children } = (await snapshot.data()) as FirestoreCommonTask;
 
-    batch.set(doc, {
+    batch.update(doc, {
       children: children.map(({ inFocus, ...rest }) =>
         childrenToBeUpdated.some((s) =>
           subTasksEqual(s, { inFocus, ...rest })


### PR DESCRIPTION
### Summary

Currently, when you click clear focus on a set of completed tasks, it actually appears to remove those tasks from the UI. By inspection, it's because these lines should be an `update` rather than a `set` since `set` will set the whole document to just those children.

https://user-images.githubusercontent.com/20008134/103161338-4c01cc80-47ae-11eb-8fb7-5d7565586334.mov

### Test Plan

Create some tasks, complete them,

 and then click clear focus.

### Notes
I'll move this into `common/firebase/common-actions.ts` once #719 is merged.
