### PR TITLE
[chore] Update course-info fetch script for SP21 and eliminate semifinals

### DIFF
--- a/course-info/src/fetch-exam.ts
+++ b/course-info/src/fetch-exam.ts
@@ -2,11 +2,10 @@ import fetch from 'node-fetch';
 import { JSDOM } from 'jsdom';
 import { ExamInfo } from './types';
 
-type ExamType = 'final' | 'semifinal' | 'prelim';
+type ExamType = 'final' | 'prelim';
 
-const prelimUrl = 'https://registrar.cornell.edu/exams/fall-prelim-exam-schedule';
-const semiFinalUrl = 'https://registrar.cornell.edu/calendars-exams/semifinal-exam-schedule';
-const finalUrl = 'https://registrar.cornell.edu/exams/fall-final-exam-schedule';
+const prelimUrl = 'https://registrar.cornell.edu/exams/spring-prelim-schedule';
+const finalUrl = 'https://registrar.cornell.edu/exams/spring-final-exam-schedule'; // not published yet.
 
 const currentYear = new Date().getFullYear();
 
@@ -23,11 +22,14 @@ function parsePrelimLine(line: string): ExamInfo {
   const subject = segments[0];
   const courseNumber = segments[1];
   const dateTimeString = `${segments[3]} ${segments[4]} ${currentYear}`;
-  const dateHours = parseInt(segments[5].substring(0, 2), 10);
-  const dateMinutes = parseInt(segments[5].substring(3, 5), 10);
+  const dateHours = parseInt(segments[5].substring(0, segments[5].indexOf(':')), 10);
+  const dateMinutes = parseInt(
+    segments[5].substring(segments[5].indexOf(':') + 1, segments[5].length - 2),
+    10
+  );
   const date = new Date(dateTimeString);
   date.setFullYear(currentYear);
-  date.setHours(segments[6] === 'PM' ? dateHours + 12 : dateHours, dateMinutes);
+  date.setHours(segments[5].slice(-2) === 'pm' ? dateHours + 12 : dateHours, dateMinutes);
   return {
     subject,
     courseNumber,
@@ -36,53 +38,8 @@ function parsePrelimLine(line: string): ExamInfo {
   };
 }
 
-function parseSemiFinalLine(line: string): ExamInfo {
-  // Adapted for FA20 semifinals.
-  const segments = line.split(/\s+/);
-  const subject = segments[0];
-  const courseNumber = segments[1];
-  const sectionNumber = segments[2];
-  if (subject === 'CS' && courseNumber === '2800') {
-    return {
-      subject,
-      courseNumber,
-      sectionNumber,
-      time: new Date(2020, 10, 17, 19, 30).getTime(),
-    };
-  }
-  const dateFormat = segments[3];
-  const dateData = dateFormat.split('-');
-  let dateTimeString = '';
-  switch (dateData[1]) {
-    case 'Oct':
-      dateTimeString += '10';
-      break;
-    case 'Nov':
-      dateTimeString += '11';
-      break;
-    case 'Dec':
-      dateTimeString += '12';
-      break;
-    default:
-      throw new Error(`Invalid month of final ${dateData[1]}`);
-  }
-  dateTimeString += `/${dateData[0]}/${currentYear}`;
-
-  const date = new Date(dateTimeString);
-  const time12Hr = segments[4];
-  const dateHours = parseInt(time12Hr.substring(0, time12Hr.indexOf(':')), 10);
-  const dateMinutes = parseInt(time12Hr.substring(time12Hr.indexOf(':') + 1, time12Hr.length), 10);
-  date.setHours(segments[5] === 'PM' ? dateHours + 12 : dateHours, dateMinutes);
-  return {
-    subject,
-    courseNumber,
-    sectionNumber,
-    time: date.getTime(),
-  };
-}
-
 function parseFinalLine(line: string): ExamInfo {
-  // Adapted for FA20 finals.
+  // TODO: Finals not published for SP21, update this when they're out
   const segments = line.split(/\s+/);
   const subject = segments[0];
   const courseNumber = segments[1];
@@ -111,15 +68,12 @@ function getExamInfoList(rawText: string, examType: ExamType): readonly ExamInfo
       line !== '' &&
       !line.startsWith('<b>class') &&
       !line.startsWith('final exam') &&
-      !line.startsWith('Course')
+      !line.startsWith('course')
     ) {
       let info: ExamInfo;
       switch (examType) {
         case 'final':
           info = parseFinalLine(line);
-          break;
-        case 'semifinal':
-          info = parseSemiFinalLine(line);
           break;
         case 'prelim':
           info = parsePrelimLine(line);
@@ -135,8 +89,5 @@ function getExamInfoList(rawText: string, examType: ExamType): readonly ExamInfo
 
 const createJson = (url: string, examType: ExamType): Promise<readonly ExamInfo[]> =>
   fetchExamText(url).then((rawText) => getExamInfoList(rawText, examType));
-
-export const createSemiFinalJson = (): Promise<readonly ExamInfo[]> =>
-  createJson(semiFinalUrl, 'semifinal');
 export const createPrelimJson = (): Promise<readonly ExamInfo[]> => createJson(prelimUrl, 'prelim');
 export const createFinalJson = (): Promise<readonly ExamInfo[]> => createJson(finalUrl, 'final');

--- a/course-info/src/main.ts
+++ b/course-info/src/main.ts
@@ -1,20 +1,19 @@
 import { writeFileSync } from 'fs';
 
 import getAllCoursesInSemester from './fetch-courses';
-import { createFinalJson, createPrelimJson, createSemiFinalJson } from './fetch-exam';
+import { createPrelimJson } from './fetch-exam';
 import mergeCoursesAndExamJson from './merge-json';
 
-const SEMESTER = 'FA20';
+const SEMESTER = 'SP21';
 const JSON_FILENAME = 'courses-with-exams-min.json';
 
 async function main(): Promise<void> {
-  const [courses, prelimExams, semifinalExams, finalExams] = await Promise.all([
+  const [courses, prelimExams] = await Promise.all([
     getAllCoursesInSemester(SEMESTER),
     createPrelimJson(),
-    createSemiFinalJson(),
-    createFinalJson(),
+    // createFinalJson(),
   ]);
-  const json = mergeCoursesAndExamJson(courses, prelimExams, semifinalExams, finalExams);
+  const json = mergeCoursesAndExamJson(courses, prelimExams);
   // eslint-disable-next-line no-console
   writeFileSync(JSON_FILENAME, JSON.stringify(json));
 }

--- a/course-info/src/merge-json.ts
+++ b/course-info/src/merge-json.ts
@@ -56,14 +56,12 @@ function processExamInfoJson(
 
 export default function mergeCoursesAndExamJson(
   courses: readonly CourseInfo[],
-  prelimExams: readonly ExamInfo[],
-  semifinalExams: readonly ExamInfo[],
-  finalExams: readonly ExamInfo[]
+  prelimExams: readonly ExamInfo[]
+  // finalExams: readonly ExamInfo[]
 ): readonly FullInfo[] {
   const map = new Map<string, Course>();
   processCourseInfoJson(map, courses);
   processExamInfoJson(map, prelimExams, 'prelim');
-  processExamInfoJson(map, semifinalExams, 'semifinal');
-  processExamInfoJson(map, finalExams, 'final');
+  // processExamInfoJson(map, finalExams, 'final');
   return Array.from(map.values()).map((course) => course.plainJs);
 }


### PR DESCRIPTION
### Summary <!-- Required -->

This PR updates the course data and exams to Spring 2021. It also removes semifinals from consideration as the registrar is likely never implementing these again since they were a "disaster".

- [x] Update course times for SP21
- [x] Remove semifinals
- [x] Update course script to fetch prelim times this semester 

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

![image](https://user-images.githubusercontent.com/7517829/107430235-e2861500-6af2-11eb-9e9e-23558eb7abfb.png)

Run `yarn workspace course-info fetch` to grab the latest course data for SP21. CS 4670 has a prelim on Apr 6, as seen above in the corresponding Unix timestamp.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

Still not updated for finals this sem since the registrar still hasn't released this info. Will submit a PR when this comes out.
