### PR TITLE
Use clsx to concat (sometimes conditional) css classnames

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.26",
     "@fortawesome/free-solid-svg-icons": "^5.12.0",
     "@fortawesome/react-fontawesome": "^0.1.8",
+    "clsx": "^1.1.1",
     "common": "0.1.0",
     "firebase": "^7.21.0",
     "fuse.js": "^6.4.1",

--- a/frontend/src/components/GroupView/MiddleBar/ProfileImage.tsx
+++ b/frontend/src/components/GroupView/MiddleBar/ProfileImage.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import clsx from 'clsx';
 import styles from './ProfileImage.module.scss';
 
 type Props = {
@@ -8,13 +9,7 @@ type Props = {
 };
 
 const ProfileImage = ({ memberName, imageURL, className }: Props): ReactElement => {
-  return (
-    <img
-      className={className != null ? `${styles.ProfileCircle} ${className}` : styles.ProfileCircle}
-      src={imageURL}
-      alt={memberName}
-    />
-  );
+  return <img className={clsx(styles.ProfileCircle, className)} src={imageURL} alt={memberName} />;
 };
 
 export default ProfileImage;

--- a/frontend/src/components/GroupView/RightView/GroupTaskProgress.tsx
+++ b/frontend/src/components/GroupView/RightView/GroupTaskProgress.tsx
@@ -1,5 +1,6 @@
 import { Task } from 'common/types/store-types';
 import React, { ReactElement } from 'react';
+import clsx from 'clsx';
 import styles from './GroupTaskProgress.module.scss';
 import { GroupDeadline, PeakingBear } from '../../../assets/assets-constants';
 
@@ -15,9 +16,10 @@ type ProgressBubbleProps = {
 
 const ProgressBubble = ({ completed, value }: ProgressBubbleProps): ReactElement => (
   <div
-    className={`${styles.ProgressBubble} ${
+    className={clsx(
+      styles.ProgressBubble,
       completed ? styles.CompleteBubble : styles.IncompleteBubble
-    }`}
+    )}
   >
     {value ? `+${value}` : ''}
   </div>
@@ -116,9 +118,9 @@ const GroupTaskProgress = ({ tasks, deadline }: Props): ReactElement => {
       )}
       <div className={styles.Deadline}>
         <img src={GroupDeadline} className={styles.DeadlineIcon} alt="Group deadline" />
-        <p className={`${styles.GrayBoldText} ${styles.DeadlineDate}`}>{`${
-          months[deadline.getMonth()]
-        } ${deadline.getDate()}`}</p>
+        <p className={clsx(styles.GrayBoldText, styles.DeadlineDate)}>
+          {`${months[deadline.getMonth()]} ${deadline.getDate()}`}
+        </p>
       </div>
     </div>
   );

--- a/frontend/src/components/Popup/AllComplete/index.tsx
+++ b/frontend/src/components/Popup/AllComplete/index.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import clsx from 'clsx';
 import { connect } from 'react-redux';
 import Confetti from 'react-dom-confetti';
 import { TasksProgressProps } from 'common/util/task-util';
@@ -51,10 +52,8 @@ export function AllComplete({ completedTasksCount, allTasksCount }: Props): Reac
     colors: ['#a864fd', '#29cdff', '#78ff44', '#ff718d', '#fdff6a'],
   };
 
-  const showClass = shouldShow ? styles.Main : `${styles.Main} ${styles.Hidden}`;
-
   return (
-    <div className={showClass}>
+    <div className={clsx(styles.Main, !shouldShow && styles.Hidden)}>
       <span className={styles.ConfWrap}>
         <Confetti active={shouldShow} config={confettiConfig} />
       </span>

--- a/frontend/src/components/SideBar/GroupIcon.tsx
+++ b/frontend/src/components/SideBar/GroupIcon.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import clsx from 'clsx';
 import { connect } from 'react-redux';
 import { State, Tag } from 'common/types/store-types';
 import { NONE_TAG } from 'common/util/tag-util';
@@ -30,9 +31,7 @@ const GroupIcon = ({ classCode, handleClick, selected, tags }: Props): ReactElem
     <button
       type="button"
       onClick={() => handleClick('group', classCode)}
-      className={`${sidebarStyles.GroupLetterIcon} ${styles.GroupIcon}${
-        selected ? ` ${styles.Active}` : ''
-      }`}
+      className={clsx(sidebarStyles.GroupLetterIcon, styles.GroupIcon, selected && styles.Active)}
       style={{ background: color }}
     >
       {classCode.charAt(0)}

--- a/frontend/src/components/TaskCreator/DatePicker.tsx
+++ b/frontend/src/components/TaskCreator/DatePicker.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, SyntheticEvent, ChangeEvent, KeyboardEvent } from 'react';
+import clsx from 'clsx';
 import Calendar from 'react-calendar';
 import { date2String, getDateAfterXWeeks } from 'common/util/datetime-util';
 import { NONE_TAG } from 'common/util/tag-util';
@@ -135,7 +136,7 @@ export default function DatePicker(props: Props): ReactElement {
       <button
         onClick={clickPicker}
         onKeyPress={pressedPicker}
-        className={`${styles.DateButton} ${styles.Label}`}
+        className={clsx(styles.DateButton, styles.Label)}
         style={style}
         type="button"
       >

--- a/frontend/src/components/TaskCreator/FocusPicker.tsx
+++ b/frontend/src/components/TaskCreator/FocusPicker.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, SyntheticEvent, KeyboardEvent } from 'react';
+import clsx from 'clsx';
 import styles from './Picker.module.scss';
 import SamwiseIcon from '../UI/SamwiseIcon';
 
@@ -25,12 +26,9 @@ export default function FocusPicker({ pinned, onPinChange }: Props): ReactElemen
         type="button"
         onClick={clickPicker}
         onKeyPress={pressedPicker}
-        className={`${styles.TestBorder} ${styles.Label}`}
+        className={clsx(styles.TestBorder, styles.Label)}
       >
-        <SamwiseIcon
-          iconName={pinIconName}
-          className={`${styles.CenterIcon} ${styles.ImageSize}`}
-        />
+        <SamwiseIcon iconName={pinIconName} className={clsx(styles.CenterIcon, styles.ImageSize)} />
       </button>
     </div>
   );

--- a/frontend/src/components/TaskCreator/GroupMemberPicker.tsx
+++ b/frontend/src/components/TaskCreator/GroupMemberPicker.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, KeyboardEvent } from 'react';
+import clsx from 'clsx';
 import { NONE_TAG } from 'common/util/tag-util';
 import { SamwiseUserProfile } from 'common/types/store-types';
 import SearchGroupMember from '../Util/GroupMemberListPicker/SearchGroupMember';
@@ -84,7 +85,7 @@ export default function GroupMemberPicker({
         type="button"
         onClick={clickPicker}
         onKeyPress={pressedPicker}
-        className={`${styles.TagButton} ${styles.Label}`}
+        className={clsx(styles.TagButton, styles.Label)}
         style={style}
       >
         {internal}

--- a/frontend/src/components/TaskCreator/TagPicker.tsx
+++ b/frontend/src/components/TaskCreator/TagPicker.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, KeyboardEvent } from 'react';
 import { connect } from 'react-redux';
+import clsx from 'clsx';
 import { NONE_TAG, NONE_TAG_ID } from 'common/util/tag-util';
 import { State, Tag } from 'common/types/store-types';
 import TagListPicker from '../Util/TagListPicker/TagListPicker';
@@ -50,7 +51,7 @@ function TagPicker({ tag, opened, onTagChange, onPickerOpened, getTag }: Props):
         type="button"
         onClick={clickPicker}
         onKeyPress={pressedPicker}
-        className={`${styles.TagButton} ${styles.Label}`}
+        className={clsx(styles.TagButton, styles.Label)}
         style={style}
       >
         {internal}

--- a/frontend/src/components/TaskCreator/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/TaskCreator/__snapshots__/index.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`TaskCreator matches snapshot 1`] = `
   className="TaskCreator TaskCreatorClosed"
 >
   <form
-    className="NewTaskWrap "
+    className="NewTaskWrap"
     onFocus={[Function]}
     onSubmit={[Function]}
   >

--- a/frontend/src/components/TaskCreator/index.tsx
+++ b/frontend/src/components/TaskCreator/index.tsx
@@ -9,6 +9,7 @@ import React, {
   useContext,
 } from 'react';
 import { useSelector } from 'react-redux';
+import clsx from 'clsx';
 import { randomId } from 'common/util/general-util';
 import {
   Task,
@@ -359,9 +360,9 @@ export const TaskCreator = ({ view }: Props): ReactElement => {
     const { name, tag, member, date, inFocus, subTasks, datePicked, needToSwitchFocus } = state;
     if (!taskCreatorOpened) {
       return (
-        <div className={`${styles.TaskCreator} ${styles.TaskCreatorClosed}`} style={darkModeStyle}>
+        <div className={clsx(styles.TaskCreator, styles.TaskCreatorClosed)} style={darkModeStyle}>
           <form
-            className={`${styles.NewTaskWrap} ${groupMemberProfiles ? styles.GroupTaskWrap : ''}`}
+            className={clsx(styles.NewTaskWrap, groupMemberProfiles && styles.GroupTaskWrap)}
             onSubmit={handleSave}
             onFocus={openNewTask}
           >
@@ -420,11 +421,11 @@ export const TaskCreator = ({ view }: Props): ReactElement => {
         <div onClick={closeNewTask} role="presentation" className={styles.CloseNewTask} />
         <div className={styles.TaskCreatorOpenedPlaceHolder} />
         <form
-          className={`${styles.NewTaskWrap} ${styles.NewTaskModal}`}
+          className={clsx(styles.NewTaskWrap, styles.NewTaskModal)}
           onSubmit={handleSave}
           onFocus={openNewTask}
         >
-          <div className={`${styles.TaskCreatorRow} ${styles.FirstRow}`}>
+          <div className={clsx(styles.TaskCreatorRow, styles.FirstRow)}>
             <div className={styles.TitleText}>Add Task</div>
             {date instanceof Date && <FocusPicker pinned={inFocus} onPinChange={togglePin} />}
             <div className={styles.TagPickWrap}>
@@ -465,7 +466,7 @@ export const TaskCreator = ({ view }: Props): ReactElement => {
               type="text"
               value={name}
               onChange={editTaskName}
-              className={`${styles.NewTaskComponent} ${styles.NewTaskComponentOpened}`}
+              className={clsx(styles.NewTaskComponent, styles.NewTaskComponentOpened)}
               ref={addTaskRef}
               style={darkModeStyle}
             />

--- a/frontend/src/components/TaskView/FocusView/CompletedSeparator.tsx
+++ b/frontend/src/components/TaskView/FocusView/CompletedSeparator.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import clsx from 'clsx';
 import styles from './CompletedSeparator.module.scss';
 import SamwiseIcon from '../../UI/SamwiseIcon';
 
@@ -7,9 +8,6 @@ type Props = {
   readonly doesShowCompletedTasks: boolean;
   readonly onDoesShowCompletedTasksChange: () => void;
 };
-
-const getIconClassName = (notInverted: boolean): string =>
-  notInverted ? styles.Icon : `${styles.Icon} ${styles.Inverted}`;
 
 const CompletedSeparator = ({
   count,
@@ -20,7 +18,7 @@ const CompletedSeparator = ({
     <span className={styles.Text}>{`Completed: (${count})`}</span>
     <SamwiseIcon
       iconName="dropdown"
-      className={getIconClassName(doesShowCompletedTasks)}
+      className={clsx(styles.Icon, !doesShowCompletedTasks && styles.Inverted)}
       onClick={onDoesShowCompletedTasksChange}
     />
     <div className={styles.Line} />

--- a/frontend/src/components/TaskView/FutureView/FutureViewControl.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewControl.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import clsx from 'clsx';
 import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
 import { date2YearMonth } from 'common/util/datetime-util';
 import { useTodayLastSecondTime } from '../../../hooks/time-hook';
@@ -97,7 +98,7 @@ function NavControl(props: NavControlProps): ReactElement {
           <SamwiseIcon
             iconName="arrow-down-dark"
             title="Go back"
-            className={`${styles.NavButtonPrev} ${styles.NavButtonNDays}`}
+            className={clsx(styles.NavButtonPrev, styles.NavButtonNDays)}
             style={prevStyle}
             onClick={prevHandler}
           />
@@ -105,7 +106,7 @@ function NavControl(props: NavControlProps): ReactElement {
         <SamwiseIcon
           iconName="arrow-down-dark"
           title="Go forward"
-          className={`${styles.NavButtonNext} ${styles.NavButtonNDays}`}
+          className={clsx(styles.NavButtonNext, styles.NavButtonNDays)}
           style={nextStyle}
           onClick={nextHandler}
         />
@@ -204,15 +205,14 @@ function DisplayOptionControl({ nDays, displayOption, offset, onChange }: Props)
     type: FutureViewContainerType,
     text: string
   ): ReactElement => {
-    const className =
-      containerType === type
-        ? `${styles.ContainerTypeSwitcherButton} ${styles.ContainerTypeSwitcherActiveButton}`
-        : styles.ContainerTypeSwitcherButton;
     return (
       <button
         type="button"
         title={`Change to ${text} view`}
-        className={className}
+        className={clsx(
+          styles.ContainerTypeSwitcherButton,
+          containerType === type && styles.ContainerTypeSwitcherActiveButton
+        )}
         onClick={() => switchContainerType(type)}
       >
         <span className={styles.ContainerTypeSwitcherButtonText}>{text}</span>

--- a/frontend/src/components/TaskView/FutureView/FutureViewDay.tsx
+++ b/frontend/src/components/TaskView/FutureView/FutureViewDay.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
 import { connect } from 'react-redux';
+import clsx from 'clsx';
 import { getTodayAtZeroAM } from 'common/util/datetime-util';
 import { State, Theme } from 'common/types/store-types';
 import { SimpleDate } from './future-view-types';
@@ -54,15 +55,9 @@ export function FutureViewDay(props: Props & { readonly theme: Theme }): ReactEl
           color: 'white',
         };
   })();
-  let wrapperCssClass: string;
-  if (inNDaysView) {
-    wrapperCssClass = isToday ? `${styles.NDaysView} ${styles.Today}` : styles.NDaysView;
-  } else {
-    wrapperCssClass = isToday ? `${styles.OtherViews} ${styles.Today}` : styles.OtherViews;
-  }
   return (
     <div
-      className={wrapperCssClass}
+      className={clsx(inNDaysView ? styles.NDaysView : styles.OtherViews, isToday && styles.Today)}
       ref={componentDivRef}
       style={{ ...darkModeStyles, overflowY: 'scroll' }}
     >

--- a/frontend/src/components/TaskView/ProgressTracker/index.tsx
+++ b/frontend/src/components/TaskView/ProgressTracker/index.tsx
@@ -1,13 +1,11 @@
 import React, { ReactElement } from 'react';
 import { connect } from 'react-redux';
+import clsx from 'clsx';
 import { TasksProgressProps } from 'common/util/task-util';
 import Bear from './Bear';
 import ProgressIndicator from './ProgressIndicator';
 import styles from './index.module.scss';
 import { getProgress } from '../../../store/selectors';
-
-const mobileViewStyle = `${styles.ProgressTracker} ${styles.MobileView}`;
-const desktopViewStyle = `${styles.ProgressTracker} ${styles.DesktopView}`;
 
 type Props = TasksProgressProps & { readonly inMobileView: boolean };
 
@@ -20,9 +18,13 @@ export function ProgressTracker({
   allTasksCount,
   inMobileView,
 }: Props): ReactElement {
-  const containerClass = inMobileView ? mobileViewStyle : desktopViewStyle;
   return (
-    <div className={containerClass}>
+    <div
+      className={clsx(
+        styles.ProgressTracker,
+        inMobileView ? styles.MobileView : styles.DesktopView
+      )}
+    >
       <Bear
         completedTasksCount={completedTasksCount}
         allTasksCount={allTasksCount}

--- a/frontend/src/components/TitleBar/Settings/SettingsButton.tsx
+++ b/frontend/src/components/TitleBar/Settings/SettingsButton.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import clsx from 'clsx';
 import SettingsPage from './SettingsPage';
 import styles from './SettingsButton.module.scss';
 import SamwiseIcon from '../../UI/SamwiseIcon';
@@ -16,7 +17,7 @@ export default function SettingsButton({ buttonClassname }: Props): ReactElement
       <button
         type="submit"
         onClick={displayModal}
-        className={`${buttonClassname ?? ''} ${styles.SettingsButton}`}
+        className={clsx(buttonClassname, styles.SettingsButton)}
       >
         <p style={{ transform: 'scale(2)translateY(-5px)' }} title="Settings Button">
           <SamwiseIcon iconName="settings" />

--- a/frontend/src/components/TitleBar/Settings/SettingsPage.tsx
+++ b/frontend/src/components/TitleBar/Settings/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement, ReactNode } from 'react';
 import { Map } from 'immutable';
 import { connect } from 'react-redux';
+import clsx from 'clsx';
 import { Tag, State } from 'common/types/store-types';
 import TagItem from '../Tags/TagItem';
 import ClassTagAdder from '../Tags/ClassTagAdder';
@@ -29,7 +30,7 @@ export const ClassAdder = (): ReactElement => (
 export const ExamImporter = (): ReactElement => (
   <div className={styles.SettingsSection}>
     <p className={styles.SettingsSectionTitle}>Auto Import Exams</p>
-    <div className={`${styles.SettingsButton} ${styles.SettingsSectionContent}`}>
+    <div className={clsx(styles.SettingsButton, styles.SettingsSectionContent)}>
       Click the following button to reimport the prelims and finals from your classes into your
       planner. We will only import those that appears on Cornell prelim/final schedule webpage.
       <br />

--- a/frontend/src/components/TitleBar/Settings/__snapshots__/SettingsButton.test.tsx.snap
+++ b/frontend/src/components/TitleBar/Settings/__snapshots__/SettingsButton.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`SettingsButton matches snapshot. 1`] = `
   className="SettingsButtonContainer"
 >
   <button
-    className=" SettingsButton"
+    className="SettingsButton"
     onClick={[Function]}
     type="submit"
   >

--- a/frontend/src/components/TitleBar/Tags/ClassTagAdder.tsx
+++ b/frontend/src/components/TitleBar/Tags/ClassTagAdder.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import clsx from 'clsx';
 import { Map } from 'immutable';
 import { connect } from 'react-redux';
 import Fuse from 'fuse.js';
@@ -83,7 +84,7 @@ function ClassTagAdder({ fuse }: Props): ReactElement | null {
   };
   return (
     <div
-      className={`${styles.TagColorConfigItemAdder} ${styles.SearchClasses}`}
+      className={clsx(styles.TagColorConfigItemAdder, styles.SearchClasses)}
       title="Search for a class"
     >
       <SearchBox

--- a/frontend/src/components/TitleBar/Tags/OtherTagAdder.tsx
+++ b/frontend/src/components/TitleBar/Tags/OtherTagAdder.tsx
@@ -1,4 +1,5 @@
 import React, { KeyboardEvent, SyntheticEvent, ReactElement } from 'react';
+import clsx from 'clsx';
 import styles from './TagItem.module.scss';
 import ColorEditor from './ColorEditor';
 import { addTag } from '../../../firebase/actions';
@@ -37,7 +38,7 @@ export default class OtherTagAdder extends React.PureComponent<unknown, State> {
       <li className={styles.ColorConfigItem}>
         <input
           type="text"
-          className={`${styles.TagName} ${styles.AddTagName}`}
+          className={clsx(styles.TagName, styles.AddTagName)}
           placeholder="New Tag"
           value={name}
           onChange={this.editName}

--- a/frontend/src/components/UI/CheckBox.tsx
+++ b/frontend/src/components/UI/CheckBox.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable jsx-a11y/label-has-associated-control,jsx-a11y/label-has-for */
 
 import React, { ReactElement } from 'react';
+import clsx from 'clsx';
 import styles from './CheckBox.module.scss';
 
 type Props = {
@@ -21,11 +22,6 @@ export default function CheckBox({
   inverted = false,
   className = undefined,
 }: Props): ReactElement {
-  let allClassNames = className === undefined ? styles.CheckBox : `${className} ${styles.CheckBox}`;
-  if (inverted) {
-    allClassNames = `${allClassNames} ${styles.InvertedCheckBox}`;
-  }
-
   const handleClick = (): void => {
     if (!disabled) {
       onChange(!checked);
@@ -33,9 +29,12 @@ export default function CheckBox({
   };
   return (
     <label
-      className={
-        disabled ? `${allClassNames} ${styles.Disabled}` : `${allClassNames} ${styles.Enabled}`
-      }
+      className={clsx(
+        className,
+        styles.CheckBox,
+        inverted && styles.InvertedCheckBox,
+        disabled ? styles.Disabled : styles.Enabled
+      )}
     >
       <input
         tabIndex={0}

--- a/frontend/src/components/UI/SamwiseIcon.tsx
+++ b/frontend/src/components/UI/SamwiseIcon.tsx
@@ -3,6 +3,7 @@
  */
 
 import React, { ReactElement, CSSProperties } from 'react';
+import clsx from 'clsx';
 import { IconName } from './samwise-icon-types';
 import styles from './SamwiseIcon.module.scss';
 import {
@@ -225,11 +226,7 @@ const SamwiseIcon = ({
     >
       <img
         src={svg}
-        className={
-          className != null
-            ? `${styles.SamwiseIconDefaultStyle} ${className}`
-            : styles.SamwiseIconDefaultStyle
-        }
+        className={clsx(styles.SamwiseIconDefaultStyle, className)}
         tabIndex={tabIndex}
         style={style}
         alt={altText}

--- a/frontend/src/components/UI/SquareIconToggle.tsx
+++ b/frontend/src/components/UI/SquareIconToggle.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import clsx from 'clsx';
 import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
 import { IconLookup } from '@fortawesome/fontawesome-svg-core';
 import styles from './SquareButtons.module.scss';
@@ -20,12 +21,9 @@ type Props = {
  */
 export default function SquareIconToggle({ active, iconNames, onToggle }: Props): ReactElement {
   const [activeIconName, inactiveIconName] = iconNames;
-  const className = active
-    ? `${styles.SquareButton} ${styles.SquareButtonIconButton}`
-    : `${styles.SquareButton} ${styles.SquareButtonIconButton} ${styles.active}`;
   return (
     <button
-      className={className}
+      className={clsx(styles.SquareButton, styles.SquareButtonIconButton, !active && styles.active)}
       title="Hide/unhide completed tasks"
       type="button"
       onClick={onToggle}

--- a/frontend/src/components/Util/Modals/TextInputModal.tsx
+++ b/frontend/src/components/Util/Modals/TextInputModal.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useState } from 'react';
 import Modal from 'react-modal';
+import clsx from 'clsx';
 import modalStyles from './Modal.module.scss';
 import textInputModalStyles from './TextInputModal.module.scss';
 
@@ -57,7 +58,7 @@ const TextInputModal = ({
   return (
     <Modal
       isOpen={open}
-      className={`${modalStyles.Modal} ${textInputModalStyles.TextInputModal}`}
+      className={clsx(modalStyles.Modal, textInputModalStyles.TextInputModal)}
       contentLabel="Choice Dialog"
     >
       <div className={textInputModalStyles.Title}>{title}</div>

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/EditorHeader.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/EditorHeader.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import clsx from 'clsx';
 import Calendar from 'react-calendar';
 import { Tag, RepeatingDate } from 'common/types/store-types';
 import styles from './index.module.scss';
@@ -70,7 +71,6 @@ export default function EditorHeader({
   };
 
   const { doesShowTagEditor, doesShowDateEditor } = editorDisplayStatus;
-  const headerClassName = `${styles.TaskEditorFlexibleContainer} ${styles.TaskEditorHeader}`;
   const tagDisplay = (
     <button type="button" className={styles.TaskEditorTag} onClick={toggleTagEditor}>
       {getTag(tag).name}
@@ -127,11 +127,11 @@ export default function EditorHeader({
     >
       <Calendar
         value={date}
-        className={`${
+        className={
           calendarPosition === 'top'
             ? styles.TaskEditorCalendarTop
             : styles.TaskEditorCalendarBottom
-        } `}
+        }
         minDate={new Date()}
         onChange={editTaskDate}
         calendarType="US"
@@ -141,7 +141,7 @@ export default function EditorHeader({
   const isCanvasTask = typeof icalUID === 'string' ? icalUID !== '' : false;
 
   return (
-    <div className={headerClassName}>
+    <div className={clsx(styles.TaskEditorFlexibleContainer, styles.TaskEditorHeader)}>
       {isOverdue && <OverdueAlert target="task-card" />}
       {displayGrabber && type !== 'GROUP' && (
         <SamwiseIcon iconName="grabber" className={styles.TaskEditorGrabberIcon} />

--- a/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
+++ b/frontend/src/components/Util/TaskEditors/TaskEditor/index.tsx
@@ -5,6 +5,7 @@
 
 import React, { ReactElement, useEffect, useState, useCallback } from 'react';
 import { connect } from 'react-redux';
+import clsx from 'clsx';
 import {
   TaskMainData,
   Settings,
@@ -264,8 +265,6 @@ function TaskEditor({
   const formStyle = isOverdue
     ? { backgroundColor, border: '5px solid #D0021B' }
     : { backgroundColor };
-  const actualClassName =
-    className == null ? styles.TaskEditor : `${styles.TaskEditor} ${className}`;
 
   useEffect(() => {
     const intervalID = setInterval(() => {
@@ -278,7 +277,7 @@ function TaskEditor({
 
   return (
     <form
-      className={actualClassName}
+      className={clsx(styles.TaskEditor, className)}
       style={formStyle}
       onMouseEnter={onFocus}
       onMouseLeave={onMouseLeave}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4411,6 +4411,11 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
+clsx@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"


### PR DESCRIPTION
### Summary <!-- Required -->

Using template literals can concat css well sometimes, but when there are conditional css classnames, it gets messy very quickly. This PR replaces those template literal css classnames with the `clsx` library, which can handle the conditional css very well.

### Test Plan <!-- Required -->

Check the affected components' css is still fine. Read the changes to convince yourself that it's correct.