### PR TITLE
Auto-focus repeating task by firebase functions

### DIFF
--- a/frontend/src/firebase/actions.ts
+++ b/frontend/src/firebase/actions.ts
@@ -115,12 +115,13 @@ export const editTaskWithDiff = (taskId: string, editType: EditType, diff: Diff)
   );
 };
 
-export const forkTaskWithDiff = (taskId: string, replaceDate: Date, diff: Diff): void =>
+export const forkTaskWithDiff = (taskId: string, replaceDate: Date, diff: Diff): void => {
   actions.forkTaskWithDiff(
     store.getState().tasks.get(taskId) as Task<RepeatingTaskMetadata>,
     replaceDate,
     diff
   );
+};
 
 export const removeTask = (task: Task): void => {
   actions.removeTask(store.getState(), task).then(() => reportDeleteTaskEvent());

--- a/functions/src/focus-today-task.ts
+++ b/functions/src/focus-today-task.ts
@@ -25,12 +25,12 @@ const focusOneTimeTasksThatAreDueToday = async (): Promise<void> => {
 const focusRepeatingTasksThatAreDueToday = async (): Promise<void> => {
   const todayAtZero = new Date();
   todayAtZero.setHours(0, 0, 0, 0);
-  const querySnapsot = await database
+  const querySnapshot = await database
     .tasksCollection()
     .where('type', '==', 'MASTER_TEMPLATE')
     .get();
   await Promise.all(
-    querySnapsot.docs.map(async (snapshot) => {
+    querySnapshot.docs.map(async (snapshot) => {
       const {
         date: { startDate, endDate, pattern },
         forks,


### PR DESCRIPTION
### Summary <!-- Required -->

Close #333, our last open issue.

Implemented via a firebase function that auto focuses the repeating task by forking it. It reuses the existing common util function to tell whether today is on the repeating tasks' repetition schedule.

### Test Plan <!-- Required -->

I created a repeating task that repeats on today, and run the function manually. It indeed got focused.