### PR TITLE
Remove testOrderUnique check in reorder function

### DIFF
--- a/common/util/order-util.ts
+++ b/common/util/order-util.ts
@@ -15,17 +15,6 @@ function testSorted<T extends { readonly order: number }>(list: T[]): void {
   }
 }
 
-function testOrderUnique<T extends { readonly order: number }>(list: T[]): void {
-  const orders: Set<number> = new Set<number>();
-  for (let i = 0; i < list.length - 1; i += 1) {
-    const { order } = list[i];
-    if (orders.has(order)) {
-      throw new Error('Orders not unique!');
-    }
-    orders.add(order);
-  }
-}
-
 /**
  * @param list the list to sort.
  * @returns the sorted list in increasing order.
@@ -56,7 +45,6 @@ export function computeReorderMap<T extends { readonly id: string; readonly orde
     return Map.of();
   }
   testSorted(originalList);
-  testOrderUnique(originalList);
   let reorderMap = Map<string, number>(); // key: id, value: new order
   const orders = originalList.map((t) => t.order);
   if (sourceOrder < destinationOrder) {


### PR DESCRIPTION
### Summary <!-- Required -->

Resolve #733.

The input `originalList` contains both completed and uncompleted task. However, if a task is partially completed (i.e. with some completed subtask), it will appear twice, thus causing the duplicate order error while there should be none.

We should enforce no duplicate order by logic and test (which we already do, hopefully), instead of this buggy checker. Therefore, I just removed the checker.

### Test Plan <!-- Required -->

Repeats steps in #733 to ensure that it no longer errors.